### PR TITLE
hotfix: set module to commonjs if ts-node

### DIFF
--- a/lib/core-common/src/utils/interpret-require.ts
+++ b/lib/core-common/src/utils/interpret-require.ts
@@ -20,7 +20,17 @@ function registerCompiler(moduleDescriptor: Extension): number {
 
   if (typeof moduleDescriptor === 'string') {
     // eslint-disable-next-line import/no-dynamic-require,global-require
-    require(moduleDescriptor);
+    if (moduleDescriptor === 'ts-node/register') {
+      const { register } = require('ts-node');
+      register({
+        compilerOptions: {
+          module: 'commonjs',
+        },
+      })
+    } else {
+      require(moduleDescriptor);
+    }
+
     compilersState.set(moduleDescriptor, 1);
     return 1;
   }


### PR DESCRIPTION
This is for version `6.5.13` and if it would be merged, it should be added as a hotfix to that version. The workaround would be to add 

```
"tsnode":{
  compilerOptions: {
    module: 'commonjs',
  },
}
```

in the `tsconfig.json`.

Issue: Storybook resolves to root `tsconfig.json`, ignoring `.storybook/tsconfig.json`, if a root `tsconfig.json` exists. The root `tsconfig.json` may have different settings for `module` (eg. `esnext`), which will cause issues if one is using `.storybook/main.ts`, not recognizing it as a module, resulting in the `Cannot use import statement outside a module` error. This should fix this issue, forcing `ts-node/register` to have `module: commonjs`.


