### PR TITLE
Build: Early exit tasks based on Nx affected graph

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ parameters:
     type: enum
     enum: ['ci', 'pr', 'merged', 'daily']
     default: 'ci'
+  target-branch:
+    description: Which branch the PR is targeting
+    type: string
+    default: $CIRCLE_BRANCH
 
 executors:
   sb_node_16_classic:
@@ -52,6 +56,7 @@ orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.4.1
   browser-tools: circleci/browser-tools@1.4.0
   discord: antonioned/discord@0.1.0
+  nx: nrwl/nx@1.6.1
 
 commands:
   cancel-workflow-on-failure:
@@ -113,11 +118,27 @@ jobs:
       name: sb_node_16_classic
     steps:
       - git-shallow-clone/checkout_advanced:
-          clone_options: '--depth 1 --verbose'
+          clone_options: '--shallow-since "5 weeks ago" --verbose'
+          fetch_options: '--shallow-since "5 weeks ago" --verbose'
       - restore_cache:
           name: Restore Yarn cache
           keys:
             - build-yarn-2-cache-v4--{{ checksum "code/yarn.lock" }}--{{ checksum "scripts/yarn.lock" }}
+      - run:
+          name: Determine target branch if in a PR
+          command: |
+            echo $CIRCLE_PULL_REQUEST
+            echo $CIRCLE_PR_NUMBER
+            echo "<< pipeline.parameters.target-branch >>"
+            if [[ -n ${CIRCLE_PULL_REQUEST} ]]; then
+              pr=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
+              echo fetching target branch for $pr
+              target_branch=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" $pr | jq '.base.ref')
+              echo the target branch is $target_branch
+              echo "export MAIN_BRANCH_NAME=\"$target_branch\";" >>$BASH_ENV
+            fi
+      - nx/set-shas:
+          main-branch-name: $MAIN_BRANCH_NAME
       - run:
           name: Compile
           command: |
@@ -128,6 +149,10 @@ jobs:
           command: |
             cd code
             yarn local-registry --publish
+      - run:
+          name: Generate affected templates file
+          command: |
+            yarn nx-affected-templates
       - report-workflow-on-failure
       - save_cache:
           name: Save Yarn cache
@@ -148,6 +173,7 @@ jobs:
             - code/renderers
             - code/presets
             - .verdaccio-cache
+            - affected-templates.json
   cra-bench:
     executor:
       class: large
@@ -355,10 +381,14 @@ jobs:
           command: yarn task --task sandbox --template $(yarn get-template << pipeline.parameters.workflow >> sandbox) --no-link --start-from=never --junit
       - report-workflow-on-failure:
           template: $(yarn get-template << pipeline.parameters.workflow >> sandbox)
-      - persist_to_workspace:
-          root: .
-          paths:
-            - sandbox
+      - when:
+          condition:
+            equal: ['true', "$([[ -d 'sandbox' ]] && echo 'true')"]
+          steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - sandbox
       - store_test_results:
           path: test-results
   smoke-test-sandboxes:
@@ -412,10 +442,14 @@ jobs:
           template: $(yarn get-template << pipeline.parameters.workflow >> build)
       - store_test_results:
           path: test-results
-      - persist_to_workspace:
-          root: .
-          paths:
-            - sandbox/*/storybook-static
+      - when:
+          condition:
+            equal: ['true', "$([[ -d 'sandbox' ]] && echo 'true')"]
+          steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - sandbox/*/storybook-static
   test-runner-sandboxes:
     parameters:
       parallelism:

--- a/.github/workflows/trigger-circle-ci-workflow.yml
+++ b/.github/workflows/trigger-circle-ci-workflow.yml
@@ -44,7 +44,8 @@ jobs:
             -d '{
                   "branch": "'"$BRANCH"'",
                   "parameters": {
-                    "workflow": "ci"
+                    "workflow": "ci",
+                    "target-branch": "${{ github.base_ref }}"
                   }
                 }'
         env:
@@ -63,7 +64,8 @@ jobs:
             -d '{
                   "branch": "'"$BRANCH"'",
                   "parameters": {
-                    "workflow": "pr"
+                    "workflow": "pr",
+                    "target-branch": "${{ github.base_ref }}"
                   }
                 }'
         env:
@@ -82,7 +84,8 @@ jobs:
             -d '{
                   "branch": "'"$BRANCH"'",
                   "parameters": {
-                    "workflow": "merged"
+                    "workflow": "merged",
+                    "target-branch": "${{ github.base_ref }}"
                   }
                 }'
         env:
@@ -101,7 +104,8 @@ jobs:
             -d '{
                   "branch": "'"$BRANCH"'",
                   "parameters": {
-                    "workflow": "daily"
+                    "workflow": "daily",
+                    "target-branch": "${{ github.base_ref }}"
                   }
                 }'
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test-results
 /bench
 .verdaccio-cache
 .next
+affected-templates.json
 
 # Yarn stuff
 /**/.yarn/*

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "task": "echo 'Installing Script Dependencies...'; cd scripts; yarn install >/dev/null; yarn task",
     "get-template": "cd scripts; yarn get-template",
     "get-report-message": "cd scripts; yarn get-report-message",
+    "nx-affected-templates": "cd scripts; yarn nx-affected-templates",
     "test": "cd code; yarn test",
     "lint": "cd code; yarn lint",
     "nx": "cd code; yarn nx",

--- a/scripts/event-log-checker.ts
+++ b/scripts/event-log-checker.ts
@@ -2,8 +2,9 @@
 import chalk from 'chalk';
 import assert from 'assert';
 import fetch from 'node-fetch';
-import { allTemplates } from '../code/lib/cli/src/sandbox-templates';
+import { allTemplates, type TemplateKey } from '../code/lib/cli/src/sandbox-templates';
 import { oneWayHash } from '../code/lib/telemetry/src/one-way-hash';
+import { shouldSkipTask } from './nx-affected-templates';
 
 const PORT = process.env.PORT || 6007;
 
@@ -12,7 +13,13 @@ const eventTypeExpectations = {
 };
 
 async function run() {
-  const [eventType, templateName] = process.argv.slice(2);
+  const [eventType, templateName] = process.argv.slice(2) as [string, TemplateKey];
+
+  if (await shouldSkipTask(templateName)) {
+    console.log(`Skipping checks for "${templateName}" as it was not affected by the changes`);
+    return;
+  }
+
   let testMessage = '';
 
   // very simple jest-like test fn for better error readability
@@ -24,7 +31,7 @@ async function run() {
   try {
     if (!eventType || !templateName) {
       throw new Error(
-        `Need eventType and templateName; call with ./event-log-checker <eventType> <templateName>`
+        `Need eventType and templateKey; call with ./event-log-checker <eventType> <templateKey>`
       );
     }
 

--- a/scripts/nx-affected-templates.ts
+++ b/scripts/nx-affected-templates.ts
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+import { readJson, writeFile } from 'fs-extra';
+import { join } from 'path';
+import { ci, allTemplates, type TemplateKey } from '../code/lib/cli/src/sandbox-templates';
+import { execaCommand } from './utils/exec';
+
+const affectedTemplatesPath = join(__dirname, '..', 'affected-templates.json');
+
+// check whether a given template is related to affected packages (via nx affected graph)
+export const shouldSkipTask = async (template: TemplateKey) => {
+  try {
+    const affectTemplates = (await readJson(affectedTemplatesPath)) as string[];
+    // we want to always test the most basic templates, for safety (coming from CI cadence)
+    return !affectTemplates.concat(ci).includes(template);
+  } catch (e) {
+    // return false if the file doesn't exist
+    return false;
+  }
+};
+
+async function run() {
+  const baseTarget = process.env.NX_BASE || 'origin/next';
+  let nxCommand = 'yarn nx print-affected';
+
+  console.log(`Using the following NX_BASE hash for NX comparison: ${baseTarget}\n`);
+  nxCommand = `${nxCommand} --base=${baseTarget}`;
+
+  const contents = await execaCommand(nxCommand, { cwd: join(__dirname, '..') });
+
+  const affectedPackages = JSON.parse(contents.stdout).projects as string[];
+
+  const hasAddonChanges = affectedPackages.some((p: string) => p.includes('addon'));
+
+  const affectedTemplates = hasAddonChanges
+    ? Object.keys(allTemplates)
+    : Object.entries(allTemplates).reduce((acc, [templateKey, template]) => {
+        if (
+          affectedPackages.includes(template.expected.builder) ||
+          affectedPackages.includes(template.expected.renderer) ||
+          affectedPackages.includes(template.expected.framework)
+        ) {
+          acc.push(templateKey);
+        }
+        return acc;
+      }, []);
+
+  if (affectedTemplates.length > 0) {
+    console.log(
+      `🕵️  Detected the affected Storybook packages:\n${affectedPackages
+        .map((v) => `- ${v}`)
+        .join('\n')}`
+    );
+    if (hasAddonChanges) {
+      console.log('⚠️ All templates are affected because there were changes in an addon');
+    }
+    console.log(
+      `\n📝 Writing affected templates:\n${affectedTemplates.map((v) => `- ${v}`).join('\n')}`
+    );
+  } else {
+    console.log('📭 No templates were affected by the changes');
+  }
+
+  await writeFile(
+    join(__dirname, '..', 'affected-templates.json'),
+    JSON.stringify(affectedTemplates)
+  );
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,10 +11,11 @@
     "lint:js": "yarn lint:js:cmd .  --quiet",
     "lint:js:cmd": "cross-env NODE_ENV=production eslint --cache --cache-location=../.cache/eslint --ext .js,.jsx,.json,.html,.ts,.tsx,.mjs --report-unused-disable-directives",
     "lint:package": "sort-package-json",
+    "migrate-docs": "node --require esbuild-register ./ts-to-ts49.ts",
+    "nx-affected-templates": "ts-node ./nx-affected-templates.ts",
     "task": "ts-node --swc ./task.ts",
-    "upgrade": "ts-node --swc ./task.ts",
     "test": "jest --config ./jest.config.js",
-    "migrate-docs": "node --require esbuild-register ./ts-to-ts49.ts"
+    "upgrade": "ts-node --swc ./task.ts"
   },
   "husky": {
     "hooks": {

--- a/scripts/task.ts
+++ b/scripts/task.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import type { TestCase } from 'junit-xml';
 import { getJunitXml } from 'junit-xml';
-import { outputFile, readFile, pathExists } from 'fs-extra';
+import { outputFile, readFile, pathExists, readJson } from 'fs-extra';
 import { join, resolve } from 'path';
 import { prompt } from 'prompts';
 import { dedent } from 'ts-dedent';
@@ -28,6 +28,7 @@ import {
   type TemplateKey,
   type Template,
 } from '../code/lib/cli/src/sandbox-templates';
+import { shouldSkipTask } from './nx-affected-templates';
 
 import { version } from '../code/package.json';
 
@@ -323,6 +324,14 @@ async function run() {
 
   const finalTask = tasks[taskKey];
   const { template: templateKey } = optionValues;
+
+  if (process.env.CI && templateKey && (await shouldSkipTask(templateKey))) {
+    logger.info(
+      `Skipping tasks up to "${taskKey}" for "${templateKey}" as it was not affected by the changes`
+    );
+    return 0;
+  }
+
   const template = TEMPLATES[templateKey];
 
   const templateSandboxDir = templateKey && join(sandboxDir, templateKey.replace('/', '-'));


### PR DESCRIPTION
## What I did

Taking a pass at this again, so we don't run tasks unnecessarily and use Nx's affected graph in order to detect what we really need to test:

![image](https://user-images.githubusercontent.com/1671563/224449004-ff1e1868-5ad3-4946-8c69-2aec835f8d51.png)

If there are changes which affect addons, then everything is tested.

This solution is not the best it can be, because processes are still spawned in CircleCI (therefore yarn cache is restored in each of them), the difference is that they bail early, meaning we don't run Chromatic many times, or the Test-runner, etc.
The reason it's suboptimal, is that CircleCI needs a hardcoded number to specify the parallelism. We'd need to create a solution that dynamically changes CircleCI config based on Nx affected, to get into the most optimal solution: only execute the necessary amount of instances based on Nx's affected graph.

## How to test

1. Make a change to something that might only affect one or a few packages
2. Check how CI behaves

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [x] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
