### PR TITLE
Webpack: Set extensionAlias mapping to support TypeScript's automatic extension substitution

### DIFF
--- a/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
+++ b/code/builders/builder-webpack5/src/preview/iframe-webpack.config.ts
@@ -243,6 +243,13 @@ export default async (
     },
     resolve: {
       extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json', '.cjs'],
+      // This mapping is taken from TypeScript's file extension substitution logic
+      // for more info see https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution
+      extensionAlias: {
+        '.js': ['.ts', '.tsx', '.d.ts', '.js', '.jsx'],
+        '.mjs': ['.mts', '.d.mts', '.mjs'],
+        '.cjs': ['.cts', '.d.cts', '.cjs'],
+      },
       modules: ['node_modules'].concat(envs.NODE_PATH || []),
       mainFields: ['browser', 'module', 'main'].filter(Boolean),
       alias: storybookPaths,


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/15633

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have added a default list of `resolve.extensionAlias` to the Webpack5 builder to support TypeScript configurations, where relative imports use file extensions to satisfy ESM module relative import rules. I have taken the same extension substitution, which TypeScript also applies internally when trying to resolve a file with an extension that doesn't exist.

```tsx
// Button.stories.ts

// only Button.ts exists, but with `extensionAlias` set up, Webpack can resolve the path.
import { Button } from "./Button.js";

```

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1. Run a Webpack5 TypeScript sandbox
2. Change the following settings in the tsconfig.json:

```json
{
  ...
  "compilerOptions": {
    ...
    "moduleResolution": "NodeNext",
    "module": "NodeNext"
  }
}
```
3. Change the import in the story file to import the component via `.js` file extension. It has to be `js` instead of `ts`, because TypeScript doesn't transform import paths. TypeScript will instead substitute file extensions.

```tsx
// Button.stories.ts

// only Button.ts exists, but with `extensionAlias` set up, Webpack can resolve the path.
import { Button } from "./Button.js";

```

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
