### PR TITLE
Types: Revert "Fix `React.ReactElement` not found" #23967

### DIFF
--- a/code/lib/types/package.json
+++ b/code/lib/types/package.json
@@ -47,7 +47,6 @@
     "@storybook/channels": "workspace:*",
     "@types/babel__core": "^7.0.0",
     "@types/express": "^4.7.0",
-    "@types/react": "^16.14.34",
     "file-system-cache": "2.3.0"
   },
   "devDependencies": {

--- a/code/lib/types/src/modules/api.ts
+++ b/code/lib/types/src/modules/api.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import type { ReactElement } from 'react';
 import type { RenderData } from '../../../router/src/types';
 import type { Channel } from '../../../channels/src';
 import type { ThemeVars } from '../../../theming/src/types';
@@ -75,7 +74,7 @@ export type API_IframeRenderer = (
   baseUrl: string,
   scale: number,
   queryParams: Record<string, any>
-) => ReactElement<any, any> | null;
+) => React.ReactElement<any, any> | null;
 
 export interface API_UIOptions {
   name?: string;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8037,7 +8037,6 @@ __metadata:
     "@types/babel__core": ^7.0.0
     "@types/express": ^4.7.0
     "@types/node": ^16.0.0
-    "@types/react": ^16.14.34
     file-system-cache: 2.3.0
     typescript: ~4.9.3
   languageName: unknown


### PR DESCRIPTION
Reverts storybookjs/storybook#23967

It broke local sandbox linking in the monorepo for some of the React sandboxes, at least the  `react-vite`-based ones.