### PR TITLE
Vue: Disable controls for events and exposed by default

### DIFF
--- a/code/renderers/vue3/src/docs/__snapshots__/extractArgTypes.test.ts.snap
+++ b/code/renderers/vue3/src/docs/__snapshots__/extractArgTypes.test.ts.snap
@@ -798,9 +798,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
 exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1`] = `
 {
   "default": {
-    "control": {
-      "disable": true,
-    },
     "description": undefined,
     "name": "default",
     "table": {
@@ -818,9 +815,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
     },
   },
   "named": {
-    "control": {
-      "disable": true,
-    },
     "description": undefined,
     "name": "named",
     "table": {
@@ -838,9 +832,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
     },
   },
   "no-bind": {
-    "control": {
-      "disable": true,
-    },
     "description": undefined,
     "name": "no-bind",
     "table": {
@@ -856,9 +847,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
     },
   },
   "vbind": {
-    "control": {
-      "disable": true,
-    },
     "description": undefined,
     "name": "vbind",
     "table": {
@@ -881,9 +869,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
 exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue component 1`] = `
 {
   "default": {
-    "control": {
-      "disable": true,
-    },
     "description": "",
     "name": "default",
     "table": {
@@ -898,9 +883,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
     },
   },
   "named": {
-    "control": {
-      "disable": true,
-    },
     "description": "",
     "name": "named",
     "table": {
@@ -915,9 +897,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
     },
   },
   "no-bind": {
-    "control": {
-      "disable": true,
-    },
     "description": "",
     "name": "no-bind",
     "table": {
@@ -932,9 +911,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
     },
   },
   "vbind": {
-    "control": {
-      "disable": true,
-    },
     "description": "",
     "name": "vbind",
     "table": {

--- a/code/renderers/vue3/src/docs/__snapshots__/extractArgTypes.test.ts.snap
+++ b/code/renderers/vue3/src/docs/__snapshots__/extractArgTypes.test.ts.snap
@@ -4,7 +4,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract events for Vue compon
 {
   "bar": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "",
     "name": "bar",
@@ -21,7 +21,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract events for Vue compon
   },
   "baz": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "",
     "name": "baz",
@@ -38,7 +38,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract events for Vue compon
   },
   "foo": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "",
     "name": "foo",
@@ -60,7 +60,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract events for component 
 {
   "bar": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "Test description bar",
     "name": "bar",
@@ -80,7 +80,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract events for component 
   },
   "baz": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "Test description baz",
     "name": "baz",
@@ -103,7 +103,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract expose for component 
 {
   "count": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "a count number",
     "name": "count",
@@ -120,7 +120,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract expose for component 
   },
   "label": {
     "control": {
-      "disabled": true,
+      "disable": true,
     },
     "description": "a label string",
     "name": "label",
@@ -141,9 +141,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract expose for component 
 exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1`] = `
 {
   "array": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description required array object",
     "name": "array",
@@ -170,9 +167,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "arrayOptional": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description optional array object",
     "name": "arrayOptional",
@@ -199,9 +193,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "bar": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": {
       "summary": "1",
     },
@@ -222,9 +213,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "baz": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description baz is required boolean",
     "name": "baz",
@@ -241,9 +229,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "enumValue": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description enum value",
     "name": "enumValue",
@@ -265,9 +250,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "foo": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "@default: "rounded"<br>@since: v1.0.0<br>@see: https://vuejs.org/<br>@deprecated: v1.1.0<br><br>string foo",
     "name": "foo",
@@ -284,9 +266,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "inlined": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "",
     "name": "inlined",
@@ -309,9 +288,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "literalFromContext": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description literal type alias that require context",
     "name": "literalFromContext",
@@ -336,9 +312,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "nested": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description nested is required nested object",
     "name": "nested",
@@ -361,9 +334,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "nestedIntersection": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description required nested object with intersection",
     "name": "nestedIntersection",
@@ -390,9 +360,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "nestedOptional": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description optional nested object",
     "name": "nestedOptional",
@@ -431,9 +398,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "recursive": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "",
     "name": "recursive",
@@ -457,9 +421,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "stringArray": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": {
       "summary": "["foo", "bar"]",
     },
@@ -484,9 +445,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "union": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description union is required union type",
     "name": "union",
@@ -513,9 +471,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
     },
   },
   "unionOptional": {
-    "control": {
-      "disabled": false,
-    },
     "defaultValue": undefined,
     "description": "description unionOptional is optional union type",
     "name": "unionOptional",
@@ -551,9 +506,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 1
 exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2`] = `
 {
   "array": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description required array object",
     "name": "array",
     "table": {
@@ -571,9 +523,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "arrayOptional": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description optional array object",
     "name": "arrayOptional",
     "table": {
@@ -591,9 +540,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "bar": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description bar is optional number",
     "name": "bar",
     "table": {
@@ -612,9 +558,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "baz": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description baz is required boolean",
     "name": "baz",
     "table": {
@@ -631,9 +574,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "enumValue": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description enum value",
     "name": "enumValue",
     "table": {
@@ -651,9 +591,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "foo": {
-    "control": {
-      "disabled": false,
-    },
     "description": "string foo",
     "name": "foo",
     "table": {
@@ -670,9 +607,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "inlined": {
-    "control": {
-      "disabled": false,
-    },
     "description": undefined,
     "name": "inlined",
     "table": {
@@ -690,9 +624,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "literalFromContext": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description literal type alias that require context",
     "name": "literalFromContext",
     "table": {
@@ -710,9 +641,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "nested": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description nested is required nested object",
     "name": "nested",
     "table": {
@@ -730,9 +658,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "nestedIntersection": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description required nested object with intersection",
     "name": "nestedIntersection",
     "table": {
@@ -755,9 +680,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "nestedOptional": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description optional nested object",
     "name": "nestedOptional",
     "table": {
@@ -784,9 +706,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "recursive": {
-    "control": {
-      "disabled": false,
-    },
     "description": undefined,
     "name": "recursive",
     "table": {
@@ -804,9 +723,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "stringArray": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description stringArray is string array",
     "name": "stringArray",
     "table": {
@@ -826,9 +742,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "union": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description union is required union type",
     "name": "union",
     "table": {
@@ -853,9 +766,6 @@ exports[`extractArgTypes (vue-docgen-api) > should extract props for component 2
     },
   },
   "unionOptional": {
-    "control": {
-      "disabled": false,
-    },
     "description": "description unionOptional is optional union type",
     "name": "unionOptional",
     "table": {
@@ -889,7 +799,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
 {
   "default": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": undefined,
     "name": "default",
@@ -909,7 +819,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
   },
   "named": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": undefined,
     "name": "named",
@@ -929,7 +839,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
   },
   "no-bind": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": undefined,
     "name": "no-bind",
@@ -947,7 +857,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots for component 1
   },
   "vbind": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": undefined,
     "name": "vbind",
@@ -972,7 +882,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
 {
   "default": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": "",
     "name": "default",
@@ -989,7 +899,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
   },
   "named": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": "",
     "name": "named",
@@ -1006,7 +916,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
   },
   "no-bind": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": "",
     "name": "no-bind",
@@ -1023,7 +933,7 @@ exports[`extractArgTypes (vue-docgen-api) > should extract slots type for Vue co
   },
   "vbind": {
     "control": {
-      "disabled": false,
+      "disable": true,
     },
     "description": "",
     "name": "vbind",

--- a/code/renderers/vue3/src/docs/extractArgTypes.ts
+++ b/code/renderers/vue3/src/docs/extractArgTypes.ts
@@ -44,7 +44,9 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
       // skip duplicate and global props
       if (!argType || argTypes[argType.name]) return;
 
-      if (section !== 'props') {
+      // disable controls for events and exposed since they can not be controlled
+      const sectionsToDisableControls: (typeof section)[] = ['events', 'expose', 'exposed'];
+      if (sectionsToDisableControls.includes(section)) {
         argType.control = { disable: true };
       }
 

--- a/code/renderers/vue3/src/docs/extractArgTypes.ts
+++ b/code/renderers/vue3/src/docs/extractArgTypes.ts
@@ -44,10 +44,11 @@ export const extractArgTypes: ArgTypesExtractor = (component) => {
       // skip duplicate and global props
       if (!argType || argTypes[argType.name]) return;
 
-      argTypes[argType.name] = {
-        ...argType,
-        control: { disabled: !['props', 'slots'].includes(section) },
-      };
+      if (section !== 'props') {
+        argType.control = { disable: true };
+      }
+
+      argTypes[argType.name] = argType;
     });
   });
 


### PR DESCRIPTION
## What I did

For events and exposes it does not really make sense to show controls since it is not used.
They will be disabled by default now.

The behaviour was already implemented but it didn't work due to a typo.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template vue3-vite/default-ts`
2. Set framework option `docgen` to `vue-component-meta` in `.storybook/main.ts` file
3. Open http://localhost:6006/?path=/docs/stories-renderers-vue3-vue3-vite-default-ts-component-meta-defineslots--docs

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
