### PR TITLE
Core: Fix `esbuild-register` to 3.3.x

### DIFF
--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -55,7 +55,7 @@
     "@types/pretty-hrtime": "^1.0.0",
     "chalk": "^4.1.0",
     "esbuild": "^0.14.48",
-    "esbuild-register": "^3.3.3",
+    "esbuild-register": "3.3.x",
     "express": "^4.17.1",
     "file-system-cache": "^2.0.0",
     "find-up": "^5.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6493,7 +6493,7 @@ __metadata:
     "@types/pretty-hrtime": ^1.0.0
     chalk: ^4.1.0
     esbuild: ^0.14.48
-    esbuild-register: ^3.3.3
+    esbuild-register: 3.3.x
     express: ^4.17.1
     file-system-cache: ^2.0.0
     find-up: ^5.0.0
@@ -16086,7 +16086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-register@npm:^3.3.3":
+"esbuild-register@npm:3.3.x":
   version: 3.3.3
   resolution: "esbuild-register@npm:3.3.3"
   peerDependencies:


### PR DESCRIPTION
Issue: https://github.com/storybookjs/storybook/issues/19792

Seems an issue in the `esbuild-register@3.4.0` release. cc @egoist (will create a better report later I hope)

## What I did

Fix 3.3 version

## How to test

Hopefully CI is green!