### PR TITLE
Add stories for "unattached" doc blocks

### DIFF
--- a/code/ui/blocks/src/blocks/Description.stories.tsx
+++ b/code/ui/blocks/src/blocks/Description.stories.tsx
@@ -16,8 +16,25 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
+export const PrimaryStory: Story = {
+  args: {
+    of: '^',
+  },
+};
+
 export const BooleanControlJSDoc: Story = {
   args: {
     of: BooleanControl,
+  },
+};
+
+export const OfUnattached: Story = {
+  args: {
+    of: BooleanControl,
+  },
+  parameters: {
+    relativeCsfPaths: [],
   },
 };


### PR DESCRIPTION
Issue: #19964 

## What I did

See the issue, this shows how we can use stories in our doc blocks SB to reproduce + fix those issues.

## How to test

See the failing story.