### PR TITLE
Example: Convert react button to createElement to fix CRA compat

### DIFF
--- a/code/renderers/react/template/components/Button.jsx
+++ b/code/renderers/react/template/components/Button.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const Button = ({ onClick, children }) => (
-  <button type="button" onClick={onClick}>
-    {children}
-  </button>
-);
+export const Button = ({ onClick, children }) =>
+  React.createElement('button', { type: 'button', onClick }, children);
 
 Button.propTypes = {
   onClick: PropTypes.func.isRequired,


### PR DESCRIPTION
Issue: N/A

## What I did

This is a weird one. @ndelangen and I ran into a problem when running the `cra-default-ts` sandbox:

```
/Users/shilman/projects/storybookjs/storybook/sandbox/cra-default-ts/node_modules/webpack/lib/NormalModule.js:976
                                const error = new ModuleParseError(source, e, loaders, this.type);
                                              ^
ModuleParseError: Module parse failed: Unexpected token (7:2)
File was processed with these loaders:
 * ./node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
You may need an additional loader to handle the result of these loaders.
| 
| export const Button = ({ onClick, children }) => (
>   <button type="button" onClick={onClick}>
|     {children}
```

We think this is because CRA doesn't have loaders for files outside `src`. However, I'm not sure why this wasn't a problem for you @tmeasday during development, and also doesn't seem to be a problem in CI. Leaving this here for discussion

## How to test

```
yarn task --task create --template cra/default-ts
```