### PR TITLE
Angular: Fix for monorepo setups

### DIFF
--- a/code/frameworks/angular/src/client/angular-beta/utils/NgModulesAnalyzer.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/NgModulesAnalyzer.ts
@@ -1,4 +1,5 @@
 import { NgModule, ɵReflectionCapabilities as ReflectionCapabilities } from '@angular/core';
+import { isDecoratorInstanceOf } from './isDecoratorInstanceOf';
 
 const reflectionCapabilities = new ReflectionCapabilities();
 
@@ -45,11 +46,13 @@ const extractNgModuleMetadata = (importItem: any): NgModule => {
     return null;
   }
 
-  const ngModuleDecorator: NgModule | undefined = decorators.find(
-    (decorator) => decorator instanceof NgModule
-  );
+  const ngModuleDecorator: NgModule | undefined = decorators.find((decorator) => {
+    return isDecoratorInstanceOf(decorator, 'NgModule');
+  });
+
   if (!ngModuleDecorator) {
     return null;
   }
+
   return ngModuleDecorator;
 };

--- a/code/frameworks/angular/src/client/angular-beta/utils/PropertyExtractor.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/PropertyExtractor.test.ts
@@ -8,7 +8,7 @@ import {
   provideNoopAnimations,
 } from '@angular/platform-browser/animations';
 import { NgModuleMetadata } from '../../types';
-import { PropertyExtractor, REMOVED_MODULES } from './PropertyExtractor';
+import { PropertyExtractor } from './PropertyExtractor';
 import { WithOfficialModule } from '../__testfixtures__/test.module';
 
 const TEST_TOKEN = new InjectionToken('testToken');
@@ -17,7 +17,6 @@ const TestService = Injectable()(class {});
 const TestComponent1 = Component({})(class {});
 const TestComponent2 = Component({})(class {});
 const StandaloneTestComponent = Component({ standalone: true })(class {});
-const TestDirective = Directive({})(class {});
 const StandaloneTestDirective = Directive({ standalone: true })(class {});
 const TestModuleWithDeclarations = NgModule({ declarations: [TestComponent1] })(class {});
 const TestModuleWithImportsAndProviders = NgModule({

--- a/code/frameworks/angular/src/client/angular-beta/utils/PropertyExtractor.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/PropertyExtractor.ts
@@ -1,15 +1,9 @@
 /* eslint-disable no-console */
 import { CommonModule } from '@angular/common';
 import {
-  Component,
-  Directive,
   importProvidersFrom,
-  Injectable,
   InjectionToken,
-  Input,
   NgModule,
-  Output,
-  Pipe,
   Provider,
   ɵReflectionCapabilities as ReflectionCapabilities,
 } from '@angular/core';
@@ -23,6 +17,7 @@ import {
 import dedent from 'ts-dedent';
 import { NgModuleMetadata } from '../../types';
 import { isComponentAlreadyDeclared } from './NgModulesAnalyzer';
+import { isDecoratorInstanceOf } from './isDecoratorInstanceOf';
 
 export const reflectionCapabilities = new ReflectionCapabilities();
 export const REMOVED_MODULES = new InjectionToken('REMOVED_MODULES');
@@ -168,40 +163,13 @@ export class PropertyExtractor implements NgModuleMetadata {
   static analyzeDecorators = (component: any) => {
     const decorators = reflectionCapabilities.annotations(component);
 
-    const isComponent = decorators.some((d) => this.isDecoratorInstanceOf(d, 'Component'));
-    const isDirective = decorators.some((d) => this.isDecoratorInstanceOf(d, 'Directive'));
-    const isPipe = decorators.some((d) => this.isDecoratorInstanceOf(d, 'Pipe'));
+    const isComponent = decorators.some((d) => isDecoratorInstanceOf(d, 'Component'));
+    const isDirective = decorators.some((d) => isDecoratorInstanceOf(d, 'Directive'));
+    const isPipe = decorators.some((d) => isDecoratorInstanceOf(d, 'Pipe'));
 
     const isDeclarable = isComponent || isDirective || isPipe;
     const isStandalone = (isComponent || isDirective) && decorators.some((d) => d.standalone);
 
     return { isDeclarable, isStandalone };
-  };
-
-  static isDecoratorInstanceOf = (decorator: any, name: string) => {
-    let factory;
-    switch (name) {
-      case 'Component':
-        factory = Component;
-        break;
-      case 'Directive':
-        factory = Directive;
-        break;
-      case 'Pipe':
-        factory = Pipe;
-        break;
-      case 'Injectable':
-        factory = Injectable;
-        break;
-      case 'Input':
-        factory = Input;
-        break;
-      case 'Output':
-        factory = Output;
-        break;
-      default:
-        throw new Error(`Unknown decorator type: ${name}`);
-    }
-    return decorator instanceof factory || decorator.ngMetadataName === name;
   };
 }

--- a/code/frameworks/angular/src/client/angular-beta/utils/isDecoratorInstanceOf.test.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/isDecoratorInstanceOf.test.ts
@@ -1,0 +1,50 @@
+import { Component, Directive, Pipe, Input, Output, NgModule } from '@angular/core';
+import { isDecoratorInstanceOf } from './isDecoratorInstanceOf';
+
+// Simulate Angular's behavior by manually adding the ngMetadataName property, since this information is added during compile time.
+const MockComponentDecorator = { ...Component, ngMetadataName: 'Component' };
+const MockDirectiveDecorator = { ...Directive, ngMetadataName: 'Directive' };
+const MockPipeDecorator = { ...Pipe, ngMetadataName: 'Pipe' };
+const MockInputDecorator = { ...Input, ngMetadataName: 'Input' };
+const MockOutputDecorator = { ...Output, ngMetadataName: 'Output' };
+const MockNgModuleDecorator = { ...NgModule, ngMetadataName: 'NgModule' };
+
+describe('isDecoratorInstanceOf', () => {
+  it('should correctly identify a Component', () => {
+    expect(isDecoratorInstanceOf(MockComponentDecorator, 'Component')).toBe(true);
+  });
+
+  it('should correctly identify a Directive', () => {
+    expect(isDecoratorInstanceOf(MockDirectiveDecorator, 'Directive')).toBe(true);
+  });
+
+  it('should correctly identify a Pipe', () => {
+    expect(isDecoratorInstanceOf(MockPipeDecorator, 'Pipe')).toBe(true);
+  });
+
+  it('should correctly identify an Input', () => {
+    expect(isDecoratorInstanceOf(MockInputDecorator, 'Input')).toBe(true);
+  });
+
+  it('should correctly identify an Output', () => {
+    expect(isDecoratorInstanceOf(MockOutputDecorator, 'Output')).toBe(true);
+  });
+
+  it('should correctly identify an NgModule', () => {
+    expect(isDecoratorInstanceOf(MockNgModuleDecorator, 'NgModule')).toBe(true);
+  });
+
+  it('should return false for mismatched metadata names', () => {
+    expect(isDecoratorInstanceOf(MockComponentDecorator, 'Directive')).toBe(false);
+  });
+
+  it('should handle null or undefined decorators gracefully', () => {
+    expect(isDecoratorInstanceOf(null, 'Component')).toBe(false);
+    expect(isDecoratorInstanceOf(undefined, 'Component')).toBe(false);
+  });
+
+  it('should handle decorators without ngMetadataName property', () => {
+    const mockDecoratorWithoutMetadata = {};
+    expect(isDecoratorInstanceOf(mockDecoratorWithoutMetadata, 'Component')).toBe(false);
+  });
+});

--- a/code/frameworks/angular/src/client/angular-beta/utils/isDecoratorInstanceOf.ts
+++ b/code/frameworks/angular/src/client/angular-beta/utils/isDecoratorInstanceOf.ts
@@ -1,0 +1,6 @@
+export function isDecoratorInstanceOf(
+  decorator: any,
+  name: 'Component' | 'Directive' | 'Pipe' | 'Input' | 'Output' | 'NgModule'
+) {
+  return decorator?.ngMetadataName === name;
+}


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/14828

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

**Problem: (See the explanation/findings [here](https://github.com/storybookjs/storybook/issues/14828#issuecomment-1686463001))**

In monorepository setups, multiple projects or libraries share common dependencies. Sometimes, due to various configurations or linking strategies, these dependencies might get loaded more than once. This results in multiple distinct instances of the same library coexisting in the runtime.

When using the instanceof operator to check if an object is an instance of a particular constructor or class, JavaScript checks against a specific prototype/reference. If two versions (or instances) of a library are loaded in a monorepository, the prototype of a class from one instance is not the same as the prototype of the same class from another instance. This can cause the instanceof checks to fail even when, from a logical perspective, they shouldn’t.

In the context of our Angular decorators (like Component or Directive), the instanceof operator might give incorrect results if, for instance, one part of the monorepo references one instance/version of @angular/core and another part references a different instance. This can lead to situations where an object that logically is an instance of Component is not recognized as such by the instanceof check.

**Solution:**

To address this, we're moving away from using instanceof for type checks. Instead, we're leveraging Angular's internal property ngMetadataName, which is set on decorators like Component, Directive, etc., during the compilation phase. This property provides a string representation of the decorator's type, making it a reliable way to determine the type of decorator, irrespective of how many instances of @angular/core are loaded.

By implementing the isDecoratorInstanceOf function and using the ngMetadataName property, we can ensure consistent and accurate type checks across all projects in the monorepository, eliminating the quirks introduced by the instanceof operator in this specific context.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Manual testing not required

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
