### PR TITLE
Build: Don't generate stories.json by default

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,6 +12,7 @@
     - [Icons is deprecated](#icons-is-deprecated)
     - [React-docgen component analysis by default](#react-docgen-component-analysis-by-default)
     - [Removed postinstall](#removed-postinstall)
+    - [Removed stories.json generation](#removed-storiesjson-generation)
   - [Framework-specific changes](#framework-specific-changes)
     - [Angular: Drop support for Angular \< 15](#angular-drop-support-for-angular--15)
     - [Next.js: Drop support for version \< 13.5](#nextjs-drop-support-for-version--135)
@@ -472,6 +473,20 @@ For more information see: https://storybook.js.org/docs/react/api/main-config-ty
 #### Removed postinstall
 
 We removed the `@storybook/postinstall` package, which provided some utilities for addons to programmatically modify user configuration files on install. This package was years out of date, so this should be a non-disruptive change. If your addon used the package, you can view the old source code [here](https://github.com/storybookjs/storybook/tree/release-7-5/code/lib/postinstall) and adapt it into your addon.
+
+#### Removed stories.json generation
+
+In addition to the built storybook, `storybook build` generates two files, `index.json` and `stories.json`, that list out the contents of the Storybook. `stories.json` is a legacy format and we included it for backwards compatibility. As of 8.0 we no longer build `stories.json` by default, and we will remove it completely in 9.0.
+
+In the meantime if you have code that relies on `stories.json`, you can re-enable it in your `main.js`:
+
+```js
+export default {
+  features: {
+    buildLegacyStoriesJson: true
+  }
+}
+```
 
 ### Framework-specific changes
 

--- a/code/lib/core-server/src/build-static.ts
+++ b/code/lib/core-server/src/build-static.ts
@@ -178,13 +178,15 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     });
 
     initializedStoryIndexGenerator = generator.initialize().then(() => generator);
-    effects.push(
-      extractStoriesJson(
-        join(options.outputDir, 'stories.json'),
-        initializedStoryIndexGenerator as Promise<StoryIndexGenerator>,
-        convertToIndexV3
-      )
-    );
+    if (features?.buildLegacyStoriesJson) {
+      effects.push(
+        extractStoriesJson(
+          join(options.outputDir, 'stories.json'),
+          initializedStoryIndexGenerator as Promise<StoryIndexGenerator>,
+          convertToIndexV3
+        )
+      );
+    }
     effects.push(
       extractStoriesJson(
         join(options.outputDir, 'index.json'),

--- a/code/lib/types/src/modules/core-common.ts
+++ b/code/lib/types/src/modules/core-common.ts
@@ -401,6 +401,14 @@ export interface StorybookConfigRaw {
      * Enable asynchronous component rendering in NextJS framework
      */
     experimentalNextRSC?: boolean;
+
+    /**
+     * Legacy stories.json extraction. stories.json will be removed in v9,
+     * use `index.json` instead.
+     *
+     * @deprecated
+     */
+    buildLegacyStoriesJson?: boolean;
   };
 
   build?: TestBuildConfig;


### PR DESCRIPTION
Closes N/A

## What I did

Don't build `stories.json` by default since it is a legacy format. Added a feature flag for backwards compatibility, to be removed in 9.0.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Build a sandbox and verify that there is no `stories.json` in the output. Turn on the flag and verify that it comes back.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Updated MIGRATION.md

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
