### PR TITLE
CLI: init with version specified

### DIFF
--- a/code/lib/cli/src/utils/detect-args-version.test.ts
+++ b/code/lib/cli/src/utils/detect-args-version.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, vi } from 'vitest';
+import prompts from 'prompts';
+import { detectStorybookVersionFromNodeArgs } from './detect-args-version';
+import packageVersions from '../versions';
+
+vi.mock('prompts', () => ({ default: vi.fn() }));
+
+describe('normal', () => {
+  test.each([
+    [['npx', 'storybook@6.3.0', 'init'], '6.3.0'],
+    [['npx', 'sb@6.3.0', 'init'], '6.3.0'],
+    [['npx', 'storybook@^8.0.0', 'init'], '^8.0.0'],
+    [['npx', 'sb@^8.0.0', 'init'], '^8.0.0'],
+    [['npx', 'storybook@next', 'init'], 'next'],
+    [['npx', 'sb@next', 'init'], 'next'],
+    [['npx', 'storybook@latest', 'init'], 'latest'],
+    [['npx', 'sb@latest', 'init'], 'latest'],
+    [['npx', '-p', 'sb@latest', 'init'], 'latest'],
+  ])('detects storybook version from node args %s', async (args, expected) => {
+    await expect(detectStorybookVersionFromNodeArgs(args)).resolves.toBe(expected);
+    expect(prompts).not.toHaveBeenCalledOnce();
+  });
+});
+
+describe('no version', () => {
+  test.each([
+    [['npx', 'storybook', 'init'], undefined],
+    [['npx', 'sb', 'init'], undefined],
+  ])('should prompt - return true', async (args, expected) => {
+    // @ts-expect-error (how to make this type safe?)
+    prompts.mockResolvedValueOnce({ runLatest: true });
+    await expect(detectStorybookVersionFromNodeArgs(args)).resolves.toBe(expected);
+    expect(prompts).toHaveBeenCalledOnce();
+  });
+
+  test.each([
+    [['npx', 'storybook', 'init'], undefined],
+    [['npx', 'sb', 'init'], undefined],
+  ])('should prompt - return false', async (args, expected) => {
+    // @ts-expect-error (how to make this type safe?)
+    prompts.mockResolvedValueOnce({ runLatest: false });
+    await expect(detectStorybookVersionFromNodeArgs(args)).rejects.toThrowError();
+    expect(prompts).toHaveBeenCalledOnce();
+  });
+});
+
+describe('edge case', () => {
+  test.each([
+    [['node', '../../mono/code/cli/bin/index.js', 'init']],
+    [['ts-node', '../../mono/code/cli/src/index.ts', 'init']],
+  ])('detects storybook version from node args %s', async (args) => {
+    await expect(detectStorybookVersionFromNodeArgs(args)).resolves.toBe(packageVersions.storybook);
+    expect(prompts).not.toHaveBeenCalledOnce();
+  });
+});

--- a/code/lib/cli/src/utils/detect-args-version.ts
+++ b/code/lib/cli/src/utils/detect-args-version.ts
@@ -1,0 +1,35 @@
+import prompts from 'prompts';
+import packageVersions from '../versions';
+
+export const detectStorybookVersionFromNodeArgs = async (args: string[]) => {
+  const version = args.reduce<undefined | null | string>((acc, arg) => {
+    if (arg.startsWith('storybook@') || arg.startsWith('sb@')) {
+      return arg.split('@')[1];
+    }
+    if (arg === 'storybook' || arg === 'sb') {
+      return null;
+    }
+    return acc;
+  }, undefined);
+
+  if (typeof version === 'string') {
+    return version;
+  }
+
+  if (typeof version === 'undefined') {
+    return packageVersions.storybook;
+  }
+
+  const { runLatest } = await prompts({
+    type: 'confirm',
+    initial: false,
+    name: 'runLatest',
+    message: `You ran the storybook CLI without specifying a version, do you want to run the latest version?`,
+  });
+
+  if (runLatest) {
+    return undefined;
+  }
+
+  throw new Error('user cancelled');
+};


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/25501

## What I did

Add detection if we're being run with an version specifier or not

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
