### PR TITLE
Enable interactions debugger when creating sandboxes

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -70,6 +70,11 @@ export const create: Task['run'] = async (
 
   const mainConfig = await readMainConfig({ cwd });
 
+  // Enable or disable Storybook features
+  mainConfig.setFieldValue(['features'], {
+    interactionsDebugger: true,
+  });
+
   mainConfig.setFieldValue(['core', 'disableTelemetry'], true);
   if (template.expected.builder === '@storybook/builder-vite') setSandboxViteFinal(mainConfig);
   await writeConfig(mainConfig);


### PR DESCRIPTION
Issue: N/A

## What I did

This PR adds changes to `main.js -> features` when creating a sandbox, to improve our debugging experience.
It sets `interactionsDebugger` to true so we always have it enabled for the sandboxes.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
