### PR TITLE
Upgrade: Install/Add Storybook dependencies the default way

### DIFF
--- a/code/lib/cli/src/upgrade.ts
+++ b/code/lib/cli/src/upgrade.ts
@@ -229,18 +229,7 @@ export const doUpgrade = async ({
         // only upgrade packages that are in the monorepo
         return dependency in versions;
       }) as Array<keyof typeof versions>;
-      return monorepoDependencies.map((dependency) => {
-        let char = '^';
-        if (isCLIOutdated) {
-          char = '';
-        }
-        if (isCanary) {
-          char = '';
-        }
-        /* add ^ modifier to the version if this is the latest stable or prerelease version
-           example outputs: @storybook/react@^8.0.0 */
-        return `${dependency}@${char}${versions[dependency]}`;
-      });
+      return monorepoDependencies.map((dependency) => `${dependency}@${versions[dependency]}`);
     };
 
     const upgradedDependencies = toUpgradedDependencies(packageJson.dependencies);
@@ -249,17 +238,16 @@ export const doUpgrade = async ({
     logger.info(`Updating dependencies in ${chalk.cyan('package.json')}..`);
     if (upgradedDependencies.length > 0) {
       await packageManager.addDependencies(
-        { installAsDevDependencies: false, skipInstall: true, packageJson },
+        { installAsDevDependencies: false, packageJson },
         upgradedDependencies
       );
     }
     if (upgradedDevDependencies.length > 0) {
       await packageManager.addDependencies(
-        { installAsDevDependencies: true, skipInstall: true, packageJson },
+        { installAsDevDependencies: true, packageJson },
         upgradedDevDependencies
       );
     }
-    await packageManager.installDependencies();
   }
 
   // AUTOMIGRATIONS


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28569

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

With this change we are respecting the user's setting related to how dependencies should be saved to the package.json. The default behaviour is adding a caret to dependencies when added to the package.json. People can override this behaviour by defining them in, for example, a `save-exact=true` setting in their .npmrc file.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | % |
| ---- | ------ | ----- | ---- | - |
| createTime |  23.2s | 7.1s | -16s -166ms | 🔰-227.3% |
| generateTime |  22.8s | 24.8s | 1.9s | 🔺7.8% |
| initTime |  23.9s | 25.6s | 1.6s | 🔺6.5% |
| createSize |  0 B | 0 B | 0 B | - |
| generateSize |  76.5 MB | 76.5 MB | 0 B | 0% |
| initSize |  198 MB | 198 MB | -601 B | 0% |
| diffSize |  122 MB | 122 MB | -601 B | 0% |
| buildTime |  15.8s | 15.2s | -563ms | -3.7% |
| buildSize |  7.59 MB | 7.59 MB | 0 B | 0% |
| buildSbAddonsSize |  1.63 MB | 1.63 MB | 0 B | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0% |
| buildSbPreviewSize |  349 kB | 349 kB | 0 B | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - |
| buildPrebuildSize |  4.47 MB | 4.47 MB | 0 B | 0% |
| buildPreviewSize |  3.12 MB | 3.12 MB | 0 B | 0% |
| testBuildTime |  0ms | 0ms | 0ms | - |
| testBuildSize |  0 B | 0 B | 0 B | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - |
| devPreviewResponsive |  8.6s | 9s | 371ms | 4.1% |
| devManagerResponsive |  5.7s | 5.7s | 18ms | 0.3% |
| devManagerHeaderVisible |  917ms | 847ms | -70ms | 🔰-8.3% |
| devManagerIndexVisible |  944ms | 891ms | -53ms | 🔰-5.9% |
| devStoryVisibleUncached |  1.4s | 1.4s | -79ms | 🔰-5.6% |
| devStoryVisible |  969ms | 920ms | -49ms | 🔰-5.3% |
| devAutodocsVisible |  787ms | 689ms | -98ms | 🔰-14.2% |
| devMDXVisible |  743ms | 760ms | 17ms | 2.2% |
| buildManagerHeaderVisible |  780ms | 677ms | -103ms | 🔰-15.2% |
| buildManagerIndexVisible |  783ms | 680ms | -103ms | 🔰-15.1% |
| buildStoryVisible |  840ms | 726ms | -114ms | 🔰-15.7% |
| buildAutodocsVisible |  732ms | 650ms | -82ms | 🔰-12.6% |
| buildMDXVisible |  711ms | 790ms | 79ms | 🔺10% |

<!-- BENCHMARK_SECTION -->