### PR TITLE
Downgrade slash

### DIFF
--- a/code/lib/builder-webpack5/package.json
+++ b/code/lib/builder-webpack5/package.json
@@ -91,7 +91,7 @@
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "semver": "^7.3.7",
-    "slash": "^5.0.0",
+    "slash": "^3.0.0",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.1",
     "ts-dedent": "^2.0.0",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6115,7 +6115,7 @@ __metadata:
     pretty-hrtime: ^1.0.3
     process: ^0.11.10
     semver: ^7.3.7
-    slash: ^5.0.0
+    slash: ^3.0.0
     style-loader: ^3.3.1
     terser-webpack-plugin: ^5.3.1
     ts-dedent: ^2.0.0


### PR DESCRIPTION
Issue: N/A

## What I did

Downgrade "slash" to 3.0.0 to avoid conflicts locally when creating sandboxes without "--no-link" option. Upgrading the other slash occurrences to 5.0.0 is not possible, because it is a ESM only module, which is not compatible with our testing environment.

## How to test

- [ ] Is this testable with Jest or Chromatic screenshots?
- [ ] Does this need a new example in the kitchen sink apps?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
