### PR TITLE
Dependency: Upgrade execa and replace "execaCommand" method calls by "execa"

### DIFF
--- a/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.spec.ts
@@ -10,7 +10,7 @@ const mockRunScript = vi.fn();
 vi.mock('@storybook/core-common', () => ({
   JsPackageManagerFactory: {
     getPackageManager: () => ({
-      runPackageCommandSync: mockRunScript,
+      runPackageCommand: mockRunScript,
     }),
   },
 }));

--- a/code/frameworks/angular/src/builders/utils/run-compodoc.ts
+++ b/code/frameworks/angular/src/builders/utils/run-compodoc.ts
@@ -26,7 +26,7 @@ export const runCompodoc = async (
   const packageManager = JsPackageManagerFactory.getPackageManager();
 
   try {
-    const stdout = packageManager.runPackageCommandSync(
+    const stdout = await packageManager.runPackageCommand(
       'compodoc',
       finalCompodocArgs,
       context.workspaceRoot,

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -75,7 +75,7 @@
     "cross-spawn": "^7.0.3",
     "detect-indent": "^6.1.0",
     "envinfo": "^7.7.3",
-    "execa": "^5.0.0",
+    "execa": "^7.0.0",
     "find-up": "^5.0.0",
     "fs-extra": "^11.1.0",
     "get-npm-tarball-url": "^2.0.3",

--- a/code/lib/cli/src/initiate.ts
+++ b/code/lib/cli/src/initiate.ts
@@ -451,7 +451,7 @@ export async function initiate(options: CommandOptions): Promise<void> {
       // instead of calling 'dev' automatically, we spawn a subprocess so that it gets
       // executed directly in the user's project directory. This avoid potential issues
       // with packages running in npxs' node_modules
-      packageManager.runPackageCommandSync(
+      await packageManager.runPackageCommand(
         storybookCommand.replace(/^yarn /, ''),
         flags,
         undefined,

--- a/code/lib/cli/src/scaffold-new-project.ts
+++ b/code/lib/cli/src/scaffold-new-project.ts
@@ -1,6 +1,5 @@
 import boxen from 'boxen';
 import chalk from 'chalk';
-import execa from 'execa';
 import { readdirSync, remove } from 'fs-extra';
 import prompts from 'prompts';
 import dedent from 'ts-dedent';
@@ -179,9 +178,10 @@ export const scaffoldNewProject = async (
     await remove(`${targetDir}/.cache`);
 
     // Create new project in temp directory
-    await execa.command(createScript, {
+    const { execa } = await import('execa');
+    const [script, ...args] = createScript.split(' ');
+    await execa(script, args, {
       stdio: 'pipe',
-      shell: true,
       cwd: targetDir,
       cleanup: true,
     });

--- a/code/lib/core-common/package.json
+++ b/code/lib/core-common/package.json
@@ -54,7 +54,7 @@
     "cross-spawn": "^7.0.3",
     "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
     "esbuild-register": "^3.5.0",
-    "execa": "^5.0.0",
+    "execa": "^7.0.0",
     "file-system-cache": "2.3.0",
     "find-cache-dir": "^3.0.0",
     "find-up": "^5.0.0",

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -493,48 +493,8 @@ export abstract class JsPackageManager {
     cwd?: string,
     stdio?: string
   ): Promise<string>;
-  public abstract runPackageCommandSync(
-    command: string,
-    args: string[],
-    cwd?: string,
-    stdio?: 'inherit' | 'pipe'
-  ): string;
   public abstract findInstallations(pattern?: string[]): Promise<InstallationMetadata | undefined>;
   public abstract parseErrorFromLogs(logs?: string): string;
-
-  public executeCommandSync({
-    command,
-    args = [],
-    stdio,
-    cwd,
-    ignoreError = false,
-    env,
-    ...execaOptions
-  }: CommonOptions<string> & {
-    command: string;
-    args: string[];
-    cwd?: string;
-    ignoreError?: boolean;
-  }): string {
-    try {
-      const commandResult = execaCommandSync(command, args, {
-        cwd: cwd ?? this.cwd,
-        stdio: stdio ?? 'pipe',
-        encoding: 'utf-8',
-        shell: true,
-        cleanup: true,
-        env,
-        ...execaOptions,
-      });
-
-      return commandResult.stdout ?? '';
-    } catch (err) {
-      if (ignoreError !== true) {
-        throw err;
-      }
-      return '';
-    }
-  }
 
   /**
    * Returns the installed (within node_modules or pnp zip) version of a specified package

--- a/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
+++ b/code/lib/core-common/src/js-package-manager/JsPackageManager.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import { gt, satisfies } from 'semver';
 import type { CommonOptions } from 'execa';
-import { command as execaCommand, sync as execaCommandSync } from 'execa';
 import path from 'path';
 import fs from 'fs';
 
@@ -523,11 +522,11 @@ export abstract class JsPackageManager {
     ignoreError?: boolean;
   }): Promise<string> {
     try {
-      const commandResult = await execaCommand([command, ...args].join(' '), {
+      const { execa } = await import('execa');
+      const commandResult = await execa(command, args, {
         cwd: cwd ?? this.cwd,
         stdio: stdio ?? 'pipe',
         encoding: 'utf-8',
-        shell: true,
         cleanup: true,
         env,
         ...execaOptions,

--- a/code/lib/core-common/src/js-package-manager/NPMProxy.ts
+++ b/code/lib/core-common/src/js-package-manager/NPMProxy.ts
@@ -108,20 +108,6 @@ export class NPMProxy extends JsPackageManager {
     return this.installArgs;
   }
 
-  public runPackageCommandSync(
-    command: string,
-    args: string[],
-    cwd?: string,
-    stdio?: 'pipe' | 'inherit'
-  ): string {
-    return this.executeCommandSync({
-      command: 'npm',
-      args: ['exec', '--', command, ...args],
-      cwd,
-      stdio,
-    });
-  }
-
   public async runPackageCommand(command: string, args: string[], cwd?: string): Promise<string> {
     return this.executeCommand({
       command: 'npm',

--- a/code/lib/core-common/src/js-package-manager/PNPMProxy.ts
+++ b/code/lib/core-common/src/js-package-manager/PNPMProxy.ts
@@ -74,20 +74,6 @@ export class PNPMProxy extends JsPackageManager {
     return this.installArgs;
   }
 
-  public runPackageCommandSync(
-    command: string,
-    args: string[],
-    cwd?: string,
-    stdio?: 'pipe' | 'inherit'
-  ): string {
-    return this.executeCommandSync({
-      command: 'pnpm',
-      args: ['exec', command, ...args],
-      cwd,
-      stdio,
-    });
-  }
-
   async runPackageCommand(command: string, args: string[], cwd?: string): Promise<string> {
     return this.executeCommand({
       command: 'pnpm',

--- a/code/lib/core-common/src/js-package-manager/Yarn1Proxy.ts
+++ b/code/lib/core-common/src/js-package-manager/Yarn1Proxy.ts
@@ -49,15 +49,6 @@ export class Yarn1Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  public runPackageCommandSync(
-    command: string,
-    args: string[],
-    cwd?: string,
-    stdio?: 'pipe' | 'inherit'
-  ): string {
-    return this.executeCommandSync({ command: `yarn`, args: [command, ...args], cwd, stdio });
-  }
-
   async runPackageCommand(command: string, args: string[], cwd?: string): Promise<string> {
     return this.executeCommand({ command: `yarn`, args: [command, ...args], cwd });
   }

--- a/code/lib/core-common/src/js-package-manager/Yarn2Proxy.ts
+++ b/code/lib/core-common/src/js-package-manager/Yarn2Proxy.ts
@@ -106,15 +106,6 @@ export class Yarn2Proxy extends JsPackageManager {
     return `yarn ${command}`;
   }
 
-  public runPackageCommandSync(
-    command: string,
-    args: string[],
-    cwd?: string,
-    stdio?: 'pipe' | 'inherit'
-  ) {
-    return this.executeCommandSync({ command: 'yarn', args: [command, ...args], cwd, stdio });
-  }
-
   async runPackageCommand(command: string, args: string[], cwd?: string) {
     return this.executeCommand({ command: 'yarn', args: [command, ...args], cwd });
   }

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5779,7 +5779,7 @@ __metadata:
     cross-spawn: "npm:^7.0.3"
     detect-indent: "npm:^6.1.0"
     envinfo: "npm:^7.7.3"
-    execa: "npm:^5.0.0"
+    execa: "npm:^7.0.0"
     find-up: "npm:^5.0.0"
     fs-extra: "npm:^11.1.0"
     get-npm-tarball-url: "npm:^2.0.3"
@@ -5905,7 +5905,7 @@ __metadata:
     cross-spawn: "npm:^7.0.3"
     esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0"
     esbuild-register: "npm:^3.5.0"
-    execa: "npm:^5.0.0"
+    execa: "npm:^7.0.0"
     file-system-cache: "npm:2.3.0"
     find-cache-dir: "npm:^3.0.0"
     find-up: "npm:^5.0.0"
@@ -14940,7 +14940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:7.2.0":
+"execa@npm:7.2.0, execa@npm:^7.0.0":
   version: 7.2.0
   resolution: "execa@npm:7.2.0"
   dependencies:


### PR DESCRIPTION
Closes N/A

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have upgraded execa and I have replaced `execaCommand` calls by `execa` as recommended [here](https://github.com/storybookjs/storybook/issues/26553#issuecomment-2083829631). Since `execa` is now a ESM only package, I have to dynamically import execa to import it in CJS and ESM environments appropriately.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-27359-sha-2d459478`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-27359-sha-2d459478 sandbox` or in an existing project with `npx storybook@0.0.0-pr-27359-sha-2d459478 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-27359-sha-2d459478`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-27359-sha-2d459478) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/upgrade-execa`](https://github.com/storybookjs/storybook/tree/valentin/upgrade-execa) |
| **Commit** | [`2d459478`](https://github.com/storybookjs/storybook/commit/2d45947833fc7c602187777c875661f143f5e823) |
| **Datetime** | Fri May 24 12:55:48 UTC 2024 (`1716555348`) |
| **Workflow run** | [9224294073](https://github.com/storybookjs/storybook/actions/runs/9224294073) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=27359`_
</details>
<!-- CANARY_RELEASE_SECTION -->
