### PR TITLE
Make cache.get fault tolerant

### DIFF
--- a/code/lib/core-common/src/utils/notify-telemetry.ts
+++ b/code/lib/core-common/src/utils/notify-telemetry.ts
@@ -6,7 +6,7 @@ const TELEMETRY_KEY_NOTIFY_DATE = 'telemetry-notification-date';
 const logger = console;
 
 export const notifyTelemetry = async () => {
-  const telemetryNotifyDate = await cache.get(TELEMETRY_KEY_NOTIFY_DATE, null);
+  const telemetryNotifyDate = await cache.get(TELEMETRY_KEY_NOTIFY_DATE, null).catch(() => null);
   // The end-user has already been notified about our telemetry integration. We
   // don't need to constantly annoy them about it.
   // We will re-inform users about the telemetry if significant changes are

--- a/code/lib/core-server/src/utils/update-check.ts
+++ b/code/lib/core-server/src/utils/update-check.ts
@@ -12,7 +12,9 @@ export const updateCheck = async (version: string): Promise<VersionCheck> => {
   let result;
   const time = Date.now();
   try {
-    const fromCache = await cache.get('lastUpdateCheck', { success: false, time: 0 });
+    const fromCache = await cache
+      .get('lastUpdateCheck', { success: false, time: 0 })
+      .catch(() => ({ time: 0, success: false }));
 
     // if last check was more then 24h ago
     if (time - 86400000 > fromCache.time && !CI) {

--- a/code/lib/core-server/src/withTelemetry.ts
+++ b/code/lib/core-server/src/withTelemetry.ts
@@ -47,7 +47,8 @@ async function shouldSendError({ cliOptions, presetOptions }: TelemetryOptions) 
 
   // Deal with typo, remove in future version (7.1?)
   const valueFromCache =
-    (await cache.get('enableCrashReports')) ?? (await cache.get('enableCrashreports'));
+    (await cache.get('enableCrashReports').catch(() => null)) ??
+    (await cache.get('enableCrashreports').catch(() => null));
   if (valueFromCache !== undefined) return valueFromCache;
 
   const valueFromPrompt = await promptCrashReports();

--- a/code/lib/telemetry/src/event-cache.ts
+++ b/code/lib/telemetry/src/event-cache.ts
@@ -2,7 +2,7 @@ import { cache } from '@storybook/core-common';
 import type { EventType } from './types';
 
 export const set = async (eventType: EventType, body: any) => {
-  const lastEvents = (await cache.get('lastEvents')).catch(() => null) || {};
+  const lastEvents = (await cache.get('lastEvents').catch(() => null)) || {};
   lastEvents[eventType] = { body, timestamp: Date.now() };
   await cache.set('lastEvents', lastEvents);
 };
@@ -23,7 +23,7 @@ const upgradeFields = (event: any) => {
 };
 
 export const getPrecedingUpgrade = async (eventType: EventType, events: any = undefined) => {
-  const lastEvents = events || (await cache.get('lastEvents')).catch(() => null);
+  const lastEvents = events || (await cache.get('lastEvents').catch(() => null));
   const init = lastEvents?.init;
   let precedingUpgrade = init;
   const upgrade = lastEvents?.upgrade;

--- a/code/lib/telemetry/src/event-cache.ts
+++ b/code/lib/telemetry/src/event-cache.ts
@@ -2,13 +2,13 @@ import { cache } from '@storybook/core-common';
 import type { EventType } from './types';
 
 export const set = async (eventType: EventType, body: any) => {
-  const lastEvents = (await cache.get('lastEvents')) || {};
+  const lastEvents = (await cache.get('lastEvents')).catch(() => null) || {};
   lastEvents[eventType] = { body, timestamp: Date.now() };
   await cache.set('lastEvents', lastEvents);
 };
 
 export const get = async (eventType: EventType) => {
-  const lastEvents = await cache.get('lastEvents');
+  const lastEvents = await cache.get('lastEvents').catch(() => null);
   return lastEvents?.[eventType];
 };
 
@@ -23,7 +23,7 @@ const upgradeFields = (event: any) => {
 };
 
 export const getPrecedingUpgrade = async (eventType: EventType, events: any = undefined) => {
-  const lastEvents = events || (await cache.get('lastEvents'));
+  const lastEvents = events || (await cache.get('lastEvents')).catch(() => null);
   const init = lastEvents?.init;
   let precedingUpgrade = init;
   const upgrade = lastEvents?.upgrade;

--- a/code/lib/telemetry/src/notify.ts
+++ b/code/lib/telemetry/src/notify.ts
@@ -6,7 +6,7 @@ const TELEMETRY_KEY_NOTIFY_DATE = 'telemetry-notification-date';
 const logger = console;
 
 export const notify = async () => {
-  const telemetryNotifyDate = await cache.get(TELEMETRY_KEY_NOTIFY_DATE, null);
+  const telemetryNotifyDate = await cache.get(TELEMETRY_KEY_NOTIFY_DATE, null).catch(() => null);
   // The end-user has already been notified about our telemetry integration. We
   // don't need to constantly annoy them about it.
   // We will re-inform users about the telemetry if significant changes are


### PR DESCRIPTION
Branched off this PR: https://github.com/storybookjs/storybook/pull/20100

We see an odd invalid JSON in the cache in that PR.
An invalid cache should not break storybook.

I added catches for pulling values out of the cache,
because we don't want some invalid cache values breaking the complete run.