### PR TITLE
Set min height relative to the viewport and the zoom level.

### DIFF
--- a/code/ui/components/src/Zoom/ZoomIFrame.tsx
+++ b/code/ui/components/src/Zoom/ZoomIFrame.tsx
@@ -39,6 +39,7 @@ export class ZoomIFrame extends Component<IZoomIFrameProps> {
       if (browserSupportsCssZoom()) {
         Object.assign(this.iframe.contentDocument.body.style, {
           zoom: 1 / scale,
+          minHeight: `calc(100vh / ${1 / scale})`,
         });
       } else {
         Object.assign(this.iframe.contentDocument.body.style, {


### PR DESCRIPTION
Issue:

## What I did

Set the `min-height` according to the `zoom` level. Previously the `min-height` was set based on the viewport height (`100vh`), but with this fix, the height is now relative to the viewport as well as the zoom level. This prevents overflow when the layout is centered. It also works in the default layout.

## How to test

Zoom in without this patch, the preview layout set to centered and the controls open. The layout will overflow. With this patch, the layout will remain in the center when zooming.

## Screenshots

### Before

<img width="1680" alt="Screenshot 2022-12-20 at 2 24 48 PM" src="https://user-images.githubusercontent.com/6753/208751790-c4ab0a77-7ca0-4d91-a814-5ea7d025e60b.png">

### After

<img width="1680" alt="Screenshot 2022-12-20 at 2 28 42 PM" src="https://user-images.githubusercontent.com/6753/208751839-56294af6-8fb3-40af-b842-38d2b4123335.png">
