### PR TITLE
Angular: use teardown in renderToDOM fn

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/AbstractRenderer.ts
@@ -142,6 +142,11 @@ export abstract class AbstractRenderer {
     await this.afterFullRender();
   }
 
+  public async destroy() {
+    await AbstractRenderer.resetPlatformBrowserDynamic();
+    await AbstractRenderer.resetCompiledComponents();
+  }
+
   /**
    * Only ASCII alphanumerics can be used as HTML tag name.
    * https://html.spec.whatwg.org/#elements-2

--- a/code/frameworks/angular/src/client/angular-beta/CanvasRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/CanvasRenderer.ts
@@ -12,11 +12,7 @@ export class CanvasRenderer extends AbstractRenderer {
     await super.render(options);
   }
 
-  async beforeFullRender(): Promise<void> {
-    await CanvasRenderer.resetPlatformBrowserDynamic();
-  }
+  async beforeFullRender(): Promise<void> {}
 
-  async afterFullRender(): Promise<void> {
-    await AbstractRenderer.resetCompiledComponents();
-  }
+  async afterFullRender(): Promise<void> {}
 }

--- a/code/frameworks/angular/src/client/angular-beta/DocsRenderer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/DocsRenderer.ts
@@ -1,5 +1,3 @@
-import { addons } from '@storybook/addons';
-import Events from '@storybook/core-events';
 import { AbstractRenderer } from './AbstractRenderer';
 import { StoryFnAngularReturnType, Parameters } from '../types';
 
@@ -11,36 +9,10 @@ export class DocsRenderer extends AbstractRenderer {
     parameters: Parameters;
     targetDOMNode: HTMLElement;
   }) {
-    const channel = addons.getChannel();
-    /**
-     * Destroy and recreate the PlatformBrowserDynamic of angular
-     * For several stories to be rendered in the same docs we should
-     * not destroy angular between each rendering but do it when the
-     * rendered stories are not needed anymore.
-     *
-     * Note for improvement: currently there is one event per story
-     * rendered in the doc. But one event could be enough for the whole docs
-     *
-     */
-    channel.once(Events.STORY_CHANGED, async () => {
-      await DocsRenderer.resetPlatformBrowserDynamic();
-    });
-
-    /**
-     * Destroy and recreate the PlatformBrowserDynamic of angular
-     * when doc re render. Allows to call ngOnDestroy of angular
-     * for previous component
-     */
-    channel.once(Events.DOCS_RENDERED, async () => {
-      await DocsRenderer.resetPlatformBrowserDynamic();
-    });
-
     await super.render({ ...options, forced: false });
   }
 
   async beforeFullRender(): Promise<void> {}
 
-  async afterFullRender(): Promise<void> {
-    await AbstractRenderer.resetCompiledComponents();
-  }
+  async afterFullRender(): Promise<void> {}
 }

--- a/code/frameworks/angular/src/client/render.ts
+++ b/code/frameworks/angular/src/client/render.ts
@@ -36,4 +36,8 @@ export async function renderToDOM(
     forced: !forceRemount,
     targetDOMNode: element,
   });
+
+  // todo fix eslint. I don't know why it expects void since there is no return type declaration and it should infer it
+  // eslint-disable-next-line consistent-return
+  return () => renderer.destroy();
 }


### PR DESCRIPTION
## What I did

Previously, framework angular listened to
channel events. It now uses a callback in
renderToDOM that makes it easier to properly
teardown Angular story instances.

## How to test

- [x] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
