### PR TITLE
Simplify mdxPlugin used in vite builder

### DIFF
--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -22,7 +22,7 @@
     "@storybook/client-api": "7.0.0-alpha.40",
     "@storybook/client-logger": "7.0.0-alpha.40",
     "@storybook/core-common": "7.0.0-alpha.40",
-    "@storybook/mdx2-csf": "0.1.0-next.0",
+    "@storybook/mdx2-csf": "0.0.4-canary.20.b3f2a2f.0",
     "@storybook/node-logger": "7.0.0-alpha.40",
     "@storybook/preview-web": "7.0.0-alpha.40",
     "@storybook/source-loader": "7.0.0-alpha.40",

--- a/code/lib/builder-vite/package.json
+++ b/code/lib/builder-vite/package.json
@@ -26,7 +26,6 @@
     "@storybook/node-logger": "7.0.0-alpha.40",
     "@storybook/preview-web": "7.0.0-alpha.40",
     "@storybook/source-loader": "7.0.0-alpha.40",
-    "@vitejs/plugin-react": "^2.0.0",
     "browser-assert": "^1.2.1",
     "es-module-lexer": "^0.9.3",
     "glob": "^7.2.0",

--- a/code/lib/builder-vite/src/plugins/mdx-plugin.ts
+++ b/code/lib/builder-vite/src/plugins/mdx-plugin.ts
@@ -1,24 +1,5 @@
-import type { Options } from '@storybook/core-common';
 import type { Plugin } from 'vite';
 import { createFilter } from 'vite';
-
-const isStorybookMdx = (id: string) => id.endsWith('stories.mdx') || id.endsWith('story.mdx');
-
-function injectRenderer(code: string, mdx2: boolean) {
-  if (mdx2) {
-    return `
-           import React from 'react';
-           ${code}
-           `;
-  }
-
-  return `
-        /* @jsx mdx */
-        import React from 'react';
-        import { mdx } from '@mdx-js/react';
-        ${code}
-        `;
-}
 
 /**
  * Storybook uses two different loaders when dealing with MDX:
@@ -28,30 +9,15 @@ function injectRenderer(code: string, mdx2: boolean) {
  *
  * @see https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/recipes.md#csf-stories-with-arbitrary-mdx
  */
-export function mdxPlugin(options: Options): Plugin {
-  const { features } = options;
+const isStorybookMdx = (id: string) => id.endsWith('stories.mdx') || id.endsWith('story.mdx');
 
-  let reactRefresh: Plugin | undefined;
+export function mdxPlugin(): Plugin {
   const include = /\.mdx?$/;
   const filter = createFilter(include);
 
   return {
     name: 'storybook:mdx-plugin',
     enforce: 'pre',
-    configResolved({ plugins }) {
-      // @vitejs/plugin-react-refresh has been upgraded to @vitejs/plugin-react,
-      // and the name of the plugin performing `transform` has been changed from 'react-refresh' to 'vite:react-babel',
-      // to be compatible, we need to look for both plugin name.
-      // We should also look for the other plugins names exported from @vitejs/plugin-react in case there are some internal refactors.
-      const reactRefreshPlugins = plugins.filter(
-        (p) =>
-          p.name === 'react-refresh' ||
-          p.name === 'vite:react-babel' ||
-          p.name === 'vite:react-refresh' ||
-          p.name === 'vite:react-jsx'
-      );
-      reactRefresh = reactRefreshPlugins.find((p) => p.transform);
-    },
     async transform(src, id, options) {
       if (!filter(id)) return undefined;
 
@@ -59,28 +25,7 @@ export function mdxPlugin(options: Options): Plugin {
       const { compile } = await import('@storybook/mdx2-csf');
 
       const mdxCode = String(await compile(src, { skipCsf: !isStorybookMdx(id) }));
-
-      const modifiedCode = injectRenderer(mdxCode, true);
-
-      // Hooks in recent rollup versions can be functions or objects, and though react hasn't changed, the typescript defs have
-      const rTransform = reactRefresh?.transform;
-      const transform = rTransform && 'handler' in rTransform ? rTransform.handler : rTransform;
-
-      // It's safe to disable this, because we know it'll be there, since we added it ourselves.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const result = await transform!.call(this, modifiedCode, `${id}.jsx`, options);
-
-      if (!result) return modifiedCode;
-
-      if (typeof result === 'string') return result;
-
-      const { code, map: resultMap } = result;
-
-      return {
-        code,
-        map:
-          !resultMap || typeof resultMap === 'string' ? resultMap : { ...resultMap, sources: [id] },
-      };
+      return mdxCode;
     },
   };
 }

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -79,7 +79,7 @@ export async function pluginConfig(options: ExtendedOptions) {
   const plugins = [
     codeGeneratorPlugin(options),
     // sourceLoaderPlugin(options),
-    mdxPlugin(options),
+    mdxPlugin(),
     injectExportOrderPlugin,
     stripStoryHMRBoundary(),
     {

--- a/code/lib/builder-vite/src/vite-config.ts
+++ b/code/lib/builder-vite/src/vite-config.ts
@@ -6,7 +6,6 @@ import type {
   PluginOption,
   UserConfig as ViteConfig,
 } from 'vite';
-import viteReact from '@vitejs/plugin-react';
 import { isPreservingSymlinks, getFrameworkName } from '@storybook/core-common';
 import { stringifyProcessEnvs } from './envs';
 import {
@@ -96,11 +95,6 @@ export async function pluginConfig(options: ExtendedOptions) {
       },
     },
   ] as PluginOption[];
-
-  // We need the react plugin here to support MDX in non-react projects.
-  if (frameworkName !== '@storybook/react-vite') {
-    plugins.push(viteReact({ exclude: [/\.stories\.([tj])sx?$/, /node_modules/, /\.([tj])sx?$/] }));
-  }
 
   // TODO: framework doesn't exist, should move into framework when/if built
   if (frameworkName === '@storybook/preact-vite') {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -7061,7 +7061,6 @@ __metadata:
     "@storybook/source-loader": 7.0.0-alpha.40
     "@types/express": ^4.17.13
     "@types/node": ^16.0.0
-    "@vitejs/plugin-react": ^2.0.0
     browser-assert: ^1.2.1
     es-module-lexer: ^0.9.3
     glob: ^7.2.0

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2172,7 +2172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.11.5, @babel/types@npm:^7.12.11, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.8, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.19.4, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.6.1, @babel/types@npm:^7.7.0, @babel/types@npm:^7.7.2, @babel/types@npm:^7.8.3, @babel/types@npm:^7.8.6, @babel/types@npm:^7.8.7, @babel/types@npm:^7.9.6":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.11.5, @babel/types@npm:^7.12.11, @babel/types@npm:^7.14.8, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.8, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.19.4, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.6.1, @babel/types@npm:^7.7.0, @babel/types@npm:^7.7.2, @babel/types@npm:^7.8.3, @babel/types@npm:^7.8.6, @babel/types@npm:^7.8.7, @babel/types@npm:^7.9.6":
   version: 7.19.4
   resolution: "@babel/types@npm:7.19.4"
   dependencies:
@@ -7055,7 +7055,7 @@ __metadata:
     "@storybook/client-api": 7.0.0-alpha.40
     "@storybook/client-logger": 7.0.0-alpha.40
     "@storybook/core-common": 7.0.0-alpha.40
-    "@storybook/mdx2-csf": 0.1.0-next.0
+    "@storybook/mdx2-csf": 0.0.4-canary.20.b3f2a2f.0
     "@storybook/node-logger": 7.0.0-alpha.40
     "@storybook/preview-web": 7.0.0-alpha.40
     "@storybook/source-loader": 7.0.0-alpha.40
@@ -7772,6 +7772,23 @@ __metadata:
     remark: ^12.0.0
     typescript: ^3.8.0
   checksum: e092785c4d248644e8b72da2386b43afb28ad9449441ecce1d12dc9ba6f3360a52371fa3f3812065a990643513779b0b9d3f8d5eead21463f088a7459d7d472c
+  languageName: node
+  linkType: hard
+
+"@storybook/mdx2-csf@npm:0.0.4-canary.20.b3f2a2f.0":
+  version: 0.0.4-canary.20.b3f2a2f.0
+  resolution: "@storybook/mdx2-csf@npm:0.0.4-canary.20.b3f2a2f.0"
+  dependencies:
+    "@babel/generator": ^7.12.11
+    "@babel/parser": ^7.12.11
+    "@babel/types": ^7.14.8
+    "@mdx-js/mdx": ^2.0.0
+    estree-to-babel: ^4.9.0
+    hast-util-to-estree: ^2.0.2
+    js-string-escape: ^1.0.1
+    loader-utils: ^2.0.0
+    lodash: ^4.17.21
+  checksum: a5bca16b5d010e97c1287a26b2eb5ada25b48dc2ff2bdee6d43cd7f4ef94e3e1ac124931ec28edede42321143e2714e49d613ac40de5223d4743c5c2cb4caf89
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue:

We are currently adding `@vitejs/plugin-react` to every non-react vite storybook project, in order to process the code that is returned from `@storybook/mdx2-csf`. 

## What I did

This change pulls in https://github.com/storybookjs/mdx2-csf/pull/20, which swaps out JSX syntax for a call to the `_jsx()` transform instead, which is what the rest of the code returned from `@mdxjs/mdx` uses.

That allows us to remove the use of the react vite plugin in our custom mdx vite plugin.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

I'm not super-confident in this change, and I'm hoping CI will help give a bit of confidence.  But it will need a close look as well.  I tested in a react sandbox, but the mdx there is not very complex.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
