### PR TITLE
Vite: Prebundle react-dogen

### DIFF
--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -58,11 +58,11 @@
     "@vitejs/plugin-react": "^2.0.0",
     "ast-types": "^0.14.2",
     "magic-string": "^0.26.1",
-    "react-docgen": "^6.0.0-alpha.3",
     "vite": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
+    "react-docgen": "^6.0.0-alpha.3",
     "typescript": "~4.9.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Issue:

It's now ESM only.  :(

## What I did

Hopefully this will turn CI green again.  By pre-bundling it, we can turn the ESM-only package into CJS and ESM, according to @shilman.

## How to test

CI

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
