### PR TITLE
Fix height of App story

### DIFF
--- a/code/ui/manager/src/app.stories.tsx
+++ b/code/ui/manager/src/app.stories.tsx
@@ -29,7 +29,7 @@ export default {
 const ThemeStack = styled.div(
   {
     position: 'relative',
-    minHeight: '50vh',
+    minHeight: '100vh',
     height: '100%',
   },
   ({ theme }) => ({


### PR DESCRIPTION
Should decorators like this be necessary with the "fullscreen" layout? In the meantime, here's a quick fix.

<!-- Thank you for contributing to Storybook! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

#### Before
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/1123119/220395615-458e0ea0-7e8c-483b-b961-1cfd0b2247e1.png">

#### After
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/1123119/220395814-94d48650-a6cf-46dd-ac0f-056ba1cef4a1.png">


## How to test

<!-- Please include the steps to test your changes here. For example:

1. Open the App/Default story
-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
