### PR TITLE
Manager: Support path aliases in manager.ts

### DIFF
--- a/code/builders/builder-manager/package.json
+++ b/code/builders/builder-manager/package.json
@@ -57,6 +57,7 @@
     "esbuild-plugin-alias": "^0.2.1",
     "express": "^4.17.3",
     "find-cache-dir": "^3.0.0",
+    "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
     "process": "^0.11.10",
     "util": "^0.12.4"
@@ -64,6 +65,14 @@
   "devDependencies": {
     "slash": "^5.0.0",
     "typescript": "~4.9.3"
+  },
+  "peerDependencies": {
+    "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/code/builders/builder-manager/src/index.ts
+++ b/code/builders/builder-manager/src/index.ts
@@ -91,9 +91,9 @@ export const getConfig: ManagerBuilder['getConfig'] = async (options) => {
 
     tsconfigRaw: {
       ...templateTsConfig,
-      ...userTsConfig.config,
+      ...(userTsConfig?.config ?? {}),
       compilerOptions: {
-        ...userTsConfig?.config.compilerOptions,
+        ...(userTsConfig?.config.compilerOptions ?? {}),
         ...templateTsConfig?.compilerOptions,
       },
     },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6095,11 +6095,17 @@ __metadata:
     esbuild-plugin-alias: "npm:^0.2.1"
     express: "npm:^4.17.3"
     find-cache-dir: "npm:^3.0.0"
+    find-up: "npm:^5.0.0"
     fs-extra: "npm:^11.1.0"
     process: "npm:^0.11.10"
     slash: "npm:^5.0.0"
     typescript: "npm:~4.9.3"
     util: "npm:^0.12.4"
+  peerDependencies:
+    typescript: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/22078
Closes https://github.com/storybookjs/storybook/issues/20582
Closes https://github.com/storybookjs/storybook/issues/22027

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/react/contribute/how-to-contribute

-->


## What I did

Passed the user's Typescript configuration to esbuild. With that, esbuild is able to pick up the path alias configuration appropriately.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
