### PR TITLE
Vue3: Use $slots for slots

### DIFF
--- a/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
+++ b/code/lib/preview-api/src/modules/store/csf/prepareStory.ts
@@ -68,8 +68,17 @@ export function prepareStory<TRenderer extends Renderer>(
     return updatedContext;
   };
 
-  const undecoratedStoryFn = (context: StoryContext<TRenderer>) =>
-    (render as ArgsStoryFn<TRenderer>)(context.args, context);
+  const undecoratedStoryFn = (context: StoryContext<TRenderer>) => {
+    const args = { ...context.args };
+
+    // Object.entries(args).forEach(([key]) => {
+    //   if (key.startsWith('$')) {
+    //     delete args[key];
+    //   }
+    // });
+
+    return (render as ArgsStoryFn<TRenderer>)(args, context);
+  };
 
   // Currently it is only possible to set these globally
   const { applyDecorators = defaultDecorateStory, runStep } = projectAnnotations;

--- a/code/renderers/vue3/src/public-types.test.ts
+++ b/code/renderers/vue3/src/public-types.test.ts
@@ -65,8 +65,13 @@ describe('StoryObj', () => {
       args: { label: 'good' },
     });
 
-    type Actual = StoryObj<typeof meta>;
-    type Expected = StoryAnnotations<VueRenderer, ButtonProps, SetOptional<ButtonProps, 'label'>>;
+    type Actual = StoryObj<typeof meta>['args'];
+    type Expected = StoryAnnotations<
+      VueRenderer,
+      ButtonProps,
+      SetOptional<ButtonProps, 'label'>
+    >['args'];
+
     expectTypeOf<Actual>().toEqualTypeOf<Expected>();
   });
 
@@ -75,7 +80,8 @@ describe('StoryObj', () => {
       const meta = satisfies<Meta<typeof Button>>()({ component: Button });
 
       type Expected = StoryAnnotations<VueRenderer, ButtonProps, ButtonProps>;
-      expectTypeOf<StoryObj<typeof meta>>().toEqualTypeOf<Expected>();
+
+      expectTypeOf<StoryObj<typeof meta>['args']>().toEqualTypeOf<Expected['args']>();
     }
     {
       const meta = satisfies<Meta<typeof Button>>()({
@@ -86,7 +92,7 @@ describe('StoryObj', () => {
       const Basic: StoryObj<typeof meta> = {};
 
       type Expected = StoryAnnotations<VueRenderer, ButtonProps, SetOptional<ButtonProps, 'label'>>;
-      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+      expectTypeOf(Basic.args).toEqualTypeOf<Expected['args']>();
     }
     {
       const meta = satisfies<Meta<{ label: string; disabled: boolean }>>()({ component: Button });
@@ -96,18 +102,20 @@ describe('StoryObj', () => {
       };
 
       type Expected = StoryAnnotations<VueRenderer, ButtonProps, ButtonProps>;
-      expectTypeOf(Basic).toEqualTypeOf<Expected>();
+      expectTypeOf(Basic.args).toEqualTypeOf<Expected['args']>();
     }
   });
 
   it('Component can be used as generic parameter for StoryObj', () => {
-    expectTypeOf<StoryObj<typeof Button>>().toEqualTypeOf<
-      StoryAnnotations<VueRenderer, ButtonProps>
+    expectTypeOf<StoryObj<typeof Button>['args']>().toEqualTypeOf<
+      StoryAnnotations<VueRenderer, ButtonProps>['args']
     >();
   });
 });
 
 type ThemeData = 'light' | 'dark';
+
+const use = (...args: unknown[]) => { };
 
 describe('Story args can be inferred', () => {
   it('Correct args are inferred when type is widened for render function', () => {
@@ -124,7 +132,10 @@ describe('Story args can be inferred', () => {
     const Basic: StoryObj<typeof meta> = { args: { theme: 'light', label: 'good' } };
 
     type Expected = StoryAnnotations<VueRenderer, Props, SetOptional<Props, 'disabled'>>;
-    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    const expected: Expected = Basic;
+    const basic: typeof Basic = expected;
+
+    use(expected, basic);
   });
 
   const withDecorator: Decorator<{ decoratorArg: string }> = (
@@ -144,7 +155,7 @@ describe('Story args can be inferred', () => {
     const Basic: StoryObj<typeof meta> = { args: { decoratorArg: 'title', label: 'good' } };
 
     type Expected = StoryAnnotations<VueRenderer, Props, SetOptional<Props, 'disabled'>>;
-    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    expectTypeOf(Basic.args).toEqualTypeOf<Expected['args']>();
   });
 
   it('Correct args are inferred when type is widened for multiple decorators', () => {
@@ -169,7 +180,7 @@ describe('Story args can be inferred', () => {
     };
 
     type Expected = StoryAnnotations<VueRenderer, Props, SetOptional<Props, 'disabled'>>;
-    expectTypeOf(Basic).toEqualTypeOf<Expected>();
+    expectTypeOf(Basic.args).toEqualTypeOf<Expected['args']>();
   });
 });
 
@@ -181,18 +192,20 @@ it('Infer type of slots', () => {
   const Basic: StoryObj<typeof meta> = {
     args: {
       otherProp: true,
-      header: ({ title }) =>
-        h({
-          components: { Button },
-          template: `<Button :primary='true' label='${title}'></Button>`,
-        }),
-      default: 'default slot',
-      footer: h(Button, { disabled: true, label: 'footer' }),
+      $slots: {
+        header: ({ title }) =>
+          h({
+            components: { Button },
+            template: `<Button :primary='true' label='${title}'></Button>`,
+          }),
+        default: 'default slot',
+        footer: h(Button, { disabled: true, label: 'footer' }),
+      },
     },
   };
 
   type Props = ComponentPropsAndSlots<typeof BaseLayout>;
 
   type Expected = StoryAnnotations<VueRenderer, Props, Props>;
-  expectTypeOf(Basic).toEqualTypeOf<Expected>();
+  expectTypeOf(Basic.args).toEqualTypeOf<Expected['args']>();
 });

--- a/code/renderers/vue3/src/public-types.ts
+++ b/code/renderers/vue3/src/public-types.ts
@@ -50,7 +50,7 @@ export type StoryObj<TMetaOrCmpOrArgs = Args> = TMetaOrCmpOrArgs extends {
   args?: infer DefaultArgs;
 }
   ? Simplify<
-      ComponentPropsAndSlots<Component> & ArgsFromMeta<VueRenderer, TMetaOrCmpOrArgs>
+      ComponentPropsOrProps<Component> & ArgsFromMeta<VueRenderer, TMetaOrCmpOrArgs>
     > extends infer TArgs
     ? StoryAnnotations<
         VueRenderer,
@@ -66,13 +66,15 @@ type AllowNonFunctionSlots<Slots> = {
   [K in keyof Slots]: Slots[K] | VNodeChild;
 };
 
-export type ComponentPropsAndSlots<C> = ComponentProps<C> & ExtractSlots<C>;
+export type ComponentPropsAndSlots<C> = ComponentProps<C> & { $slots?: ExtractSlots<C> };
 
-type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends Constructor<any>
+export type ComponentPropsOrProps<TCmpOrArgs> = TCmpOrArgs extends Constructor<any>
   ? ComponentPropsAndSlots<TCmpOrArgs>
   : TCmpOrArgs extends FunctionalComponent<any>
     ? ComponentPropsAndSlots<TCmpOrArgs>
-    : TCmpOrArgs;
+    : TCmpOrArgs extends VueRenderer['component']
+      ? Record<string, any>
+      : TCmpOrArgs;
 
 export type Decorator<TArgs = StrictArgs> = DecoratorFunction<VueRenderer, TArgs>;
 export type Loader<TArgs = StrictArgs> = LoaderFunction<VueRenderer, TArgs>;

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/CustomRenderFunctionalComponent.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/CustomRenderFunctionalComponent.stories.ts
@@ -7,11 +7,12 @@ const meta = {
   ...ReactiveDecorators.default,
   component: Reactivity,
   // storybook render function is not a functional component. it returns a functional component or a component options
-  render: (args) => {
+  render: (args, context) => {
     // create the slot contents as a functional components
-    const header = ({ title }: { title: string }) => h('h3', `${args.header} - Title: ${title}`);
-    const defaultSlot = () => h('p', `${args.default}`);
-    const footer = () => h('p', `${args.footer}`);
+    const header = ({ title }: { title: string }) =>
+      h('h3', `${context.args.$slots?.header} - Title: ${title}`);
+    const defaultSlot = () => h('p', `${context.args.$slots?.default}`);
+    const footer = () => h('p', `${context.args.$slots?.footer}`);
     // vue render function is a functional components
     return () =>
       h('div', [

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/CustomRenderOptionsArgsFromData.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/CustomRenderOptionsArgsFromData.stories.ts
@@ -14,9 +14,9 @@ const meta = {
   ...ReactiveDecorators.default,
   component: Reactivity,
   render: (args, { argTypes }) => {
-    state.header = args.header;
-    state.default = args.default;
-    state.footer = args.footer;
+    state.header = args.$slots?.header;
+    state.default = args.$slots?.default;
+    state.footer = args.$slots?.footer;
     // return a component options
     return defineComponent({
       data: () => ({ args, header: state.header, default: state.default, footer: state.footer }),

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/ReactiveArgs.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/ReactiveArgs.stories.ts
@@ -12,11 +12,11 @@ const meta = {
     // To show that other props are passed through
     backgroundColor: { control: 'color' },
   },
-} satisfies Meta<typeof ReactiveArgs>;
+} satisfies Meta;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj;
 
 export const ReactiveTest: Story = {
   args: {

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/ReactiveDecorators.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/ReactiveDecorators.stories.ts
@@ -7,16 +7,13 @@ import Reactivity from './Reactivity.vue';
 
 const meta = {
   component: Reactivity,
-  argTypes: {
-    header: { control: { type: 'text' } },
-    footer: { control: { type: 'text' } },
-    default: { control: { type: 'text' } },
-  },
   args: {
     label: 'If you see this then the label arg was not reactive.',
-    default: 'If you see this then the default slot was not reactive.',
-    header: 'If you see this, the header slot was not reactive.', // this can be useless if you have custom render function that overrides the slot
-    footer: 'If you see this, the footer slot was not reactive.',
+    $slots: {
+      default: 'If you see this then the default slot was not reactive.',
+      header: 'If you see this, the header slot was not reactive.', // this can be useless if you have custom render function that overrides the slot
+      footer: 'If you see this, the footer slot was not reactive.',
+    },
   },
   play: async ({ canvasElement, id, args }) => {
     const channel = (globalThis as any).__STORYBOOK_ADDONS_CHANNEL__;
@@ -33,9 +30,11 @@ const meta = {
       storyId: id,
       updatedArgs: {
         label: 'updated label',
-        header: 'updated header slot', // this can be useless if you have custom render function that overrides the slot which the case here
-        footer: 'updated footer slot',
-        default: 'updated default slot',
+        $slots: {
+          header: 'updated header slot', // this can be useless if you have custom render function that overrides the slot which the case here
+          footer: 'updated footer slot',
+          default: 'updated default slot',
+        },
       },
     });
     await new Promise((resolve) => channel.once(STORY_ARGS_UPDATED, resolve));

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/ReactiveSlots.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/ReactiveSlots.stories.ts
@@ -10,8 +10,10 @@ const meta = {
   component: BaseLayout,
   args: {
     label: 'Storybook Day',
-    default: () => 'Default Text Slot',
-    footer: h('p', 'Footer VNode Slot'),
+    $slots: {
+      default: () => 'Default Text Slot',
+      footer: h('p', 'Footer VNode Slot'),
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof BaseLayout>;
@@ -22,9 +24,11 @@ type Story = StoryObj<typeof meta>;
 export const SimpleSlotTest: Story = {
   args: {
     label: 'Storybook Day',
-    header: () => h('h1', 'Header Text Slot'),
-    default: () => 'Default Text Slot',
-    footer: h('p', 'Footer VNode Slot'),
+    $slots: {
+      header: () => h('h1', 'Header Text Slot'),
+      default: () => 'Default Text Slot',
+      footer: h('p', 'Footer VNode Slot'),
+    },
   },
   play: async ({ canvasElement, id }) => {
     const channel = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
@@ -59,9 +63,11 @@ export const SimpleSlotTest: Story = {
 export const NamedSlotTest: Story = {
   args: {
     label: 'Storybook Day',
-    header: ({ title }: { title: string }) => h('h1', title),
-    default: () => 'Default Text Slot',
-    footer: h('p', 'Footer VNode Slot'),
+    $slots: {
+      header: ({ title }: { title: string }) => h('h1', title),
+      default: () => 'Default Text Slot',
+      footer: h('p', 'Footer VNode Slot'),
+    },
   },
   // test that args are updated correctly in rective mode
   play: async ({ canvasElement, id }) => {
@@ -100,18 +106,20 @@ export const NamedSlotTest: Story = {
 export const SlotWithRenderFn: Story = {
   args: {
     label: 'Storybook Day',
-    header: ({ title }: { title: string }) => `${title}`,
-    default: () => 'Default Text Slot',
-    footer: h('p', 'Footer VNode Slot'),
+    $slots: {
+      header: ({ title }: { title: string }) => `${title}`,
+      default: () => 'Default Text Slot',
+      footer: h('p', 'Footer VNode Slot'),
+    },
   },
-  render: (args) => ({
+  render: (args, { args: { $slots } }) => ({
     components: { BaseLayout },
     setup() {
-      return { args };
+      return { args, slots: $slots };
     },
     template: `<BaseLayout :label="args.label" data-testid="layout">
-  	            {{args.default()}}
-                <template #header="{ title }"><h1>{{args.header({title})}}</h1></template>
+  	            {{slots.default()}}
+                <template #header="{ title }"><h1>{{slots.header({title})}}</h1></template>
               </BaseLayout>`,
   }),
   play: async ({ canvasElement, id }) => {

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/ScopedSlots.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/ScopedSlots.stories.ts
@@ -17,7 +17,9 @@ const meta = {
   args: {
     label: 'Storybook Day',
     year: 2022,
-    default: ({ text, year }) => `${text}, ${year}`,
+    $slots: {
+      default: ({ text, year }) => `${text}, ${year}`,
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof MySlotComponent>;
@@ -68,13 +70,13 @@ export const CustomRender: Story = {
 };
 
 export const CustomRenderUsingFunctionSlot: Story = {
-  render: (args: any) => ({
+  render: (args: any, context) => ({
     components: { MySlotComponent },
     setup() {
-      return { args };
+      return { args: args, slots: context.args.$slots };
     },
     template: `<MySlotComponent v-bind="args" v-slot="slotProps">
-  	            {{args.default(slotProps)}}
+  	            {{slots.default(slotProps)}}
               </MySlotComponent>`,
   }),
   play: Basic.play,

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/SourceDecorator.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/SourceDecorator.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta = {
 } satisfies Meta<typeof GlobalUsage>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj;
 
 export const MultiComponents: Story = {
   args: {

--- a/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/TemplateSlots.stories.ts
+++ b/code/renderers/vue3/template/stories_vue3-vite-default-ts/component-meta/TemplateSlots.stories.ts
@@ -11,8 +11,10 @@ export default meta;
 
 export const Default: Story = {
   args: {
-    default: ({ num }) => `Default slot { num=${num} }`,
-    named: ({ str }) => `Named slot { str=${str} }`,
-    vbind: ({ num, str }) => `Named v-bind slot { num=${num}, str=${str} }`,
+    $slots: {
+      default: ({ num }) => `Default slot { num=${num} }`,
+      named: ({ str }) => `Named slot { str=${str} }`,
+      vbind: ({ num, str }) => `Named v-bind slot { num=${num}, str=${str} }`,
+    },
   },
 };


### PR DESCRIPTION
## What I did

This is not working, and I'm not sure yet if it can work, but trying this out.

At some point we need to make sure that Vue slots are independent of docgen, as docgen is not avaialble for portable stories.

We also want to disable docgen for the --test build for extra performance.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
