### PR TITLE
Misc: Update Storybook repros repository with diff only

### DIFF
--- a/.github/workflows/generate-repros.yml
+++ b/.github/workflows/generate-repros.yml
@@ -7,7 +7,7 @@ on:
 # To remove when the branch will be merged
   push:
     branches:
-      - generate-repros
+      - update-repro-on-changes
 
 jobs:
   update:
@@ -23,6 +23,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Generate repros with Latest Storybook CLI
-        run: yarn generate-repros --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/repro-templates.git --push --force-push
+        run: yarn generate-repros --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/repro-templates.git --push
       - name: Generate repros with Next Storybook CLI
-        run: yarn generate-repros --next --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/repro-templates.git --push --force-push
+        run: yarn generate-repros --next --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT}}@github.com/storybookjs/repro-templates.git --push

--- a/scripts/repros-generator/git-helper.mjs
+++ b/scripts/repros-generator/git-helper.mjs
@@ -17,11 +17,10 @@ export async function commitEverythingInDirectory(commitMessage) {
 }
 
 /**
- * Init a Git repository with initial branch named with input string
+ * Check if there are some changes in the local Git repository
  *
- * @param {string} branch
- * @return {Promise<void>}
+ * @return {Promise<boolean>}
  */
-export async function initRepo(branch) {
-  await $`git init --initial-branch ${branch}`;
+export async function hasLocalChanges() {
+  return (await $`git status --porcelain`).toString() !== '';
 }

--- a/scripts/repros-generator/index.mjs
+++ b/scripts/repros-generator/index.mjs
@@ -1,5 +1,5 @@
-import { $, cd } from 'zx';
-import { commitEverythingInDirectory, initRepo } from './git-helper.mjs';
+import { $, cd, chalk } from 'zx';
+import { commitEverythingInDirectory, hasLocalChanges } from "./git-helper.mjs";
 import { copy, createTmpDir } from './fs-helper.mjs';
 
 export const frameworks = [
@@ -25,19 +25,25 @@ export const frameworks = [
 
 const logger = console;
 const tmpFolder = await createTmpDir();
+const currentRepoFolder = await createTmpDir();
 const scriptPath = __dirname;
 const templatesFolderPath = `${scriptPath}/templates`;
 
 const useNextVersion = argv.next;
+// Uncomment to easily run the script locally
+// const remote = 'https://github.com/storybookjs/repro-templates.git';
 const remote = argv.remote;
 const push = argv.push;
-const forcePush = argv['force-push'];
 const gitBranch = useNextVersion ? 'next' : 'main';
 const sbCliVersion = useNextVersion ? 'next' : 'latest';
 
+// First clone the current repo
+cd(currentRepoFolder);
+await $`git clone ${remote} . --branch ${gitBranch}`
+
+// Then move to another tmp dir and generate repros
 cd(tmpFolder);
 
-await initRepo(gitBranch);
 await copy(`${templatesFolderPath}/${gitBranch}/README.md`, tmpFolder);
 
 for (const framework of frameworks) {
@@ -46,37 +52,46 @@ for (const framework of frameworks) {
   await copy(`${templatesFolderPath}/${gitBranch}/.stackblitzrc`, `${tmpFolder}/${framework}`);
 }
 
-let commitMessage = `Storybook Examples - ${new Date().toDateString()}`;
+// Copy new repros into git repository
+await $`rsync -av ${tmpFolder}/ ${currentRepoFolder}/ --quiet --exclude .git --exclude "**/node_modules"`
+
+cd(currentRepoFolder);
+if(!await hasLocalChanges()) {
+  logger.info(chalk.yellow('Nothing to commit, everything was already up-to-date.'));
+  logger.info(chalk.green('☑️ Everything is good, exiting with code 0'));
+  process.exit();
+}
+
+const commitMessage = `Storybook Examples - Update ${new Date().toDateString()}`;
 await commitEverythingInDirectory(commitMessage);
 
 logger.info(`
  All the examples were bootstrapped:
-    - in ${tmpFolder}
-    - using the '${sbCliVersion}' version of Storybook CLI
-    - and committed on the '${gitBranch}' branch of a local Git repository 
+    - in ${chalk.blue(tmpFolder)}
+    - then move to the current repo in ${chalk.blue(currentRepoFolder)}
+    - using the '${chalk.yellow(sbCliVersion)}' version of Storybook CLI
+    - and committed on the '${chalk.yellow(gitBranch)}' branch of a local Git repository 
  
- Also all the files in the 'templates' folder were copied at the root of the Git repository.
+ Also, all the files in the 'templates' folder were copied at the root of the Git repository.
 `);
 
 try {
   if (remote) {
-    await $`git remote add origin ${remote}`;
-
     if (push) {
-      await $`git push --set-upstream origin ${gitBranch} ${forcePush ? '--force' : ''}`;
+      await $`git push --set-upstream origin ${gitBranch}`;
       const remoteRepoUrl = `${remote.replace('.git', '')}/tree/${gitBranch}`;
       logger.info(`🚀 Everything was pushed on ${remoteRepoUrl}`);
     } else {
       logger.info(`
    To publish these examples you just need to:
-      - push the branch: 'git push --set-upstream origin ${gitBranch}' (you might need '--force' option ;))
+      - push the branch: 'git push --set-upstream origin ${gitBranch}'
   `);
     }
   } else {
     logger.info(`
    To publish these examples you just need to:
       - add a remote Git repository: 'git remote add origin XXXXXXX'
-      - push the branch: 'git push --set-upstream origin ${gitBranch}' (you might need '--force' option ;))
+      - push the branch: 'git push --set-upstream origin ${gitBranch}'
   `);
   }
 } catch (e) {


### PR DESCRIPTION
## What I did

Currently, every night repros for most of the frameworks are recreated and pushed to: https://github.com/storybookjs/repro-templates
This is done for both `main` and `next` branches, and the full repo is recreated and force pushed after each run.

This commit improves a bit the behavior by committing and pushing only the differences between the current run and the previous one. Also, if there is no diff then nothing is done.

This offers a nice Git history allowing you to easily check out old versions of the repros.




## How to test

- [ ] GitHub Actions should run and update https://github.com/storybookjs/repro-templates
- [ ] Git history of https://github.com/storybookjs/repro-templates should contain multiple commits

![image](https://user-images.githubusercontent.com/4112568/150105540-72e50771-ee24-433e-b1b2-5519d60a2531.png)
