### PR TITLE
Svelte: Support default slot via `children` arg

### DIFF
--- a/code/renderers/svelte/src/__test__/composeStories/__snapshots__/portable-stories.test.ts.snap
+++ b/code/renderers/svelte/src/__test__/composeStories/__snapshots__/portable-stories.test.ts.snap
@@ -14,6 +14,7 @@ exports[`Renders CSF2Secondary story 1`] = `
     <!---->
     <!---->
     <!---->
+    <!---->
     
   </div>
 </body>
@@ -36,7 +37,9 @@ exports[`Renders CSF2StoryWithParamsAndDecorator story 1`] = `
       </button>
       <!---->
       <!---->
+      <!---->
     </div>
+    <!---->
     <!---->
     <!---->
     <!---->
@@ -58,6 +61,7 @@ exports[`Renders CSF3Button story 1`] = `
       foo 
       <!---->
     </button>
+    <!---->
     <!---->
     <!---->
     <!---->
@@ -89,6 +93,7 @@ exports[`Renders CSF3ButtonWithRender story 1`] = `
     <!---->
     <!---->
     <!---->
+    <!---->
     
   </div>
 </body>
@@ -102,6 +107,7 @@ exports[`Renders CSF3InputFieldFilled story 1`] = `
       formaction="http://localhost:3000/"
       formmethod=""
     />
+    <!---->
     <!---->
     <!---->
     <!---->
@@ -121,6 +127,7 @@ exports[`Renders CSF3Primary story 1`] = `
       foo 
       <!---->
     </button>
+    <!---->
     <!---->
     <!---->
     <!---->
@@ -148,6 +155,7 @@ exports[`Renders LoaderStory story 1`] = `
     <!---->
     <!---->
     <!---->
+    <!---->
     
   </div>
 </body>
@@ -170,7 +178,9 @@ exports[`Renders NewStory story 1`] = `
       </button>
       <!---->
       <!---->
+      <!---->
     </div>
+    <!---->
     <!---->
     <!---->
     <!---->

--- a/code/renderers/svelte/src/components/PreviewRender.svelte
+++ b/code/renderers/svelte/src/components/PreviewRender.svelte
@@ -15,8 +15,9 @@
     props = {},
     /** @type {{[string]: () => {}}} Attach svelte event handlers */
     on,
-    /** @type {any} whether this level of the decorator chain is the last, ie. the actual story */
     argTypes,
+    /** @type {boolean} whether this level of the decorator chain is the last, ie. the actual story */
+    isOriginalStory,
   } = storyFn();
 
   let firstTime = true;
@@ -32,13 +33,14 @@
         props,
         on,
         argTypes,
+        isOriginalStory,
       };
     }
     return storyFn();
   }
 
   // reactive, re-render on storyFn change
-  $: ({ Component, props = {}, on, argTypes } = getStoryFnValue(storyFn));
+  $: ({ Component, props = {}, on, argTypes, isOriginalStory } = getStoryFnValue(storyFn));
 
   // set the argTypes context, read by the last SlotDecorator that renders the original story
   if (!Component) {
@@ -53,4 +55,4 @@
   }
 </script>
 
-<SlotDecorator {Component} {props} {on} {argTypes} />
+<SlotDecorator {Component} {props} {on} {argTypes} {isOriginalStory} />

--- a/code/renderers/svelte/src/components/SlotDecorator.svelte
+++ b/code/renderers/svelte/src/components/SlotDecorator.svelte
@@ -14,6 +14,7 @@
 
   const IS_SVELTE_V4 = Number(SVELTE_VERSION[0]) <= 4;
 
+  const CHILDREN_ARG_AS_HTML = globalThis.FRAMEWORK_OPTIONS?.childrenArgAsHtml ?? false;
   /*
     Svelte Docgen will create argTypes for events with the name 'event_eventName'
     The Actions addon will convert these to args because they are type: 'action'
@@ -22,7 +23,15 @@
   */
   let filteredProps;
   $: filteredProps = Object.fromEntries(
-    Object.entries(props).filter(([key]) => key !== 'children' && !key.startsWith('event_'))
+    Object.entries(props).filter(([key]) => {
+      if (key.startsWith('event_')) {
+        return false;
+      }
+      if (key === 'children' && CHILDREN_ARG_AS_HTML) {
+        return false;
+      }
+      return true;
+    })
   );
 
   if (isOriginalStory && argTypes && IS_SVELTE_V4) {
@@ -45,7 +54,7 @@
 
 {#if decorator}
   <svelte:component this={decorator.Component} {...decorator.props} bind:this={decoratorInstance}>
-    {#if isOriginalStory && props.children}
+    {#if CHILDREN_ARG_AS_HTML && isOriginalStory && props.children}
       <svelte:component this={Component} {...filteredProps} bind:this={instance}>
         {@html props.children}
       </svelte:component>
@@ -53,7 +62,7 @@
       <svelte:component this={Component} {...filteredProps} bind:this={instance} />
     {/if}
   </svelte:component>
-{:else if isOriginalStory && props.children}
+{:else if CHILDREN_ARG_AS_HTML && isOriginalStory && props.children}
   <svelte:component this={Component} {...filteredProps} bind:this={instance}>
     {@html props.children}
   </svelte:component>

--- a/code/renderers/svelte/src/components/SlotDecorator.svelte
+++ b/code/renderers/svelte/src/components/SlotDecorator.svelte
@@ -14,7 +14,8 @@
 
   const IS_SVELTE_V4 = Number(SVELTE_VERSION[0]) <= 4;
 
-  const CHILDREN_ARG_AS_HTML = globalThis.FRAMEWORK_OPTIONS?.childrenArgAsHtml ?? false;
+  const CHILDREN_ARG_AS_DEFAULT_SLOT =
+    globalThis.FRAMEWORK_OPTIONS?.childrenArgAsDefaultSlot ?? false;
   /*
     Svelte Docgen will create argTypes for events with the name 'event_eventName'
     The Actions addon will convert these to args because they are type: 'action'
@@ -27,7 +28,7 @@
       if (key.startsWith('event_')) {
         return false;
       }
-      if (key === 'children' && CHILDREN_ARG_AS_HTML) {
+      if (key === 'children' && CHILDREN_ARG_AS_DEFAULT_SLOT) {
         return false;
       }
       return true;
@@ -54,17 +55,25 @@
 
 {#if decorator}
   <svelte:component this={decorator.Component} {...decorator.props} bind:this={decoratorInstance}>
-    {#if CHILDREN_ARG_AS_HTML && isOriginalStory && props.children}
+    {#if CHILDREN_ARG_AS_DEFAULT_SLOT && isOriginalStory && props.children}
       <svelte:component this={Component} {...filteredProps} bind:this={instance}>
-        {@html props.children}
+        {#if props.children.Component}
+          <svelte:component this={props.children.Component} {...props.children.props} />
+        {:else}
+          {@html props.children}
+        {/if}
       </svelte:component>
     {:else}
       <svelte:component this={Component} {...filteredProps} bind:this={instance} />
     {/if}
   </svelte:component>
-{:else if CHILDREN_ARG_AS_HTML && isOriginalStory && props.children}
+{:else if CHILDREN_ARG_AS_DEFAULT_SLOT && isOriginalStory && props.children}
   <svelte:component this={Component} {...filteredProps} bind:this={instance}>
-    {@html props.children}
+    {#if props.children.Component}
+      <svelte:component this={props.children.Component} {...props.children.props} />
+    {:else}
+      {@html props.children}
+    {/if}
   </svelte:component>
 {:else}
   <svelte:component this={Component} {...filteredProps} bind:this={instance} />

--- a/code/renderers/svelte/src/components/SlotDecorator.svelte
+++ b/code/renderers/svelte/src/components/SlotDecorator.svelte
@@ -7,6 +7,7 @@
   export let props = {};
   export let on = undefined;
   export let argTypes = undefined;
+  export let isOriginalStory = false;
 
   let instance;
   let decoratorInstance;
@@ -17,13 +18,14 @@
     Svelte Docgen will create argTypes for events with the name 'event_eventName'
     The Actions addon will convert these to args because they are type: 'action'
     We need to filter these args out so they are not passed to the component
+    We also need to filter out the 'children' prop because we render it as the default slot instead
   */
-  let propsWithoutDocgenEvents;
-  $: propsWithoutDocgenEvents = Object.fromEntries(
-    Object.entries(props).filter(([key]) => !key.startsWith('event_'))
+  let filteredProps;
+  $: filteredProps = Object.fromEntries(
+    Object.entries(props).filter(([key]) => key !== 'children' && !key.startsWith('event_'))
   );
 
-  if (argTypes && IS_SVELTE_V4) {
+  if (isOriginalStory && argTypes && IS_SVELTE_V4) {
     const eventsFromArgTypes = Object.fromEntries(
       Object.entries(argTypes)
         .filter(([key, value]) => value.action && props[key] != null)
@@ -43,8 +45,18 @@
 
 {#if decorator}
   <svelte:component this={decorator.Component} {...decorator.props} bind:this={decoratorInstance}>
-    <svelte:component this={Component} {...propsWithoutDocgenEvents} bind:this={instance} />
+    {#if isOriginalStory && props.children}
+      <svelte:component this={Component} {...filteredProps} bind:this={instance}>
+        {@html props.children}
+      </svelte:component>
+    {:else}
+      <svelte:component this={Component} {...filteredProps} bind:this={instance} />
+    {/if}
+  </svelte:component>
+{:else if isOriginalStory && props.children}
+  <svelte:component this={Component} {...filteredProps} bind:this={instance}>
+    {@html props.children}
   </svelte:component>
 {:else}
-  <svelte:component this={Component} {...propsWithoutDocgenEvents} bind:this={instance} />
+  <svelte:component this={Component} {...filteredProps} bind:this={instance} />
 {/if}

--- a/code/renderers/svelte/src/decorators.ts
+++ b/code/renderers/svelte/src/decorators.ts
@@ -70,7 +70,7 @@ function prepareStory(
   }
 
   // no innerStory means this is the last story in the decorator chain, so it should create events from argTypes
-  return { ...preparedStory, argTypes: context.argTypes };
+  return { ...preparedStory, argTypes: context.argTypes, isOriginalStory: true };
 }
 
 export function decorateStory(storyFn: any, decorators: any[]) {

--- a/code/renderers/svelte/template/stories/children-arg-as-slot.stories.js
+++ b/code/renderers/svelte/template/stories/children-arg-as-slot.stories.js
@@ -1,8 +1,18 @@
 import ComponentWithSlot from './views/ComponentWithSlot.svelte';
 import BorderDecoratorBlue from './views/BorderDecoratorBlue.svelte';
 
+const initialFrameworkOptions = structuredClone(globalThis.FRAMEWORK_OPTIONS);
 export default {
   component: ComponentWithSlot,
+  beforeEach: () => {
+    globalThis.FRAMEWORK_OPTIONS = {
+      ...globalThis.FRAMEWORK_OPTIONS,
+      childrenArgAsHtml: true,
+    };
+    return () => {
+      globalThis.FRAMEWORK_OPTIONS = initialFrameworkOptions;
+    };
+  },
 };
 
 export const NoChildren = {};
@@ -35,5 +45,20 @@ export const WithDecorator = {
   decorators: [() => BorderDecoratorBlue],
   args: {
     children: `This is a plain string with a decorator`,
+  },
+};
+
+export const FrameworkOptionDisabled = {
+  beforeEach: () => {
+    globalThis.FRAMEWORK_OPTIONS = {
+      ...globalThis.FRAMEWORK_OPTIONS,
+      childrenArgAsHtml: false,
+    };
+    return () => {
+      globalThis.FRAMEWORK_OPTIONS = initialFrameworkOptions;
+    };
+  },
+  args: {
+    children: `This is just a regular children prop`,
   },
 };

--- a/code/renderers/svelte/template/stories/children-arg-as-slot.stories.js
+++ b/code/renderers/svelte/template/stories/children-arg-as-slot.stories.js
@@ -7,7 +7,7 @@ export default {
   beforeEach: () => {
     globalThis.FRAMEWORK_OPTIONS = {
       ...globalThis.FRAMEWORK_OPTIONS,
-      childrenArgAsHtml: true,
+      childrenArgAsDefaultSlot: true,
     };
     return () => {
       globalThis.FRAMEWORK_OPTIONS = initialFrameworkOptions;
@@ -41,6 +41,23 @@ export const Number = {
     children: 1,
   },
 };
+export const ComponentWithoutProps = {
+  args: {
+    children: {
+      Component: globalThis.Components.Button,
+    },
+  },
+};
+export const ComponentWithProps = {
+  args: {
+    children: {
+      Component: globalThis.Components.Button,
+      props: {
+        label: 'Button label',
+      },
+    },
+  },
+};
 export const WithDecorator = {
   decorators: [() => BorderDecoratorBlue],
   args: {
@@ -52,7 +69,7 @@ export const FrameworkOptionDisabled = {
   beforeEach: () => {
     globalThis.FRAMEWORK_OPTIONS = {
       ...globalThis.FRAMEWORK_OPTIONS,
-      childrenArgAsHtml: false,
+      childrenArgAsDefaultSlot: false,
     };
     return () => {
       globalThis.FRAMEWORK_OPTIONS = initialFrameworkOptions;

--- a/code/renderers/svelte/template/stories/children-arg-as-slot.stories.js
+++ b/code/renderers/svelte/template/stories/children-arg-as-slot.stories.js
@@ -1,0 +1,39 @@
+import ComponentWithSlot from './views/ComponentWithSlot.svelte';
+import BorderDecoratorBlue from './views/BorderDecoratorBlue.svelte';
+
+export default {
+  component: ComponentWithSlot,
+};
+
+export const NoChildren = {};
+export const PlainString = {
+  args: {
+    children: 'This is a plain string',
+  },
+};
+export const HTMLString = {
+  args: {
+    children: `
+      <p>
+        This is an HTML string with <i>italic</i>,
+        <b>
+          bold,
+        </b>
+        <code>
+          some code
+        </code>
+      </p>
+      <p>... and a second paragraph</p>`,
+  },
+};
+export const Number = {
+  args: {
+    children: 1,
+  },
+};
+export const WithDecorator = {
+  decorators: [() => BorderDecoratorBlue],
+  args: {
+    children: `This is a plain string with a decorator`,
+  },
+};

--- a/code/renderers/svelte/template/stories/views/ComponentWithSlot.svelte
+++ b/code/renderers/svelte/template/stories/views/ComponentWithSlot.svelte
@@ -1,0 +1,4 @@
+<div style="border: 3px solid red; padding: 10px;">
+  <h1>The content below is the default slot:</h1>
+  <slot />
+</div>

--- a/code/renderers/svelte/template/stories/views/ComponentWithSlot.svelte
+++ b/code/renderers/svelte/template/stories/views/ComponentWithSlot.svelte
@@ -1,4 +1,10 @@
+<script>
+  export let children = undefined;
+</script>
+
 <div style="border: 3px solid red; padding: 10px;">
-  <h1>The content below is the default slot:</h1>
+  <h3>The content below is the default slot:</h3>
   <slot />
+  <h3>The content below is the <code>children</code> prop:</h3>
+  {children}
 </div>


### PR DESCRIPTION
Telescopes on top of #28247
<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds support for default slots in Svelte via the `children` arg. When enabled, it will convert the `children` arg to the default slot instead of a regular prop. `children` can be:

- A plain string or truthy value
- An HTML string
- A Svelte component+props via `children: { Component: TheComponent, props: theProps }`.

See the added stories for the different use cases.

This is technically a breaking change because users could be using the `children` arg for something else. Therefore it must be enabled with a framework option like below. The idea is to turn this on by default in the next major version, as the breaking change.

```js
// main.js

export default {
  ...,
  framework: {
    name: '@storybook/svelte-vite',
    options: {
      childrenArgAsDefaultSlot: true
    }
  }
}
```

I've tested this in Svelte 5 with the new syntax. With the feature disabled, the rendering will crash if a `children` arg is provided. With it enabled, it will work as expected.

None of this impacts usage in Svelte CSF which uses a separate data flow to handle args and components (also tested).

**Open questions**
1. Should the feature be enabled via parameters instead of a framework option? this would allow users to enable it per story.
2. This needs to be documented as it's one of the most asked questions about Svelte. Where would this fit in however? @kylegach 
3. Is the HTML support safe? we intentionally do not escape HTML to support it, but could this be a security issues, users injecting unsafe JS via args? It seems like the args in the URL already handles this as a warning is shown in the console pointing here, https://storybook.js.org/docs/writing-stories/args#setting-args-through-the-url
4. Should we name the arg something else than `children`? We've talked about `$children` before. Using an exotic name like that could mean that this wouldn't be a breaking change, and the feature flag would become unnecessary. `children` is established by Svelte 5 as the default snippet, which is why it seems nice to use that name directly.

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

See the new stories.


<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
4. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
