### PR TITLE
WIP: Pass beforeVersion / afterVersion to automigrations

### DIFF
--- a/code/lib/cli/src/automigrate/index.ts
+++ b/code/lib/cli/src/automigrate/index.ts
@@ -62,6 +62,8 @@ export const automigrate = async ({
   renderer: rendererPackage,
   skipInstall,
   hideMigrationSummary = false,
+  beforeVersion,
+  afterVersion,
 }: FixOptions = {}): Promise<{
   fixResults: Record<string, FixStatus>;
   preCheckFailure?: PreCheckFailure;
@@ -93,6 +95,8 @@ export const automigrate = async ({
     skipInstall,
     dryRun,
     yes,
+    beforeVersion,
+    afterVersion,
   });
 
   const hasFailures = Object.values(fixResults).some(
@@ -134,6 +138,8 @@ export async function runFixes({
   userSpecifiedConfigDir,
   rendererPackage,
   skipInstall,
+  beforeVersion,
+  afterVersion,
 }: {
   fixes: Fix[];
   yes?: boolean;
@@ -143,6 +149,8 @@ export async function runFixes({
   userSpecifiedConfigDir?: string;
   rendererPackage?: string;
   skipInstall?: boolean;
+  beforeVersion?: string;
+  afterVersion?: string;
 }): Promise<{
   preCheckFailure?: PreCheckFailure;
   fixResults: Record<FixId, FixStatus>;
@@ -227,6 +235,8 @@ export async function runFixes({
         storybookVersion,
         previewConfigPath,
         mainConfigPath,
+        beforeVersion,
+        afterVersion,
       });
     } catch (error) {
       logger.info(`⚠️  failed to check fix ${chalk.bold(f.id)}`);

--- a/code/lib/cli/src/automigrate/types.ts
+++ b/code/lib/cli/src/automigrate/types.ts
@@ -9,6 +9,8 @@ export interface CheckOptions {
   storybookVersion: string;
   previewConfigPath?: string;
   mainConfigPath?: string;
+  beforeVersion?: string;
+  afterVersion?: string;
 }
 
 export interface RunOptions<ResultType> {
@@ -47,6 +49,8 @@ export interface FixOptions {
   renderer?: string;
   skipInstall?: boolean;
   hideMigrationSummary?: boolean;
+  beforeVersion?: string;
+  afterVersion?: string;
 }
 
 export enum FixStatus {

--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -206,13 +206,21 @@ export const doUpgrade = async ({
     await packageManager.installDependencies();
   }
 
+  const afterVersion = await getStorybookCoreVersion();
+
   let automigrationResults;
   if (!skipCheck) {
     checkVersionConsistency();
-    automigrationResults = await automigrate({ dryRun, yes, packageManager: pkgMgr, configDir });
+    automigrationResults = await automigrate({
+      dryRun,
+      yes,
+      packageManager: pkgMgr,
+      configDir,
+      beforeVersion,
+      afterVersion,
+    });
   }
   if (!options.disableTelemetry) {
-    const afterVersion = await getStorybookCoreVersion();
     const { preCheckFailure, fixResults } = automigrationResults || {};
     const automigrationTelemetry = {
       automigrationResults: preCheckFailure ? null : fixResults,


### PR DESCRIPTION
Closes N/A

## What I did

Pass before/after version to automigrations so that each fix can run selectively based on that informatio.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
