### PR TITLE
Add CSF1/2 tests to monorepo

### DIFF
--- a/code/lib/store/template/stories/args.stories.ts
+++ b/code/lib/store/template/stories/args.stories.ts
@@ -21,7 +21,6 @@ export default {
     (storyFn: PartialStoryFn, context: StoryContext) => {
       const { argNames } = context.parameters;
       const object = argNames ? pick(context.args, argNames) : context.args;
-      console.log('storyFn()', object);
       return storyFn({ args: { object } });
     },
   ],

--- a/code/lib/store/template/stories/args.stories.ts
+++ b/code/lib/store/template/stories/args.stories.ts
@@ -73,6 +73,7 @@ export const Events = {
     await within(canvasElement).findByText(/initial/);
 
     await channel.emit(UPDATE_STORY_ARGS, { storyId: id, updatedArgs: { test: 'updated' } });
+    await new Promise((resolve) => channel.once(STORY_ARGS_UPDATED, resolve));
     await within(canvasElement).findByText(/updated/);
 
     await channel.emit(RESET_STORY_ARGS, { storyId: id });

--- a/code/lib/store/template/stories/args.stories.ts
+++ b/code/lib/store/template/stories/args.stories.ts
@@ -21,6 +21,7 @@ export default {
     (storyFn: PartialStoryFn, context: StoryContext) => {
       const { argNames } = context.parameters;
       const object = argNames ? pick(context.args, argNames) : context.args;
+      console.log('storyFn()', object);
       return storyFn({ args: { object } });
     },
   ],

--- a/code/renderers/react/template/stories/decorators.stories.tsx
+++ b/code/renderers/react/template/stories/decorators.stories.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
-import type { StoryObj, Meta } from '@storybook/react';
+import type { StoryObj, Meta, StoryFn } from '@storybook/react';
 
 const Component: FC = () => <p>Story</p>;
 
@@ -26,3 +26,6 @@ export const All: StoryObj<typeof Component> = {
     ),
   ],
 };
+
+export const CSF2All: StoryFn = (args) => <Component {...args} />;
+CSF2All.decorators = All.decorators;

--- a/code/renderers/react/template/stories/errors.stories.tsx
+++ b/code/renderers/react/template/stories/errors.stories.tsx
@@ -35,3 +35,12 @@ export const StoryContainsUnrenderable = {
     </div>
   ),
 };
+
+export const CSF2StoryIsUnrenderable = () => badOutput;
+
+export const CSF2StoryContainsUnrenderable = () => (
+  <div>
+    {/* @ts-expect-error we're doing it wrong here on purpose */}
+    <BadComponent />
+  </div>
+);

--- a/code/renderers/react/template/stories/hooks.stories.tsx
+++ b/code/renderers/react/template/stories/hooks.stories.tsx
@@ -1,3 +1,4 @@
+import type { Args } from '@storybook/csf';
 import type { FC } from 'react';
 import React, { useState } from 'react';
 
@@ -15,3 +16,5 @@ export default {
 };
 
 export const Basic = {};
+
+export const CSF2Basic = (args: Args) => <ButtonWithState {...args} />;

--- a/code/renderers/react/template/stories/js-argtypes-csf2.stories.jsx
+++ b/code/renderers/react/template/stories/js-argtypes-csf2.stories.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import mapValues from 'lodash/mapValues.js';
+import { PureArgsTable as ArgsTable } from '@storybook/blocks';
+import { inferControls } from '@storybook/preview-api';
+import { ThemeProvider, themes, convert } from '@storybook/theming';
+
+import { component as JsClassComponentComponent } from './docgen-components/js-class-component/input.jsx';
+import { component as JsFunctionComponentComponent } from './docgen-components/js-function-component/input.jsx';
+import { component as JsFunctionComponentInlineDefaultsComponent } from './docgen-components/js-function-component-inline-defaults/input.jsx';
+import { component as JsFunctionComponentInlineDefaultsNoPropTypesComponent } from './docgen-components/js-function-component-inline-defaults-no-propTypes/input.jsx';
+import { component as JsProptypesShapeComponent } from './docgen-components/9399-js-proptypes-shape/input.jsx';
+// import { component as JsStyledComponentsComponent } from './__testfixtures__/8663-js-styled-components/input';
+import { component as JsDefaultValuesComponent } from './docgen-components/9626-js-default-values/input.jsx';
+import { component as JsProptypesNoJsdocComponent } from './docgen-components/9668-js-proptypes-no-jsdoc/input.jsx';
+// import { component as JsStyledDocgenComponent } from './__testfixtures__/8279-js-styled-docgen/input';
+import { component as JsPropTypesOneofComponent } from './docgen-components/8140-js-prop-types-oneof/input.jsx';
+import { component as JsHocComponent } from './docgen-components/9023-js-hoc/input.jsx';
+import { component as JsReactMemoComponent } from './docgen-components/9586-js-react-memo/input.jsx';
+import { component as JsStaticPropTypesComponent } from './docgen-components/8428-js-static-prop-types/input.jsx';
+import { component as JsdocComponent } from './docgen-components/jsdoc/input.jsx';
+import { component as JsProptypesComponent } from './docgen-components/js-proptypes/input.jsx';
+
+// Detect if we are running in vite in a hacky way for now
+const isVite = typeof require === 'undefined';
+
+export default {
+  component: {},
+  // render: (_, context) => <ArgsStory parameters={context.parameters} />,
+  parameters: {
+    chromatic: {
+      disableSnapshot: isVite,
+    },
+  },
+};
+
+const Template = (_, { parameters }) => <ArgsStory parameters={parameters} />;
+
+const ArgsStory = ({ parameters }) => {
+  const argTypes = parameters.docs.extractArgTypes(parameters.component);
+  const rows = inferControls({ argTypes, parameters: { __isArgsStory: true } });
+  const initialArgs = mapValues(rows, (argType) => argType.defaultValue);
+  const [args, setArgs] = useState(initialArgs);
+
+  return (
+    <ThemeProvider theme={convert(themes.light)}>
+      <ArgsTable rows={rows} args={args} updateArgs={(val) => setArgs({ ...args, ...val })} />
+    </ThemeProvider>
+  );
+};
+
+ArgsStory.propTypes = {
+  parameters: PropTypes.shape({
+    component: PropTypes.elementType.isRequired,
+    docs: PropTypes.shape({
+      extractArgTypes: PropTypes.func.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export const JsClassComponent = Template.bind({});
+JsClassComponent.parameters = { component: JsClassComponentComponent };
+
+export const JsFunctionComponent = Template.bind({});
+JsFunctionComponent.parameters = { component: JsFunctionComponentComponent };
+
+export const JsFunctionComponentInlineDefaults = Template.bind({});
+JsFunctionComponentInlineDefaults.parameters = {
+  component: JsFunctionComponentInlineDefaultsComponent,
+};
+
+export const JsFunctionComponentInlineDefaultsNoPropTypes = {
+  parameters: { component: JsFunctionComponentInlineDefaultsNoPropTypesComponent },
+};
+
+export const JsProptypesShape = Template.bind({});
+JsProptypesShape.parameters = { component: JsProptypesShapeComponent };
+
+// export const JsStyledComponents = { parameters: { component: JsStyledComponentsComponent } };
+
+export const JsDefaultValues = Template.bind({});
+JsDefaultValues.parameters = { component: JsDefaultValuesComponent };
+
+export const JsProptypesNoJsdoc = Template.bind({});
+JsProptypesNoJsdoc.parameters = { component: JsProptypesNoJsdocComponent };
+
+// export const JsStyledDocgen = { parameters: { component: JsStyledDocgenComponent } };
+
+export const JsPropTypesOneof = Template.bind({});
+JsPropTypesOneof.parameters = { component: JsPropTypesOneofComponent };
+
+export const JsHoc = Template.bind({});
+JsHoc.parameters = { component: JsHocComponent };
+
+export const JsReactMemo = Template.bind({});
+JsReactMemo.parameters = { component: JsReactMemoComponent };
+
+export const JsStaticPropTypes = Template.bind({});
+JsStaticPropTypes.roptypes.parameters = { component: JsStaticPropTypesComponent };
+
+export const Jsdoc = Template.bind({});
+Jsdoc.parameters = { component: JsdocComponent };
+
+export const JsProptypes = Template.bind({});
+JsProptypes.parameters = { component: JsProptypesComponent };

--- a/code/renderers/react/template/stories/js-argtypes-csf2.stories.jsx
+++ b/code/renderers/react/template/stories/js-argtypes-csf2.stories.jsx
@@ -34,8 +34,6 @@ export default {
   },
 };
 
-const Template = (_, { parameters }) => <ArgsStory parameters={parameters} />;
-
 const ArgsStory = ({ parameters }) => {
   const argTypes = parameters.docs.extractArgTypes(parameters.component);
   const rows = inferControls({ argTypes, parameters: { __isArgsStory: true } });
@@ -57,6 +55,8 @@ ArgsStory.propTypes = {
     }).isRequired,
   }).isRequired,
 };
+
+const Template = (_, { parameters }) => <ArgsStory parameters={parameters} />;
 
 export const JsClassComponent = Template.bind({});
 JsClassComponent.parameters = { component: JsClassComponentComponent };

--- a/code/renderers/react/template/stories/ts-argtypes-csf2.stories.tsx
+++ b/code/renderers/react/template/stories/ts-argtypes-csf2.stories.tsx
@@ -40,88 +40,66 @@ const ArgsStory = ({ parameters }: { parameters: Parameters }) => {
     </ThemeProvider>
   );
 };
-
+function getTemplate(_: Args, parameters: Parameters) {
+  return <ArgsStory parameters={parameters} />;
+}
 export const TsFunctionComponent = (_: Args, { parameters }: StoryContext) => (
   <ArgsStory parameters={parameters} />
 );
 TsFunctionComponent.parameters = { component: TsFunctionComponentComponent };
 
-export const TsFunctionComponentInlineDefaults = TsFunctionComponent;
+export const TsFunctionComponentInlineDefaults = (_: Args, { parameters }: StoryContext) =>
+  getTemplate(_, parameters);
 TsFunctionComponentInlineDefaults.parameters = {
   component: TsFunctionComponentInlineDefaultsComponent,
 };
 
-export const TsReactFcGenerics = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsReactFcGenerics = (_: Args, { parameters }: StoryContext) =>
+  getTemplate(_, parameters);
 TsReactFcGenerics.parameters = { component: TsReactFcGenericsComponent };
 
-export const TsMultiProps = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsMultiProps = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsMultiProps.parameters = { component: TsMultiPropsComponent };
 
-export const TsReactDefaultExports = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsReactDefaultExports = (_: Args, { parameters }: StoryContext) =>
+  getTemplate(_, parameters);
 TsReactDefaultExports.parameters = { component: TsReactDefaultExportsComponent };
 
-export const TsImportTypes = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsImportTypes = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsImportTypes.parameters = { component: TsImportTypesComponent };
 
-export const TsDeprecatedJsdoc = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsDeprecatedJsdoc = (_: Args, { parameters }: StoryContext) =>
+  getTemplate(_, parameters);
 TsDeprecatedJsdoc.parameters = { component: TsDeprecatedJsdocComponent };
 
-export const TsDefaultValues = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsDefaultValues = (_: Args, { parameters }: StoryContext) =>
+  getTemplate(_, parameters);
 TsDefaultValues.parameters = { component: TsDefaultValuesComponent };
 
-export const TsCamelCase = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsCamelCase = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsCamelCase.parameters = { component: TsCamelCaseComponent };
 
-export const TsDisplayName = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsDisplayName = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsDisplayName.parameters = { component: TsDisplayNameComponent };
 
-export const TsForwardRef = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsForwardRef = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsForwardRef.parameters = { component: TsForwardRefComponent };
 
-export const TsTypeProps = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsTypeProps = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsTypeProps.parameters = { component: TsTypePropsComponent };
 
-export const TsExtendProps = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsExtendProps = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsExtendProps.parameters = { component: TsExtendPropsComponent };
 
-export const TsComponentProps = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsComponentProps = (_: Args, { parameters }: StoryContext) =>
+  getTemplate(_, parameters);
 TsComponentProps.parameters = { component: TsComponentPropsComponent };
 
-export const TsJsdoc = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsJsdoc = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsJsdoc.parameters = { component: TsJsdocComponent };
 
-export const TsTypes = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsTypes = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsTypes.parameters = { component: TsTypesComponent };
 
-export const TsHtml = (_: Args, { parameters }: StoryContext) => (
-  <ArgsStory parameters={parameters} />
-);
+export const TsHtml = (_: Args, { parameters }: StoryContext) => getTemplate(_, parameters);
 TsHtml.parameters = { component: TsHtmlComponent };

--- a/code/renderers/react/template/stories/ts-argtypes-csf2.stories.tsx
+++ b/code/renderers/react/template/stories/ts-argtypes-csf2.stories.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider, themes, convert } from '@storybook/theming';
 import { component as TsFunctionComponentComponent } from './docgen-components/ts-function-component/input';
 import { component as TsFunctionComponentInlineDefaultsComponent } from './docgen-components/ts-function-component-inline-defaults/input';
 import { component as TsReactFcGenericsComponent } from './docgen-components/8143-ts-react-fc-generics/input';
-import { component as TsImportedTypesComponent } from './docgen-components/8143-ts-imported-types/input';
+
 import { component as TsMultiPropsComponent } from './docgen-components/8740-ts-multi-props/input';
 import { component as TsReactDefaultExportsComponent } from './docgen-components/9556-ts-react-default-exports/input';
 import { component as TsImportTypesComponent } from './docgen-components/9591-ts-import-types/input';

--- a/code/renderers/react/template/stories/ts-argtypes-csf2.stories.tsx
+++ b/code/renderers/react/template/stories/ts-argtypes-csf2.stories.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import mapValues from 'lodash/mapValues.js';
+import { PureArgsTable as ArgsTable } from '@storybook/blocks';
+import type { Args, Parameters, StoryContext } from '@storybook/types';
+import { inferControls } from '@storybook/preview-api';
+import { ThemeProvider, themes, convert } from '@storybook/theming';
+
+import { component as TsFunctionComponentComponent } from './docgen-components/ts-function-component/input';
+import { component as TsFunctionComponentInlineDefaultsComponent } from './docgen-components/ts-function-component-inline-defaults/input';
+import { component as TsReactFcGenericsComponent } from './docgen-components/8143-ts-react-fc-generics/input';
+import { component as TsImportedTypesComponent } from './docgen-components/8143-ts-imported-types/input';
+import { component as TsMultiPropsComponent } from './docgen-components/8740-ts-multi-props/input';
+import { component as TsReactDefaultExportsComponent } from './docgen-components/9556-ts-react-default-exports/input';
+import { component as TsImportTypesComponent } from './docgen-components/9591-ts-import-types/input';
+import { component as TsDeprecatedJsdocComponent } from './docgen-components/9721-ts-deprecated-jsdoc/input';
+import { component as TsDefaultValuesComponent } from './docgen-components/9827-ts-default-values/input';
+import { component as TsCamelCaseComponent } from './docgen-components/9575-ts-camel-case/input';
+import { component as TsDisplayNameComponent } from './docgen-components/9493-ts-display-name/input';
+import { component as TsForwardRefComponent } from './docgen-components/8894-9511-ts-forward-ref/input';
+import { component as TsTypePropsComponent } from './docgen-components/9465-ts-type-props/input';
+import { component as TsExtendPropsComponent } from './docgen-components/9764-ts-extend-props/input';
+import { component as TsComponentPropsComponent } from './docgen-components/9922-ts-component-props/input';
+import { component as TsJsdocComponent } from './docgen-components/ts-jsdoc/input';
+import { component as TsTypesComponent } from './docgen-components/ts-types/input';
+import { component as TsHtmlComponent } from './docgen-components/ts-html/input';
+
+export default {
+  component: {},
+};
+
+const ArgsStory = ({ parameters }: { parameters: Parameters }) => {
+  const argTypes = parameters.docs.extractArgTypes(parameters.component);
+  const rows = inferControls({ argTypes, parameters: { __isArgsStory: true } } as any);
+  const initialArgs = mapValues(rows, (argType) => argType.defaultValue);
+  const [args, setArgs] = useState(initialArgs);
+
+  return (
+    <ThemeProvider theme={convert(themes.light)}>
+      <ArgsTable rows={rows} args={args} updateArgs={(val) => setArgs({ ...args, ...val })} />
+    </ThemeProvider>
+  );
+};
+
+export const TsFunctionComponent = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsFunctionComponent.parameters = { component: TsFunctionComponentComponent };
+
+export const TsFunctionComponentInlineDefaults = TsFunctionComponent;
+TsFunctionComponentInlineDefaults.parameters = {
+  component: TsFunctionComponentInlineDefaultsComponent,
+};
+
+export const TsReactFcGenerics = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsReactFcGenerics.parameters = { component: TsReactFcGenericsComponent };
+
+export const TsMultiProps = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsMultiProps.parameters = { component: TsMultiPropsComponent };
+
+export const TsReactDefaultExports = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsReactDefaultExports.parameters = { component: TsReactDefaultExportsComponent };
+
+export const TsImportTypes = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsImportTypes.parameters = { component: TsImportTypesComponent };
+
+export const TsDeprecatedJsdoc = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsDeprecatedJsdoc.parameters = { component: TsDeprecatedJsdocComponent };
+
+export const TsDefaultValues = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsDefaultValues.parameters = { component: TsDefaultValuesComponent };
+
+export const TsCamelCase = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsCamelCase.parameters = { component: TsCamelCaseComponent };
+
+export const TsDisplayName = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsDisplayName.parameters = { component: TsDisplayNameComponent };
+
+export const TsForwardRef = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsForwardRef.parameters = { component: TsForwardRefComponent };
+
+export const TsTypeProps = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsTypeProps.parameters = { component: TsTypePropsComponent };
+
+export const TsExtendProps = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsExtendProps.parameters = { component: TsExtendPropsComponent };
+
+export const TsComponentProps = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsComponentProps.parameters = { component: TsComponentPropsComponent };
+
+export const TsJsdoc = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsJsdoc.parameters = { component: TsJsdocComponent };
+
+export const TsTypes = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsTypes.parameters = { component: TsTypesComponent };
+
+export const TsHtml = (_: Args, { parameters }: StoryContext) => (
+  <ArgsStory parameters={parameters} />
+);
+TsHtml.parameters = { component: TsHtmlComponent };

--- a/code/renderers/vue3/src/decorateStory.ts
+++ b/code/renderers/vue3/src/decorateStory.ts
@@ -1,6 +1,6 @@
 import type { ConcreteComponent, Component, ComponentOptions } from 'vue';
 import { h } from 'vue';
-import type { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/types';
+import type { DecoratorFunction, StoryContext, LegacyStoryFn, Args } from '@storybook/types';
 import { sanitizeStoryContextUpdate } from '@storybook/preview-api';
 
 import type { VueRenderer } from './types';
@@ -26,24 +26,23 @@ function prepare(
   }
 
   if (innerStory) {
+    console.log('--- innerStory ', innerStory);
     return {
       // Normalize so we can always spread an object
       ...normalizeFunctionalComponent(story),
       components: { ...(story.components || {}), story: innerStory },
     };
   }
-
-  return {
-    render() {
-      return h(story);
-    },
-  };
+  console.log('--- story ', story);
+  return (args) => h(story, args);
 }
 
 export function decorateStory(
   storyFn: LegacyStoryFn<VueRenderer>,
   decorators: DecoratorFunction<VueRenderer>[]
 ): LegacyStoryFn<VueRenderer> {
+  console.log('---decorateStory storyFn ', storyFn);
+
   return decorators.reduce(
     (decorated: LegacyStoryFn<VueRenderer>, decorator) => (context: StoryContext<VueRenderer>) => {
       let story: VueRenderer['storyResult'] | undefined;
@@ -63,9 +62,17 @@ export function decorateStory(
       if (decoratedStory === story) {
         return story;
       }
+      console.log('~args ', context.args);
+      console.log('~story ', story);
+      console.log('~decoratedStory ', decoratedStory);
+      const renderStoryFn = h(story, context.args);
+      const StoryComponentFn = (props: any) => () => h(renderStoryFn, props);
 
-      return prepare(decoratedStory, h(story, context.args)) as VueRenderer['storyResult'];
+      console.log(' StoryComponentFn ', StoryComponentFn);
+      console.log(' StoryComponentFn(context.args) ', StoryComponentFn(context.args));
+
+      return prepare(decoratedStory, StoryComponentFn(context.args)) as VueRenderer['storyResult'];
     },
-    (context) => prepare(storyFn(context)) as LegacyStoryFn<VueRenderer>
+    (context) => prepare(h(storyFn(context), context.args)) as LegacyStoryFn<VueRenderer>
   );
 }

--- a/code/renderers/vue3/src/decorateStory.ts
+++ b/code/renderers/vue3/src/decorateStory.ts
@@ -1,6 +1,6 @@
 import type { ConcreteComponent, Component, ComponentOptions } from 'vue';
 import { h } from 'vue';
-import type { DecoratorFunction, StoryContext, LegacyStoryFn, Args } from '@storybook/types';
+import type { DecoratorFunction, StoryContext, LegacyStoryFn } from '@storybook/types';
 import { sanitizeStoryContextUpdate } from '@storybook/preview-api';
 
 import type { VueRenderer } from './types';
@@ -26,14 +26,13 @@ function prepare(
   }
 
   if (innerStory) {
-    console.log('--- innerStory ', innerStory);
     return {
       // Normalize so we can always spread an object
       ...normalizeFunctionalComponent(story),
       components: { ...(story.components || {}), story: innerStory },
     };
   }
-  console.log('--- story ', story);
+
   return (args) => h(story, args);
 }
 
@@ -41,8 +40,6 @@ export function decorateStory(
   storyFn: LegacyStoryFn<VueRenderer>,
   decorators: DecoratorFunction<VueRenderer>[]
 ): LegacyStoryFn<VueRenderer> {
-  console.log('---decorateStory storyFn ', storyFn);
-
   return decorators.reduce(
     (decorated: LegacyStoryFn<VueRenderer>, decorator) => (context: StoryContext<VueRenderer>) => {
       let story: VueRenderer['storyResult'] | undefined;
@@ -62,14 +59,9 @@ export function decorateStory(
       if (decoratedStory === story) {
         return story;
       }
-      console.log('~args ', context.args);
-      console.log('~story ', story);
-      console.log('~decoratedStory ', decoratedStory);
+
       const renderStoryFn = h(story, context.args);
       const StoryComponentFn = (props: any) => () => h(renderStoryFn, props);
-
-      console.log(' StoryComponentFn ', StoryComponentFn);
-      console.log(' StoryComponentFn(context.args) ', StoryComponentFn(context.args));
 
       return prepare(decoratedStory, StoryComponentFn(context.args)) as VueRenderer['storyResult'];
     },

--- a/code/renderers/vue3/src/render.test.ts
+++ b/code/renderers/vue3/src/render.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from '@jest/globals';
+import { reactive } from 'vue';
+
+import { updateArgs } from './render';
+
+expect.addSnapshotSerializer({
+  print: (val: any) => val,
+  test: (val: unknown) => typeof val === 'string',
+});
+
+describe('render component with reactivity  Vue3', () => {
+  test('update reactive Args', () => {
+    const reactiveArgs = reactive({ label: 'Button', size: 'medium' });
+    const newArgs = { label: 'Updated' };
+    updateArgs(reactiveArgs, newArgs);
+    expect(reactiveArgs).toMatchObject({ label: 'Updated' });
+  });
+
+  test('update reactive Args with empty object', () => {
+    const reactiveArgs = reactive({ label: 'Button', size: 'medium' });
+    const newArgs = {};
+    updateArgs(reactiveArgs, newArgs);
+    expect(reactiveArgs).toMatchObject({});
+  });
+
+  test('update reactive Args with new props', () => {
+    const reactiveArgs = reactive({ primary: true });
+    const newArgs = { label: 'New prop', primary: false };
+    updateArgs(reactiveArgs, newArgs);
+    expect(reactiveArgs).toMatchObject({ label: 'New prop', primary: false });
+  });
+});

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -33,10 +33,10 @@ export function renderToCanvas(
   const existingApp = map.get(canvasElement);
 
   storyContext.args = reactive(storyContext.args);
-  const rootStoryComp = !existingApp ? storyFn() : existingApp.rootComponent;
+  const rootComponent: any = storyFn(); // !existingApp ? storyFn() : existingApp.rootComponent();
 
-  const props = typeof rootStoryComp === 'function' ? rootStoryComp(storyContext.args).props : {};
-  const reactiveArgs = Object.keys(props).length > 0 ? reactive(props) : storyContext.args;
+  const appProps = rootComponent.props ?? rootComponent().props;
+  const reactiveArgs = Object.keys(appProps).length > 0 ? reactive(appProps) : storyContext.args;
 
   if (existingApp && !forceRemount) {
     updateArgs(existingApp.reactiveArgs, reactiveArgs);
@@ -49,8 +49,8 @@ export function renderToCanvas(
 
   const storybookApp = createApp({
     render() {
-      map.set(canvasElement, { vueApp: storybookApp, reactiveArgs, rootComponent: rootStoryComp });
-      return h(rootStoryComp, reactiveArgs);
+      map.set(canvasElement, { vueApp: storybookApp, reactiveArgs, rootComponent });
+      return h(rootComponent, reactiveArgs);
     },
   });
 
@@ -85,11 +85,10 @@ function getSlots(props: Args, context: StoryContext<VueRenderer, Args>) {
  * @param nextArgs
  * @returns
  */
-function updateArgs(reactiveArgs: Args, nextArgs: Args) {
+export function updateArgs(reactiveArgs: Args, nextArgs: Args) {
   if (!nextArgs) return;
-  Object.keys(reactiveArgs).forEach((key) => {
-    delete reactiveArgs[key];
-  });
+
+  Object.keys(reactiveArgs).forEach((key) => delete reactiveArgs[key]);
   Object.assign(reactiveArgs, nextArgs);
 }
 

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -35,7 +35,8 @@ export function renderToCanvas(
   storyContext.args = reactive(storyContext.args);
   const rootComponent: any = storyFn(); // !existingApp ? storyFn() : existingApp.rootComponent();
 
-  const appProps = rootComponent.props ?? rootComponent().props;
+  const appProps =
+    rootComponent.props ?? (typeof rootComponent === 'function' ? rootComponent().props : {});
   const reactiveArgs = Object.keys(appProps).length > 0 ? reactive(appProps) : storyContext.args;
 
   if (existingApp && !forceRemount) {

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -2,7 +2,7 @@
 import { createApp, h, reactive } from 'vue';
 import type { RenderContext, ArgsStoryFn } from '@storybook/types';
 import type { Args, StoryContext } from '@storybook/csf';
-import type { StoryFnVueReturnType, VueRenderer } from './types';
+import type { VueRenderer } from './types';
 
 export const render: ArgsStoryFn<VueRenderer> = (props, context) => {
   const { id, component: Component } = context;
@@ -22,24 +22,22 @@ export const setup = (fn: (app: any) => void) => {
 
 const map = new Map<
   VueRenderer['canvasElement'],
-  { vueApp: ReturnType<typeof createApp>; reactiveArgs: any }
+  { vueApp: ReturnType<typeof createApp>; reactiveArgs: any; rootComponent: any }
 >();
-
-const elementMap = new Map<VueRenderer['canvasElement'], StoryFnVueReturnType>();
 
 export function renderToCanvas(
   { storyFn, forceRemount, showMain, showException, storyContext }: RenderContext<VueRenderer>,
   canvasElement: VueRenderer['canvasElement']
 ) {
   // fetch the story with the updated context (with reactive args)
-  storyContext.args = reactive(storyContext.args);
-  const element: StoryFnVueReturnType = storyFn();
-  elementMap.set(canvasElement, element);
-
-  const props = (element as any).render?.().props;
-  const reactiveArgs = props ? reactive(props) : storyContext.args;
-
   const existingApp = map.get(canvasElement);
+
+  storyContext.args = reactive(storyContext.args);
+  const rootStoryComp = !existingApp ? storyFn() : existingApp.rootComponent;
+
+  const props = typeof rootStoryComp === 'function' ? rootStoryComp(storyContext.args).props : {};
+  const reactiveArgs = Object.keys(props).length > 0 ? reactive(props) : storyContext.args;
+
   if (existingApp && !forceRemount) {
     updateArgs(existingApp.reactiveArgs, reactiveArgs);
     return () => {
@@ -51,10 +49,8 @@ export function renderToCanvas(
 
   const storybookApp = createApp({
     render() {
-      const renderedElement: any = elementMap.get(canvasElement);
-      const current = renderedElement && renderedElement.template ? renderedElement : element;
-      map.set(canvasElement, { vueApp: storybookApp, reactiveArgs });
-      return h(current, reactiveArgs);
+      map.set(canvasElement, { vueApp: storybookApp, reactiveArgs, rootComponent: rootStoryComp });
+      return h(rootStoryComp, reactiveArgs);
     },
   });
 

--- a/code/renderers/vue3/template/stories/OverrideArgs.stories.js
+++ b/code/renderers/vue3/template/stories/OverrideArgs.stories.js
@@ -22,6 +22,9 @@ export default {
       },
     },
   },
+};
+
+export const ArgsTest = {
   render: (args) => {
     // Individual properties can be overridden by spreading the args
     // and the replacing the key-values that need to be updated
@@ -39,4 +42,11 @@ export default {
   },
 };
 
-export const TestOne = {};
+export const ArgsCSF2Test = (args) => ({
+  components: { OverrideArgs },
+  args: { ...args, icon: icons[args.icon || 'Primary'] },
+  template: '<override-args v-bind="$props" />',
+});
+ArgsCSF2Test.args = {
+  icon: icons['Primary'],
+};

--- a/code/renderers/vue3/template/stories/ReactiveArgs.stories.js
+++ b/code/renderers/vue3/template/stories/ReactiveArgs.stories.js
@@ -42,3 +42,35 @@ export const ReactiveTest = {
     await expect(reactiveButton).toHaveTextContent('updated 2');
   },
 };
+
+export const DecoratedReactive = {
+  components: { ReactiveArgs },
+  args: { ...ReactiveTest.args },
+  decorators: [
+    () => ({
+      template: `
+        <div style="border: 5px solid red;">
+          <story/>
+        </div>
+        `,
+    }),
+  ],
+  play: ReactiveTest.play,
+};
+
+// test reactive args story for CSF2
+export const ReactiveCSF2 = (args) => ({
+  components: { ReactiveArgs },
+  template: '<ReactiveArgs v-bind="$props" />',
+});
+ReactiveCSF2.args = ReactiveTest.args;
+ReactiveCSF2.play = ReactiveTest.play;
+
+// test reactive args story with decorator CSF2
+export const DecoratedReactiveCSF2 = (args) => ({
+  components: { ReactiveArgs },
+  template: '<ReactiveArgs v-bind="$props" />',
+});
+DecoratedReactiveCSF2.args = ReactiveTest.args;
+DecoratedReactiveCSF2.play = ReactiveTest.play;
+DecoratedReactiveCSF2.decorators = DecoratedReactive.decorators;

--- a/code/renderers/vue3/template/stories/decorators.stories.js
+++ b/code/renderers/vue3/template/stories/decorators.stories.js
@@ -64,3 +64,56 @@ export const DynamicWrapper = {
     }),
   ],
 };
+
+export const CSF2SimpleTemplate = (args) => ({
+  components: { Button },
+  template: '<Button v-bind="$props" />',
+});
+CSF2SimpleTemplate.args = { label: 'With border' };
+CSF2SimpleTemplate.decorators = [
+  () => ({
+    components: {
+      Pre,
+    },
+    template: `
+      <div style="border: 5px solid red;">
+        <story/>
+      </div>
+    `,
+  }),
+];
+
+export const CSF2ComponentTemplate = (args) => ({
+  components: { Button },
+  template: '<Button v-bind="$props" />',
+});
+CSF2ComponentTemplate.args = { label: 'With component' };
+CSF2ComponentTemplate.decorators = [
+  () => ({
+    components: {
+      Pre,
+    },
+    template: `
+      <Pre text="decorator" />
+      <story/>
+    `,
+  }),
+];
+
+// CSF2 with Vue render function Wrapper
+export const CSF2VueWrapper = (args) => ({
+  components: { Button },
+  template: '<Button v-bind="$props" />',
+});
+CSF2VueWrapper.args = { label: 'CSF2 With Vue wrapper' };
+CSF2VueWrapper.decorators = [
+  (storyFn) => {
+    // Call the `storyFn` to receive a component that Vue can render
+    const story = storyFn();
+    console.log(' test ->', story.story);
+    // Vue 3 "Functional" component as decorator
+    return () => {
+      return h('div', { style: 'border: 2px solid blue' }, [h(story)]);
+    };
+  },
+];


### PR DESCRIPTION
Closes #21072



## What I did

step 1- add CSF2/CSF1 stories for each framework's sandbox templates.
step 2- deactivate the one that breaks and create to TODO list to fix it.

the stories will replicate almost the same ones done for CSF3 unless it is not possible to have them.
that will be some additional stories for CSF3 too in case they are missing in a particular framework ( the ones that failed will be disabled for now till the fix ).


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
