### PR TITLE
Codemod: Timeout prettier formatting in codemods

### DIFF
--- a/code/lib/codemod/src/lib/utils.test.js
+++ b/code/lib/codemod/src/lib/utils.test.js
@@ -63,7 +63,7 @@ describe('abortablePrettierFormat', () => {
     const code = 'const foo = 123;';
     const codePath = '/path/to/code.js';
 
-    const formattedCode = await abortablePrettierFormat(code, codePath, 100);
+    const formattedCode = await abortablePrettierFormat(code, codePath, {}, 100);
 
     expect(formattedCode).toEqual(code);
   });

--- a/code/lib/codemod/src/lib/utils.test.js
+++ b/code/lib/codemod/src/lib/utils.test.js
@@ -1,5 +1,20 @@
-import { it, expect } from 'vitest';
+import { vi, it, expect } from 'vitest';
 import { sanitizeName } from './utils';
+import { abortablePrettierFormat } from './utils';
+
+const mockPrettier = vi.hoisted(() => {
+  return {
+    format: vi.fn(),
+    resolveConfig: vi.fn(),
+  };
+});
+
+vi.mock('prettier', () => {
+  return {
+    format: mockPrettier.format,
+    resolveConfig: mockPrettier.resolveConfig,
+  };
+});
 
 it('should sanitize names', () => {
   expect(sanitizeName('basic')).toMatchInlineSnapshot(`"Basic"`);
@@ -7,4 +22,49 @@ it('should sanitize names', () => {
   expect(sanitizeName('default')).toMatchInlineSnapshot(`"Default"`);
   expect(sanitizeName('w/punctuation')).toMatchInlineSnapshot(`"WPunctuation"`);
   expect(sanitizeName('5')).toMatchInlineSnapshot(`"_5"`);
+});
+
+describe('abortablePrettierFormat', () => {
+  it('returns formatted code when prettier succeeds', async () => {
+    mockPrettier.format.mockImplementation((code) => `${code}-FORMATTED`);
+    mockPrettier.resolveConfig.mockResolvedValue({});
+
+    const code = 'const foo = 123;';
+    const codePath = '/path/to/code.js';
+
+    const formattedCode = await abortablePrettierFormat(code, codePath);
+
+    expect(formattedCode).toMatchInlineSnapshot(`"const foo = 123;-FORMATTED"`);
+  });
+
+  it('returns original code when prettier fails', async () => {
+    mockPrettier.format.mockImplementation((code) => `${code}-FORMATTED`);
+    mockPrettier.resolveConfig.mockRejectedValue(new Error('Prettier failed'));
+
+    const code = 'const foo = 123;';
+    const codePath = '/path/to/code.js';
+
+    const formattedCode = await abortablePrettierFormat(code, codePath);
+
+    expect(formattedCode).toEqual(code);
+  });
+
+  it('returns original code when prettier takes too long', async () => {
+    mockPrettier.format.mockImplementation((code) => `${code}-FORMATTED`);
+    mockPrettier.resolveConfig.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({});
+          }, 200);
+        })
+    );
+
+    const code = 'const foo = 123;';
+    const codePath = '/path/to/code.js';
+
+    const formattedCode = await abortablePrettierFormat(code, codePath, 100);
+
+    expect(formattedCode).toEqual(code);
+  });
 });

--- a/code/lib/codemod/src/lib/utils.ts
+++ b/code/lib/codemod/src/lib/utils.ts
@@ -49,11 +49,16 @@ export function abortablePrettierFormat(
     new Promise<string>(async (resolve) => {
       try {
         const prettier = await import('prettier');
-        const output = await prettier.format(code, {
+
+        const config = {
           ...(await prettier.resolveConfig(codePath)),
           ...prettierConfig,
           filepath: codePath,
-        });
+        };
+
+        console.log({ config });
+
+        const output = await prettier.format(code, config);
         resolve(output);
       } catch (e) {
         logger.log(`Failed applying prettier to ${codePath}.`);

--- a/code/lib/codemod/src/lib/utils.ts
+++ b/code/lib/codemod/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import camelCase from 'lodash/camelCase.js';
 import upperFirst from 'lodash/upperFirst.js';
 
+const logger = console;
+
 export const sanitizeName = (name: string) => {
   let key = upperFirst(camelCase(name));
   // prepend _ if name starts with a digit
@@ -26,4 +28,39 @@ export function jscodeshiftToPrettierParser(parser?: string) {
     return 'babel';
   }
   return parserMap[parser] || 'babel';
+}
+
+/**
+ * Formats the code using prettier, but aborts if it takes too long and returns the original code.
+ */
+export function abortablePrettierFormat(
+  code: string,
+  codePath: string,
+  timeout = 4000
+): Promise<string> {
+  let finished = false;
+  return Promise.race([
+    new Promise<string>(async (resolve) => {
+      try {
+        const prettier = await import('prettier');
+        const output = await prettier.format(code, {
+          ...(await prettier.resolveConfig(codePath)),
+          filepath: codePath,
+        });
+        resolve(output);
+      } catch (e) {
+        logger.log(`Failed applying prettier to ${codePath}.`);
+        resolve(code);
+      } finally {
+        finished = true;
+      }
+    }),
+    new Promise<string>((resolve) => {
+      setTimeout(() => {
+        if (finished) return;
+        logger.log(`Prettier is taking a long time, skipping formatting for ${codePath}`);
+        resolve(code);
+      }, timeout);
+    }),
+  ]);
 }

--- a/code/lib/codemod/src/lib/utils.ts
+++ b/code/lib/codemod/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import camelCase from 'lodash/camelCase.js';
 import upperFirst from 'lodash/upperFirst.js';
+import type { Options } from 'prettier';
 
 const logger = console;
 
@@ -32,10 +33,15 @@ export function jscodeshiftToPrettierParser(parser?: string) {
 
 /**
  * Formats the code using prettier, but aborts if it takes too long and returns the original code.
+ * @param code The code to format
+ * @param codePath The path of the code
+ * @param prettierConfig The prettier configuration @default {}
+ * @param timeout The timeout in milliseconds @default 4000
  */
 export function abortablePrettierFormat(
   code: string,
   codePath: string,
+  prettierConfig: Options = {},
   timeout = 4000
 ): Promise<string> {
   let finished = false;
@@ -45,6 +51,7 @@ export function abortablePrettierFormat(
         const prettier = await import('prettier');
         const output = await prettier.format(code, {
           ...(await prettier.resolveConfig(codePath)),
+          ...prettierConfig,
           filepath: codePath,
         });
         resolve(output);

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -1,8 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { dedent } from 'ts-dedent';
 import type { API } from 'jscodeshift';
 import ansiRegex from 'ansi-regex';
 import _transform from '../csf-2-to-3';
+
+vi.mock('prettier', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('prettier')>();
+
+  return {
+    ...mod,
+    resolveConfig: vi.fn().mockResolvedValue({
+      printWidth: 100,
+      tabWidth: 2,
+      bracketSpacing: true,
+      trailingComma: 'es5',
+      singleQuote: true,
+    }),
+  };
+});
 
 expect.addSnapshotSerializer({
   serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),

--- a/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/csf-2-to-3.test.ts
@@ -15,6 +15,7 @@ vi.mock('prettier', async (importOriginal) => {
       bracketSpacing: true,
       trailingComma: 'es5',
       singleQuote: true,
+      parser: 'babel-ts',
     }),
   };
 });

--- a/code/lib/codemod/src/transforms/__tests__/find-implicit-spies.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/find-implicit-spies.test.ts
@@ -19,6 +19,7 @@ vi.mock('prettier', async (importOriginal) => {
       bracketSpacing: true,
       trailingComma: 'es5',
       singleQuote: true,
+      parser: 'babel-ts',
     }),
   };
 });

--- a/code/lib/codemod/src/transforms/__tests__/find-implicit-spies.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/find-implicit-spies.test.ts
@@ -8,6 +8,21 @@ expect.addSnapshotSerializer({
   test: (value) => typeof value === 'string' && ansiRegex().test(value),
 });
 
+vi.mock('prettier', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('prettier')>();
+
+  return {
+    ...mod,
+    resolveConfig: vi.fn().mockResolvedValue({
+      printWidth: 100,
+      tabWidth: 2,
+      bracketSpacing: true,
+      trailingComma: 'es5',
+      singleQuote: true,
+    }),
+  };
+});
+
 const tsTransform = async (source: string) => transform({ source, path: 'Component.stories.tsx' });
 
 const warn = vi.spyOn(console, 'warn');

--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -20,6 +20,7 @@ vi.mock('prettier', async (importOriginal) => {
       bracketSpacing: true,
       trailingComma: 'es5',
       singleQuote: true,
+      parser: 'babel-ts',
     }),
   };
 });

--- a/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/mdx-to-csf.test.ts
@@ -9,6 +9,21 @@ expect.addSnapshotSerializer({
 });
 
 vi.mock('node:fs');
+vi.mock('prettier', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('prettier')>();
+
+  return {
+    ...mod,
+    resolveConfig: vi.fn().mockResolvedValue({
+      printWidth: 100,
+      tabWidth: 2,
+      bracketSpacing: true,
+      trailingComma: 'es5',
+      singleQuote: true,
+    }),
+  };
+});
+
 const fs = vi.mocked(fs_);
 
 beforeEach(() => {

--- a/code/lib/codemod/src/transforms/__tests__/migrate-to-test-package.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/migrate-to-test-package.test.ts
@@ -1,6 +1,21 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import transform from '../migrate-to-test-package';
 import dedent from 'ts-dedent';
+
+vi.mock('prettier', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('prettier')>();
+
+  return {
+    ...mod,
+    resolveConfig: vi.fn().mockResolvedValue({
+      printWidth: 100,
+      tabWidth: 2,
+      bracketSpacing: true,
+      trailingComma: 'es5',
+      singleQuote: true,
+    }),
+  };
+});
 
 expect.addSnapshotSerializer({
   serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),

--- a/code/lib/codemod/src/transforms/__tests__/migrate-to-test-package.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/migrate-to-test-package.test.ts
@@ -13,6 +13,7 @@ vi.mock('prettier', async (importOriginal) => {
       bracketSpacing: true,
       trailingComma: 'es5',
       singleQuote: true,
+      parser: 'babel-ts',
     }),
   };
 });

--- a/code/lib/codemod/src/transforms/__tests__/upgrade-deprecated-types.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/upgrade-deprecated-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { dedent } from 'ts-dedent';
 import type { API } from 'jscodeshift';
 import ansiRegex from 'ansi-regex';
@@ -7,6 +7,21 @@ import _transform from '../upgrade-deprecated-types';
 expect.addSnapshotSerializer({
   serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
   test: () => true,
+});
+
+vi.mock('prettier', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('prettier')>();
+
+  return {
+    ...mod,
+    resolveConfig: vi.fn().mockResolvedValue({
+      printWidth: 100,
+      tabWidth: 2,
+      bracketSpacing: true,
+      trailingComma: 'es5',
+      singleQuote: true,
+    }),
+  };
 });
 
 const tsTransform = async (source: string) =>

--- a/code/lib/codemod/src/transforms/__tests__/upgrade-deprecated-types.test.ts
+++ b/code/lib/codemod/src/transforms/__tests__/upgrade-deprecated-types.test.ts
@@ -20,6 +20,7 @@ vi.mock('prettier', async (importOriginal) => {
       bracketSpacing: true,
       trailingComma: 'es5',
       singleQuote: true,
+      parser: 'babel-ts',
     }),
   };
 });

--- a/code/lib/codemod/src/transforms/csf-2-to-3.ts
+++ b/code/lib/codemod/src/transforms/csf-2-to-3.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-import prettier from 'prettier';
 import * as t from '@babel/types';
 import { isIdentifier, isTSTypeAnnotation, isTSTypeReference } from '@babel/types';
 import type { CsfFile } from '@storybook/csf-tools';
@@ -9,6 +8,7 @@ import type { BabelFile, NodePath } from '@babel/core';
 import * as babel from '@babel/core';
 import invariant from 'tiny-invariant';
 import { upgradeDeprecatedTypes } from './upgrade-deprecated-types';
+import { abortablePrettierFormat } from '../lib/utils';
 
 const logger = console;
 
@@ -201,18 +201,7 @@ export default async function transform(info: FileInfo, api: API, options: { par
   importHelper.removeDeprecatedStoryImport();
   removeUnusedTemplates(csf);
 
-  let output = printCsf(csf).code;
-
-  try {
-    output = await prettier.format(output, {
-      ...(await prettier.resolveConfig(info.path)),
-      filepath: info.path,
-    });
-  } catch (e) {
-    logger.log(`Failed applying prettier to ${info.path}.`);
-  }
-
-  return output;
+  return abortablePrettierFormat(printCsf(csf).code, info.path);
 }
 
 class StorybookImportHelper {

--- a/code/lib/codemod/src/transforms/migrate-to-test-package.ts
+++ b/code/lib/codemod/src/transforms/migrate-to-test-package.ts
@@ -4,7 +4,7 @@ import { loadCsf, printCsf } from '@storybook/csf-tools';
 import type { BabelFile } from '@babel/core';
 import * as babel from '@babel/core';
 import * as t from '@babel/types';
-import prettier from 'prettier';
+import { abortablePrettierFormat } from '../lib/utils';
 
 export default async function transform(info: FileInfo) {
   const csf = loadCsf(info.source, { makeTitle: (title) => title });
@@ -48,16 +48,7 @@ export default async function transform(info: FileInfo) {
     },
   });
 
-  let output = printCsf(csf).code;
-  try {
-    output = await prettier.format(output, {
-      ...(await prettier.resolveConfig(info.path)),
-      filepath: info.path,
-    });
-  } catch (e) {
-    console.warn(`Failed applying prettier to ${info.path}.`);
-  }
-  return output;
+  return abortablePrettierFormat(printCsf(csf).code, info.path);
 }
 
 export const parser = 'tsx';

--- a/code/lib/codemod/src/transforms/storiesof-to-csf.js
+++ b/code/lib/codemod/src/transforms/storiesof-to-csf.js
@@ -261,5 +261,7 @@ export default async function transformer(file, api, options) {
     return source;
   }
 
-  return abortablePrettierFormat(source, file.path);
+  return abortablePrettierFormat(source, file.path, {
+    parser: jscodeshiftToPrettierParser(options.parser),
+  });
 }

--- a/code/lib/codemod/src/transforms/storiesof-to-csf.js
+++ b/code/lib/codemod/src/transforms/storiesof-to-csf.js
@@ -1,7 +1,6 @@
-import prettier from 'prettier';
 import { logger } from '@storybook/node-logger';
 import { storyNameFromExport } from '@storybook/csf';
-import { sanitizeName, jscodeshiftToPrettierParser } from '../lib/utils';
+import { sanitizeName, jscodeshiftToPrettierParser, abortablePrettierFormat } from '../lib/utils';
 
 /**
  * Convert a legacy story API to component story format
@@ -262,17 +261,5 @@ export default async function transformer(file, api, options) {
     return source;
   }
 
-  let output = source;
-
-  try {
-    const prettierConfig = await prettier.resolveConfig(file.path);
-    output = prettier.format(source, {
-      ...prettierConfig,
-      parser: jscodeshiftToPrettierParser(options.parser),
-    });
-  } catch (e) {
-    logger.warn(`Failed to format ${file.path} with prettier`);
-  }
-
-  return output;
+  return abortablePrettierFormat(source, file.path);
 }

--- a/code/lib/core-server/src/utils/build-or-throw.ts
+++ b/code/lib/core-server/src/utils/build-or-throw.ts
@@ -6,8 +6,8 @@ export async function buildOrThrow<T>(callback: () => Promise<T>): Promise<T> {
   } catch (err: any) {
     const builderErrors = err.errors as { text: string }[];
     if (builderErrors) {
-      const inconsistentVersionsError = builderErrors.find(
-        (er) => er.text?.includes('No matching export')
+      const inconsistentVersionsError = builderErrors.find((er) =>
+        er.text?.includes('No matching export')
       );
 
       if (inconsistentVersionsError) {

--- a/code/lib/manager-api/src/modules/whatsnew.ts
+++ b/code/lib/manager-api/src/modules/whatsnew.ts
@@ -57,11 +57,10 @@ export const init: ModuleFn = ({ fullAPI, store, provider }) => {
   function getLatestWhatsNewPost(): Promise<WhatsNewData> {
     provider.channel?.emit(REQUEST_WHATS_NEW_DATA);
 
-    return new Promise(
-      (resolve) =>
-        provider.channel?.once(RESULT_WHATS_NEW_DATA, ({ data }: { data: WhatsNewData }) =>
-          resolve(data)
-        )
+    return new Promise((resolve) =>
+      provider.channel?.once(RESULT_WHATS_NEW_DATA, ({ data }: { data: WhatsNewData }) =>
+        resolve(data)
+      )
     );
   }
 

--- a/code/renderers/svelte/src/public-types.ts
+++ b/code/renderers/svelte/src/public-types.ts
@@ -23,17 +23,19 @@ export type { Args, ArgTypes, Parameters, StrictArgs } from '@storybook/types';
  *
  * @see [Default export](https://storybook.js.org/docs/formats/component-story-format/#default-export)
  */
-export type Meta<CmpOrArgs = Args> = CmpOrArgs extends SvelteComponent<infer Props>
-  ? ComponentAnnotations<SvelteRenderer<CmpOrArgs>, Props>
-  : ComponentAnnotations<SvelteRenderer, CmpOrArgs>;
+export type Meta<CmpOrArgs = Args> =
+  CmpOrArgs extends SvelteComponent<infer Props>
+    ? ComponentAnnotations<SvelteRenderer<CmpOrArgs>, Props>
+    : ComponentAnnotations<SvelteRenderer, CmpOrArgs>;
 /**
  * Story function that represents a CSFv2 component example.
  *
  * @see [Named Story exports](https://storybook.js.org/docs/formats/component-story-format/#named-story-exports)
  */
-export type StoryFn<TCmpOrArgs = Args> = TCmpOrArgs extends SvelteComponent<infer Props>
-  ? AnnotatedStoryFn<SvelteRenderer, Props>
-  : AnnotatedStoryFn<SvelteRenderer, TCmpOrArgs>;
+export type StoryFn<TCmpOrArgs = Args> =
+  TCmpOrArgs extends SvelteComponent<infer Props>
+    ? AnnotatedStoryFn<SvelteRenderer, Props>
+    : AnnotatedStoryFn<SvelteRenderer, TCmpOrArgs>;
 
 /**
  * Story object that represents a CSFv3 component example.

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -68,11 +68,12 @@ type AllowNonFunctionSlots<Slots> = {
 
 export type ComponentPropsAndSlots<C> = ComponentProps<C> & ExtractSlots<C>;
 
-type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends Constructor<any>
-  ? ComponentPropsAndSlots<TCmpOrArgs>
-  : TCmpOrArgs extends FunctionalComponent<any>
+type ComponentPropsOrProps<TCmpOrArgs> =
+  TCmpOrArgs extends Constructor<any>
     ? ComponentPropsAndSlots<TCmpOrArgs>
-    : TCmpOrArgs;
+    : TCmpOrArgs extends FunctionalComponent<any>
+      ? ComponentPropsAndSlots<TCmpOrArgs>
+      : TCmpOrArgs;
 
 export type Decorator<TArgs = StrictArgs> = DecoratorFunction<VueRenderer, TArgs>;
 export type Loader<TArgs = StrictArgs> = LoaderFunction<VueRenderer, TArgs>;

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -2856,10 +2856,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:8.56.0":
-  version: 8.56.0
-  resolution: "@eslint/js@npm:8.56.0"
-  checksum: 60b3a1cf240e2479cec9742424224465dc50e46d781da1b7f5ef240501b2d1202c225bd456207faac4b34a64f4765833345bc4ddffd00395e1db40fa8c426f5a
+"@eslint/js@npm:8.57.0":
+  version: 8.57.0
+  resolution: "@eslint/js@npm:8.57.0"
+  checksum: 9a518bb8625ba3350613903a6d8c622352ab0c6557a59fe6ff6178bf882bf57123f9d92aa826ee8ac3ee74b9c6203fe630e9ee00efb03d753962dcf65ee4bd94
   languageName: node
   linkType: hard
 
@@ -3335,7 +3335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.11.13":
+"@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
   dependencies:
@@ -14407,14 +14407,14 @@ __metadata:
   linkType: hard
 
 "eslint@npm:^8.56.0":
-  version: 8.56.0
-  resolution: "eslint@npm:8.56.0"
+  version: 8.57.0
+  resolution: "eslint@npm:8.57.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.6.1"
     "@eslint/eslintrc": "npm:^2.1.4"
-    "@eslint/js": "npm:8.56.0"
-    "@humanwhocodes/config-array": "npm:^0.11.13"
+    "@eslint/js": "npm:8.57.0"
+    "@humanwhocodes/config-array": "npm:^0.11.14"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@nodelib/fs.walk": "npm:^1.2.8"
     "@ungap/structured-clone": "npm:^1.2.0"
@@ -14450,7 +14450,7 @@ __metadata:
     text-table: "npm:^0.2.0"
   bin:
     eslint: bin/eslint.js
-  checksum: 2be598f7da1339d045ad933ffd3d4742bee610515cd2b0d9a2b8b729395a01d4e913552fff555b559fccaefd89d7b37632825789d1b06470608737ae69ab43fb
+  checksum: 00bb96fd2471039a312435a6776fe1fd557c056755eaa2b96093ef3a8508c92c8775d5f754768be6b1dddd09fdd3379ddb231eeb9b6c579ee17ea7d68000a529
   languageName: node
   linkType: hard
 

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -23377,11 +23377,11 @@ __metadata:
   linkType: hard
 
 "prettier@npm:*, prettier@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "prettier@npm:3.1.1"
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: facc944ba20e194ff4db765e830ffbcb642803381f0d2033ed397e79904fa4ccc877dc25ad68f42d36985c01d051c990ca1b905fb83d2d7d65fe69e4386fa1a3
+  checksum: ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Introduce a timeout mechanism if prettier isn't able to format a file in time within different codemods.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
