### PR TITLE
CLI: Fix version detection compatibility with pre SB7.5

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -30,7 +30,7 @@ type Package = {
   version: string;
 };
 
-export const versionRegex = /(@storybook\/[^@]+)@(\S+)/;
+const versionRegex = /(@storybook\/[^@]+)@(\S+)/;
 export const getStorybookVersion = (line: string) => {
   if (line.startsWith('npm ')) return null;
   const match = versionRegex.exec(line);

--- a/code/lib/cli/src/utils/legacy_storybookVersionDetection.ts
+++ b/code/lib/cli/src/utils/legacy_storybookVersionDetection.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { sync as spawnSync } from 'cross-spawn';
 import semver from 'semver';
-import { versionRegex } from '../upgrade';
+
+const legacy_versionRegex = /(@storybook\/[^@]+)@(\S+)/;
 
 const legacy_excludeList = [
   '@storybook/linter-config',
@@ -39,7 +40,7 @@ export const legacy_getStorybookVersion = (): string | undefined => {
   const result = lines
     .map((line) => {
       if (line.startsWith('npm ')) return null;
-      const match = versionRegex.exec(line);
+      const match = legacy_versionRegex.exec(line);
       if (!match || !semver.clean(match[2])) return null;
       return {
         package: match[1],

--- a/code/lib/cli/src/utils/legacy_storybookVersionDetection.ts
+++ b/code/lib/cli/src/utils/legacy_storybookVersionDetection.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { sync as spawnSync } from 'cross-spawn';
+import semver from 'semver';
+import { versionRegex } from '../upgrade';
+
+const legacy_excludeList = [
+  '@storybook/linter-config',
+  '@storybook/design-system',
+  '@storybook/ember-cli-storybook',
+  '@storybook/semver',
+  '@storybook/eslint-config-storybook',
+  '@storybook/bench',
+  '@storybook/addon-bench',
+  '@storybook/addon-console',
+  '@storybook/csf',
+  '@storybook/storybook-deployer',
+  '@storybook/addon-postcss',
+  '@storybook/react-docgen-typescript-plugin',
+  '@storybook/babel-plugin-require-context-hook',
+  '@storybook/builder-vite',
+  '@storybook/mdx1-csf',
+  '@storybook/mdx2-csf',
+  '@storybook/expect',
+  '@storybook/jest',
+  '@storybook/test-runner',
+  '@storybook/testing-library',
+];
+const legacy_isCorePackage = (pkg: string) =>
+  pkg.startsWith('@storybook/') &&
+  !pkg.startsWith('@storybook/preset-') &&
+  !legacy_excludeList.includes(pkg);
+
+/**
+ * @deprecated This function has been deprecated. This is solely to support upgrading from SB6 (and possible SB7)
+ * I took this code from https://github.com/storybookjs/storybook/blob/v6.5.16/lib/cli/src/upgrade.ts#L29-L109
+ */
+export const legacy_getStorybookVersion = (): string | undefined => {
+  const lines = spawnSync('npm', ['ls'], { stdio: 'pipe' }).output.toString().split('\n');
+  const result = lines
+    .map((line) => {
+      if (line.startsWith('npm ')) return null;
+      const match = versionRegex.exec(line);
+      if (!match || !semver.clean(match[2])) return null;
+      return {
+        package: match[1],
+        version: match[2],
+      };
+    })
+    .filter(Boolean)
+    .filter((pkg) => legacy_isCorePackage(pkg!.package))
+    .sort((a, b) => semver.rcompare(a!.version, b!.version));
+
+  if (result.length === 0) {
+    return undefined;
+  }
+
+  return result[0]?.version;
+};


### PR DESCRIPTION
Closes #25975

## What I did

- add a backup version detector ripped straight out of SB6

The problem was that some users on older versions don't have the SB CLI as a (direct) dependency. Because back in the good old days, we shipped a bin with every renderer

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- find/create a project using SB6.5 (check if it doesn't have the CLI) as a dependency) (check the issue attached)
- use the canary release to upgrade

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-26055-sha-bcc55126`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-26055-sha-bcc55126 sandbox` or in an existing project with `npx storybook@0.0.0-pr-26055-sha-bcc55126 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-26055-sha-bcc55126`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-26055-sha-bcc55126) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/fix-version-detection-cli-upgrading-from-pre-SB-7-5`](https://github.com/storybookjs/storybook/tree/norbert/fix-version-detection-cli-upgrading-from-pre-SB-7-5) |
| **Commit** | [`bcc55126`](https://github.com/storybookjs/storybook/commit/bcc551266190637f5319393e5c03595d66226e25) |
| **Datetime** | Fri Feb 16 09:23:48 UTC 2024 (`1708075428`) |
| **Workflow run** | [7928536891](https://github.com/storybookjs/storybook/actions/runs/7928536891) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=26055`_
</details>
<!-- CANARY_RELEASE_SECTION -->
