### PR TITLE
Vue3: POC fix changing controls causing full remounts

### DIFF
--- a/code/renderers/vue3/src/decorateStory.ts
+++ b/code/renderers/vue3/src/decorateStory.ts
@@ -25,11 +25,16 @@ function prepare(
     return null;
   }
 
+  // TODO: this doesn't work at all with decorators. they don't have args on setup()
+  // @ts-expect-error types are strict here, this will still work in the majority of cases where users don't have arguments in their setup() functions
+  const args = story.setup?.().args;
+
   if (innerStory) {
     return {
       // Normalize so we can always spread an object
       ...normalizeFunctionalComponent(story),
       components: { ...(story.components || {}), story: innerStory },
+      args,
     };
   }
 
@@ -37,6 +42,7 @@ function prepare(
     render() {
       return h(story);
     },
+    args,
   };
 }
 

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -1,8 +1,8 @@
 import { dedent } from 'ts-dedent';
-import { createApp, h } from 'vue';
+import { createApp, h, reactive } from 'vue';
 import type { Store_RenderContext, ArgsStoryFn } from '@storybook/types';
 
-import type { StoryFnVueReturnType, VueFramework } from './types';
+import type { VueFramework } from './types';
 
 export const render: ArgsStoryFn<VueFramework> = (props, context) => {
   const { id, component: Component } = context;
@@ -11,35 +11,67 @@ export const render: ArgsStoryFn<VueFramework> = (props, context) => {
       `Unable to render story ${id} as the component annotation is missing from the default export`
     );
   }
-
   return h(Component, props);
 };
+
+const appsAndArgsByDomElementKey = new Map<
+  string,
+  { app: ReturnType<typeof createApp>; reactiveArgs: any }
+>();
+
+const STORYBOOK_ROOT_ID = 'storybook-root';
+
+function teardown(domElementKey: string) {
+  if (!appsAndArgsByDomElementKey.has(domElementKey)) {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know it exists because we just checked
+  appsAndArgsByDomElementKey.get(domElementKey)!.app.unmount();
+  appsAndArgsByDomElementKey.delete(domElementKey);
+}
 
 let setupFunction = (app: any) => {};
 export const setup = (fn: (app: any) => void) => {
   setupFunction = fn;
 };
 
-const map = new Map<Element, ReturnType<typeof createApp>>();
+/* eslint-disable no-param-reassign */
+function updateArgs(reactiveArgs: any, nextArgs: any) {
+  if (!nextArgs) return;
+  Object.entries(nextArgs).forEach(([key, value]) => {
+    reactiveArgs[key] = value;
+  });
+  Object.keys(reactiveArgs).forEach((key) => {
+    if (!nextArgs[key]) {
+      reactiveArgs[key] = undefined;
+    }
+  });
+}
+/* eslint-enable no-param-reassign */
 
 export function renderToDOM(
-  { title, name, storyFn, showMain, showError, showException }: Store_RenderContext<VueFramework>,
+  {
+    id,
+    title,
+    name,
+    storyFn,
+    showMain,
+    showError,
+    showException,
+    storyContext,
+    forceRemount,
+  }: Store_RenderContext<VueFramework>,
   domElement: Element
 ) {
-  // TODO: explain cyclical nature of these app => story => mount
-  let element: StoryFnVueReturnType;
-  const storybookApp = createApp({
-    unmounted() {
-      map.delete(domElement);
-    },
-    render() {
-      map.set(domElement, storybookApp);
-      setupFunction(storybookApp);
-      return h(element);
-    },
-  });
-  storybookApp.config.errorHandler = (e: unknown) => showException(e as Error);
-  element = storyFn();
+  // in docs mode we're rendering multiple stories to the DOM, so we need to key by the story id
+  const domElementKey = storyContext.viewMode === 'docs' ? id : STORYBOOK_ROOT_ID;
+
+  if (forceRemount) {
+    teardown(domElementKey);
+  }
+  const existingApp = appsAndArgsByDomElementKey.get(domElementKey);
+
+  const { args, ...element } = storyFn();
 
   if (!element) {
     showError({
@@ -49,12 +81,33 @@ export function renderToDOM(
       Use "() => ({ template: '<my-comp></my-comp>' })" or "() => ({ components: MyComp, template: '<my-comp></my-comp>' })" when defining the story.
       `,
     });
-    return;
+    return () => {
+      teardown(domElementKey);
+    };
+  }
+
+  if (!existingApp || forceRemount) {
+    const reactiveArgs = args ? reactive(args) : args;
+
+    // TODO: explain cyclical nature of these app => story => mount
+    const app = createApp({
+      render() {
+        appsAndArgsByDomElementKey.set(domElementKey, { app, reactiveArgs });
+        return h(element, reactiveArgs);
+      },
+    });
+    app.config.errorHandler = (e: unknown) => showException(e as Error);
+    setupFunction(app);
+
+    app.mount(domElement);
+  } else {
+    updateArgs(existingApp.reactiveArgs, args);
   }
 
   showMain();
 
-  map.get(domElement)?.unmount();
-
-  storybookApp.mount(domElement);
+  // teardown the component when the story changes
+  return () => {
+    teardown(domElementKey);
+  };
 }


### PR DESCRIPTION
Issue: #15567 #13913

## What I did

This PR is a POC on keeping Vue3 components mounted when Controls are changed. Currently any changes to controls causes the component to remount. In this PR, we instead make the component's props reactive and update those instead.

While the basic logic in `renderToDOM` for keeping the component mounted and updating the props is sound, there are still some headache around getting access to the actual props that we want to update.
Specifically the current solution doesn't work at all if components have decorators attached because you can't read args from them the same way that we can for stories.

I'm hoping for input on how we can come up with a more bulletproof solution for reading the props in `renderToDOM`.