### PR TITLE
Improve template filtering for generate-repros-next

### DIFF
--- a/scripts/next-repro-generators/generate-repros.ts
+++ b/scripts/next-repro-generators/generate-repros.ts
@@ -182,12 +182,21 @@ const generate = async ({
       dirName,
       ...configuration,
     }))
-    .filter(({ dirName }) => {
-      if (template) {
-        return dirName === template;
+    // filter by anything provided in case `template` is passed, making it easier to do runs e.g. for all webpack templates
+    .filter(({ dirName, expected, name }) => {
+      if (!template) {
+        return true;
       }
 
-      return true;
+      const filterRegex = new RegExp(template, 'i');
+
+      return (
+        name.match(filterRegex) ||
+        dirName.match(filterRegex) ||
+        expected.builder.match(filterRegex) ||
+        expected.framework.match(filterRegex) ||
+        expected.renderer.match(filterRegex)
+      );
     });
 
   runGenerators(generatorConfigs, localRegistry);
@@ -195,7 +204,7 @@ const generate = async ({
 
 program
   .description('Create a reproduction from a set of possible templates')
-  .option('--template <template>', 'Create a single template')
+  .option('--template <template>', 'Create repros for a given filter')
   .option('--local-registry', 'Use local registry', false)
   .action((options) => {
     generate(options).catch((e) => {


### PR DESCRIPTION
Issue: N/A

## What I did

Improved the filter from `yarn generate-repros-next` from instead of being able to just pass a full dirName e.g. `lit-vite/default-js`, now they can pass anything that matches with framework, renderer, builder, name or dirName.

example:
```js
$ yarn generate-repros-next --template @storybook/web-components-vite

[
  {
    dirName: 'lit-vite/default-js',
    name: 'Lit Vite (JS)',
    script: 'yarn create vite {{beforeDir}} --template lit',
    cadence: [ 'ci', 'daily', 'weekly' ],
    skipTasks: [ 'smoke-test' ],
    expected: {
      framework: '@storybook/web-components-vite',
      renderer: '@storybook/web-components',
      builder: '@storybook/builder-vite'
    }
  },
  {
    dirName: 'lit-vite/default-ts',
    name: 'Lit Vite (TS)',
    script: 'yarn create vite {{beforeDir}} --template lit-ts',
    cadence: [ 'ci', 'daily', 'weekly' ],
    skipTasks: [ 'smoke-test' ],
    expected: {
      framework: '@storybook/web-components-vite',
      renderer: '@storybook/web-components',
      builder: '@storybook/builder-vite'
    }
  }
]
```

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
