### PR TITLE
Enable SolidJS sandboxes in Ecosystem CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,22 +701,22 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 31
+          parallelism: 34
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 31
+          parallelism: 34
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 31
+          parallelism: 34
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 31
+          parallelism: 34
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -724,7 +724,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 31
+          parallelism: 34
           requires:
             - build-sandboxes
       # TODO: reenable once we find out the source of flakyness

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,22 +701,22 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 34
+          parallelism: 33
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 34
+          parallelism: 33
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 34
+          parallelism: 33
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 34
+          parallelism: 33
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -724,7 +724,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 34
+          parallelism: 33
           requires:
             - build-sandboxes
       # TODO: reenable once we find out the source of flakyness

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -166,8 +166,6 @@ const baseTemplates = {
       renderer: 'storybook-solidjs',
       builder: '@storybook/builder-vite',
     },
-    // TODO: remove this once solid-vite framework is released
-    inDevelopment: true,
     skipTasks: ['e2e-tests-dev'],
   },
   'solid-vite/default-ts': {
@@ -178,8 +176,6 @@ const baseTemplates = {
       renderer: 'storybook-solidjs',
       builder: '@storybook/builder-vite',
     },
-    // TODO: remove this once solid-vite framework is released
-    inDevelopment: true,
     skipTasks: ['e2e-tests-dev'],
   },
   'vue3-vite/default-js': {
@@ -398,15 +394,13 @@ const baseTemplates = {
   'qwik-vite/default-ts': {
     name: 'Qwik CLI (Default TS)',
     script: 'yarn create qwik basic {{beforeDir}} --no-install',
-    // TODO: The community template does not provide standard stories, which is required for e2e tests. Reenable once it does.
-    inDevelopment: true,
     expected: {
       framework: 'storybook-framework-qwik',
       renderer: 'storybook-framework-qwik',
       builder: 'storybook-framework-qwik',
     },
     // TODO: The community template does not provide standard stories, which is required for e2e tests.
-    skipTasks: ['e2e-tests', 'e2e-tests-dev'],
+    skipTasks: ['e2e-tests-dev'],
   },
 } satisfies Record<string, Template>;
 
@@ -492,6 +486,8 @@ export const daily: TemplateKey[] = [
   'nextjs/12-js',
   'nextjs/default-js',
   'qwik-vite/default-ts',
+  'solid-vite/default-ts',
+  'solid-vite/default-js',
   'preact-webpack5/default-js',
   'preact-vite/default-js',
   'html-vite/default-js',

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -397,7 +397,8 @@ const baseTemplates = {
       renderer: 'storybook-framework-qwik',
       builder: 'storybook-framework-qwik',
     },
-    // TODO: The community template does not provide standard stories, which is required for e2e tests.
+    // TODO: The community template does not provide standard stories, which is required for building and e2e tests.
+    inDevelopment: true,
     skipTasks: ['e2e-tests-dev'],
   },
 } satisfies Record<string, Template>;

--- a/code/lib/cli/src/sandbox-templates.ts
+++ b/code/lib/cli/src/sandbox-templates.ts
@@ -166,7 +166,8 @@ const baseTemplates = {
       renderer: 'storybook-solidjs',
       builder: '@storybook/builder-vite',
     },
-    skipTasks: ['e2e-tests-dev'],
+    // The community SolidJS framework isn't feature complete, so it fails some e2e tests.
+    skipTasks: ['e2e-tests', 'e2e-tests-dev'],
   },
   'solid-vite/default-ts': {
     name: 'SolidJS Vite (TS)',
@@ -176,7 +177,8 @@ const baseTemplates = {
       renderer: 'storybook-solidjs',
       builder: '@storybook/builder-vite',
     },
-    skipTasks: ['e2e-tests-dev'],
+    // The community SolidJS framework isn't feature complete, so it fails some e2e tests.
+    skipTasks: ['e2e-tests', 'e2e-tests-dev'],
   },
   'vue3-vite/default-js': {
     name: 'Vue3 Vite (JS)',

--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -2,21 +2,23 @@ import type { PackageJson, StorybookConfig } from '@storybook/types';
 import { getActualPackageJson } from './package-json';
 
 const knownRenderers = [
-  'html',
-  'react',
-  'svelte',
-  'vue3',
-  'preact',
-  'server',
-  'vue',
-  'web-components',
-  'angular',
-  'ember',
+  '@storybook/html',
+  '@storybook/react',
+  '@storybook/svelte',
+  '@storybook/vue3',
+  '@storybook/preact',
+  '@storybook/server',
+  '@storybook/vue',
+  '@storybook/web-components',
+  '@storybook/angular',
+  '@storybook/ember',
+  'storybook-solidjs',
+  '@builder.io/qwik', // The Qwik framework is a renderer too, so the best we can do here is to detect the actual Qwik package
 ];
 
-const knownBuilders = ['builder-webpack5', 'builder-vite'];
+const knownBuilders = ['@storybook/builder-webpack5', '@storybook/builder-vite'];
 
-function findMatchingPackage(packageJson: PackageJson, suffixes: string[]) {
+function findMatchingPackage(packageJson: PackageJson, packages: string[]) {
   const { name = '', version, dependencies, devDependencies, peerDependencies } = packageJson;
 
   const allDependencies = {
@@ -27,7 +29,7 @@ function findMatchingPackage(packageJson: PackageJson, suffixes: string[]) {
     ...peerDependencies,
   };
 
-  return suffixes.map((suffix) => `@storybook/${suffix}`).find((pkg) => allDependencies[pkg]);
+  return packages.find((pkg) => allDependencies[pkg]);
 }
 
 export async function getFrameworkInfo(mainConfig: StorybookConfig) {

--- a/code/lib/telemetry/src/get-framework-info.ts
+++ b/code/lib/telemetry/src/get-framework-info.ts
@@ -13,7 +13,7 @@ const knownRenderers = [
   '@storybook/angular',
   '@storybook/ember',
   'storybook-solidjs',
-  '@builder.io/qwik', // The Qwik framework is a renderer too, so the best we can do here is to detect the actual Qwik package
+  'storybook-framework-qwik', // The Qwik framework is a renderer too
 ];
 
 const knownBuilders = ['@storybook/builder-webpack5', '@storybook/builder-vite'];


### PR DESCRIPTION
## What I did

This PR enables SolidJS sandboxes to be tested in CI, on the daily workflow.

I also had to do a minor modification to telemetry to allow it to support external frameworks, ie. frameworks that aren't prefixed with `@storybook/`, like `storybook-solidjs`.

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] If this PR should be tested against many or all sandboxes,
      make sure to add the `ci:merged` or `ci:daily` GH label to it.
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->
