### PR TITLE
CPC: Add blocker in CLI checking core package

### DIFF
--- a/code/lib/cli/bin/index.js
+++ b/code/lib/cli/bin/index.js
@@ -23,4 +23,17 @@ process.once('uncaughtException', (error) => {
   throw error;
 });
 
-require('../dist/generate.js');
+const { check } = require('../dist/check.js');
+
+check().then(
+  (result) => {
+    if (!result) {
+      process.exit(1);
+    }
+    require('../dist/generate.js');
+  },
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  }
+);

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -104,6 +104,7 @@
   },
   "bundler": {
     "entries": [
+      "./src/check.ts",
       "./src/generate.ts",
       "./src/index.ts"
     ],

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -27,8 +27,8 @@ function tryFindCore() {
       return true;
     }
 
-    const TopLevelNodeModulesPath = found.split('node_modules')[0];
-    const projectPackageJsonPath = findUp.sync('package.json', { cwd: TopLevelNodeModulesPath });
+    const topLevelNodeModulesPath = found.split('node_modules')[0];
+    const projectPackageJsonPath = findUp.sync('package.json', { cwd: topLevelNodeModulesPath });
 
     if (!projectPackageJsonPath) {
       // Unknown how this could happen.. a users uses our package, and has `node_modules` in the path, but no `package.json`?

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -90,7 +90,7 @@ export async function check() {
     return false;
   }
 
-  await execa('npx', [`storybook@${packageJson.version}`, 'automigrate'], { stdio: 'inherit' });
+  await execa('npx', [`sb@${packageJson.version}`, 'automigrate'], { stdio: 'inherit' });
 
   console.log(dedent`
     Success! The migration has been completed. Please commit the changes to your project.

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import prompts from 'prompts';
 import findUp from 'find-up';
+import { tmpdir } from 'node:os';
 import { dedent } from 'ts-dedent';
 import execa from 'execa';
 import { readJSON, readJsonSync } from 'fs-extra';
@@ -28,6 +29,7 @@ function tryFindCore() {
     }
 
     console.log('debugging: ', __dirname);
+    console.log(tmpdir());
 
     const topLevelNodeModulesPath = found.split('node_modules')[0];
     const projectPackageJsonPath = findUp.sync('package.json', { cwd: topLevelNodeModulesPath });
@@ -52,6 +54,8 @@ function tryFindCore() {
 
     return false;
   } catch (e) {
+    console.log('debugging: ', __dirname);
+    console.log(tmpdir());
     return false;
   }
 }

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -26,6 +26,7 @@ function tryFindCore() {
     const projectPackageJsonPath = findUp.sync('package.json', { cwd: TopLevelNodeModulesPath });
 
     if (!projectPackageJsonPath) {
+      // Unknown how this could happen.. a users uses our package, and has `node_modules` in the path, but no `package.json`?
       return false;
     }
 

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -103,6 +103,9 @@ export async function check() {
 
   await execa('npx', [`-p`, `sb@${packageJson.version}`, 'sb', 'automigrate'], {
     stdio: 'inherit',
+    env: {
+      CI: 'true',
+    },
   });
 
   console.log(dedent`

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -1,0 +1,68 @@
+import prompts from 'prompts';
+import { dedent } from 'ts-dedent';
+import execa from 'execa';
+
+function tryFindCore() {
+  try {
+    return require.resolve('@storybook/core');
+  } catch (e) {
+    return false;
+  }
+}
+
+async function maybePrompt() {
+  if (process.env.CI) {
+    return false;
+  }
+
+  const { runMigration } = await prompts({
+    type: 'confirm',
+    initial: true,
+    name: 'runMigration',
+    message: dedent`
+      We detected you have not installed storybook core. Did you upgrade storybook recently without running the upgrade command?
+
+      At the very least we need to have the @storybook/core package installed in the project.
+      We recommend running the following command to upgrade storybook:
+      > npx storybook@latest upgrade
+
+      If that is for some reason not an option for you, follow this guide:
+      https://storybook.js.org/docs/react/workflows/migrating-to-8-2/
+
+      Would you want to run the migration now?
+      (answering no will exit the process)
+    `,
+  });
+
+  return runMigration;
+}
+
+export async function check() {
+  const core = tryFindCore();
+
+  if (core) {
+    return true;
+  }
+
+  const shouldRunMigration = await maybePrompt();
+
+  if (!shouldRunMigration) {
+    console.log(dedent`
+      You opted not to run the automatic migration. Please install @storybook/core manually.
+      
+      To understand this change, and why it was needed, read this guide:
+      https://storybook.js.org/docs/react/workflows/migrating-to-8-2/
+    `);
+    return false;
+  }
+
+  await execa('npx', ['storybook@latest', 'upgrade'], { stdio: 'inherit' });
+
+  console.log(dedent`
+    Success! The migration has been completed. Please commit the changes to your project.
+    
+    Then run the command again.
+  `);
+
+  return false;
+}

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -1,6 +1,8 @@
+import { join } from 'node:path';
 import prompts from 'prompts';
 import { dedent } from 'ts-dedent';
 import execa from 'execa';
+import { readJSON } from 'fs-extra';
 
 function tryFindCore() {
   try {
@@ -38,6 +40,8 @@ async function maybePrompt() {
 }
 
 export async function check() {
+  const packageJson = await readJSON(join(__dirname, '..', 'package.json'));
+
   const core = tryFindCore();
 
   if (core) {
@@ -56,7 +60,7 @@ export async function check() {
     return false;
   }
 
-  await execa('npx', ['storybook@latest', 'upgrade'], { stdio: 'inherit' });
+  await execa('npx', [`storybook@${packageJson.version}`, 'automigrate'], { stdio: 'inherit' });
 
   console.log(dedent`
     Success! The migration has been completed. Please commit the changes to your project.

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -101,12 +101,19 @@ export async function check() {
     return false;
   }
 
-  await execa('npx', [`-p`, `sb@${packageJson.version}`, 'sb', 'automigrate'], {
-    stdio: 'inherit',
-    env: {
-      CI: 'true',
-    },
-  });
+  try {
+    await execa('npx', [`-p`, `sb@${packageJson.version}`, 'sb', 'automigrate'], {
+      stdio: 'inherit',
+      env: {
+        CI: 'true',
+      },
+    });
+  } catch (e) {
+    console.log(dedent`
+      The migration has failed. Please install @storybook/core manually.
+    `);
+    return false;
+  }
 
   console.log(dedent`
     Success! The migration has been completed. Please commit the changes to your project.

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -37,11 +37,17 @@ function tryFindCore() {
 
     const projectPackageJsonContents = readJsonSync(projectPackageJsonPath);
 
-    return (
-      projectPackageJsonContents.dependencies['@storybook/core'] ||
-      projectPackageJsonContents.devDependencies['@storybook/core'] ||
-      projectPackageJsonContents.peerDependencies['@storybook/core']
-    );
+    const all = [
+      ...Object.keys(projectPackageJsonContents?.devDependencies || {}),
+      ...Object.keys(projectPackageJsonContents?.dependencies || {}),
+      ...Object.keys(projectPackageJsonContents?.peerDependencies || {}),
+    ];
+
+    if (all.includes('@storybook/core')) {
+      return true;
+    }
+
+    return false;
   } catch (e) {
     return false;
   }

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -90,7 +90,9 @@ export async function check() {
     return false;
   }
 
-  await execa('npx', [`sb@${packageJson.version}`, 'automigrate'], { stdio: 'inherit' });
+  await execa('npx', [`-p`, `sb@${packageJson.version}`, 'sb', 'automigrate'], {
+    stdio: 'inherit',
+  });
 
   console.log(dedent`
     Success! The migration has been completed. Please commit the changes to your project.

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -27,6 +27,8 @@ function tryFindCore() {
       return true;
     }
 
+    console.log('debugging: ', __dirname);
+
     const topLevelNodeModulesPath = found.split('node_modules')[0];
     const projectPackageJsonPath = findUp.sync('package.json', { cwd: topLevelNodeModulesPath });
 

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -31,8 +31,9 @@ function tryFindCore() {
     const projectPackageJsonPath = findUp.sync('package.json', { cwd: topLevelNodeModulesPath });
 
     if (!projectPackageJsonPath) {
-      // Unknown how this could happen.. a users uses our package, and has `node_modules` in the path, but no `package.json`?
-      return false;
+      // We found the core package, but we couldn't find the project's package.json.
+      // This is the case when the user uses yarn dlx
+      return true;
     }
 
     const projectPackageJsonContents = readJsonSync(projectPackageJsonPath);

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -17,19 +17,19 @@ function tryFindCore() {
   try {
     const found = require.resolve('@storybook/core');
 
+    console.log('debugging: ', __dirname);
+    console.log(tmpdir());
+
     if (!found.includes('node_modules')) {
       // We're either in PNP-mode or linked-mode.
       // We were able to find the core package, so let's hope for the best.
       return true;
     }
 
-    if (found.includes('npx')) {
-      // We're in npx-mode. Good to proceed.
+    if (found.includes('npx') || found.includes('pnpm/dlx')) {
+      // We're in npx-mode | pnpm-dlx. Good to proceed.
       return true;
     }
-
-    console.log('debugging: ', __dirname);
-    console.log(tmpdir());
 
     const topLevelNodeModulesPath = found.split('node_modules')[0];
     const projectPackageJsonPath = findUp.sync('package.json', { cwd: topLevelNodeModulesPath });

--- a/code/lib/cli/src/check.ts
+++ b/code/lib/cli/src/check.ts
@@ -17,8 +17,13 @@ function tryFindCore() {
     const found = require.resolve('@storybook/core');
 
     if (!found.includes('node_modules')) {
-      // We're either in PNP-mode, linked-mode or in npx-mode. There's nothing left to check...
+      // We're either in PNP-mode or linked-mode.
       // We were able to find the core package, so let's hope for the best.
+      return true;
+    }
+
+    if (found.includes('npx')) {
+      // We're in npx-mode. Good to proceed.
       return true;
     }
 


### PR DESCRIPTION
## What I did

- add a block before running the CLI, checking if the @storybook/core dependency is satisfied/can be found. 
- If not ask the user to run the migrate command or install the core package manually.

The URL to the docs page, needs to be determined, and corrected

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

- Use yarn
- Take a pre-8.2 sandbox, and upgrade it manually, WITHOUT running the upgrade command.
- Try to run storybook (dev or build).
- You should see a inquiry from the CLI explaining the situation, and asking you if it should run the migrate command.
- Answering yes,, should run the migrate command.
- Answering no, should cancel the command, and tell you to upgrade manually.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-28288-sha-f4b255c5`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-28288-sha-f4b255c5 sandbox` or in an existing project with `npx storybook@0.0.0-pr-28288-sha-f4b255c5 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-28288-sha-f4b255c5`](https://npmjs.com/package/@storybook/cli/v/0.0.0-pr-28288-sha-f4b255c5) |
| **Triggered by** | @ndelangen |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`norbert/cpc-start-blocker`](https://github.com/storybookjs/storybook/tree/norbert/cpc-start-blocker) |
| **Commit** | [`f4b255c5`](https://github.com/storybookjs/storybook/commit/f4b255c51218f1f1484f2dec27e0288e326757a7) |
| **Datetime** | Fri Jun 21 11:20:12 UTC 2024 (`1718968812`) |
| **Workflow run** | [9612798313](https://github.com/storybookjs/storybook/actions/runs/9612798313) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=28288`_
</details>
<!-- CANARY_RELEASE_SECTION -->
