### PR TITLE
NextJS: Apply next config webpack function

### DIFF
--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -3,6 +3,8 @@ import semver from 'semver';
 
 import type { NextConfig } from 'next';
 import { DefinePlugin } from 'webpack';
+import type { NextConfigComplete } from 'next/dist/server/config-shared';
+import next from 'next/types';
 import { addScopedAlias, getNextjsVersion, resolveNextConfig } from '../utils';
 
 export const configureConfig = async ({
@@ -53,4 +55,24 @@ const setupRuntimeConfig = (baseConfig: WebpackConfig, nextConfig: NextConfig): 
   }
 
   baseConfig.plugins?.push(new DefinePlugin(definePluginConfig));
+};
+
+export const applyNextConfigWebpackConfig = (
+  baseConfig: WebpackConfig,
+  nextConfig: NextConfig
+): void => {
+  if (typeof nextConfig.webpack === 'function') {
+    nextConfig.webpack(baseConfig, {
+      dev: process.env.NODE_ENV === 'development',
+      isServer: false,
+      buildId: nextConfig.buildId || '',
+      dir: nextConfig.basePath || '.',
+      config: nextConfig as NextConfigComplete,
+      defaultLoaders: {
+        babel: {},
+      },
+      totalPages: 0,
+      webpack: baseConfig,
+    });
+  }
 };

--- a/code/frameworks/nextjs/src/config/webpack.ts
+++ b/code/frameworks/nextjs/src/config/webpack.ts
@@ -66,7 +66,7 @@ export const applyNextConfigWebpackConfig = (
       dev: process.env.NODE_ENV === 'development',
       isServer: false,
       buildId: nextConfig.buildId || '',
-      dir: nextConfig.basePath || '.',
+      dir: '.',
       config: nextConfig as NextConfigComplete,
       defaultLoaders: {
         babel: {},

--- a/code/frameworks/nextjs/src/preset.ts
+++ b/code/frameworks/nextjs/src/preset.ts
@@ -4,7 +4,7 @@ import type { Options, PresetProperty } from '@storybook/types';
 import type { ConfigItem, PluginItem, TransformOptions } from '@babel/core';
 import { loadPartialConfig } from '@babel/core';
 import { getProjectRoot } from '@storybook/core-common';
-import { configureConfig } from './config/webpack';
+import { applyNextConfigWebpackConfig, configureConfig } from './config/webpack';
 import { configureCss } from './css/webpack';
 import { configureImports } from './imports/webpack';
 import { configureRouting } from './routing/webpack';
@@ -152,6 +152,7 @@ export const webpackFinal: StorybookConfig['webpackFinal'] = async (baseConfig, 
   configureRouting(baseConfig);
   configureStyledJsx(baseConfig);
   configureNodePolyfills(baseConfig);
+  applyNextConfigWebpackConfig(baseConfig, nextConfig);
 
   return baseConfig;
 };


### PR DESCRIPTION
## What I did

- Apply webpack function from next config if it exists to the storybook webpack config

## How to test

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests)
- [ ] Make sure to add/update documentation regarding your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

#### Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below.

`["cleanup", "BREAKING CHANGE", "feature request", "bug", "build", "documentation", "maintenance", "dependencies", "other"]`

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
