### PR TITLE
Builder-Vite: Add null character prefix to virtual file IDs in code generator plugin

### DIFF
--- a/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
@@ -70,33 +70,33 @@ export function codeGeneratorPlugin(options: Options): Plugin {
     },
     resolveId(source) {
       if (source === virtualFileId) {
-        return `\0${virtualFileId}`;
+        return virtualFileId;
       }
       if (source === iframePath) {
         return iframeId;
       }
       if (source === virtualStoriesFile) {
-        return `\0${virtualStoriesFile}`;
+        return virtualStoriesFile;
       }
       if (source === virtualPreviewFile) {
         return virtualPreviewFile;
       }
       if (source === virtualAddonSetupFile) {
-        return `\0${virtualAddonSetupFile}`;
+        return virtualAddonSetupFile;
       }
 
       return undefined;
     },
     async load(id, config) {
-      if (id === `\0${virtualStoriesFile}`) {
+      if (id === virtualStoriesFile) {
         return generateImportFnScriptCode(options);
       }
 
-      if (id === `\0${virtualAddonSetupFile}`) {
+      if (id === virtualAddonSetupFile) {
         return generateAddonSetupCode();
       }
 
-      if (id === `\0${virtualFileId}`) {
+      if (id === virtualFileId) {
         return generateModernIframeScriptCode(options, projectRoot);
       }
 

--- a/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
+++ b/code/builders/builder-vite/src/plugins/code-generator-plugin.ts
@@ -15,6 +15,10 @@ import {
   virtualStoriesFile,
 } from '../virtual-file-names';
 
+function resolvedVirtualPath(path: string): string {
+  return `\0${path}`;
+}
+
 export function codeGeneratorPlugin(options: Options): Plugin {
   const iframePath = require.resolve('@storybook/builder-vite/input/iframe.html');
   let iframeId: string;
@@ -70,33 +74,33 @@ export function codeGeneratorPlugin(options: Options): Plugin {
     },
     resolveId(source) {
       if (source === virtualFileId) {
-        return virtualFileId;
+        return resolvedVirtualPath(virtualFileId);
       }
       if (source === iframePath) {
         return iframeId;
       }
       if (source === virtualStoriesFile) {
-        return virtualStoriesFile;
+        return resolvedVirtualPath(virtualStoriesFile);
       }
       if (source === virtualPreviewFile) {
         return virtualPreviewFile;
       }
       if (source === virtualAddonSetupFile) {
-        return virtualAddonSetupFile;
+        return resolvedVirtualPath(virtualAddonSetupFile);
       }
 
       return undefined;
     },
     async load(id, config) {
-      if (id === virtualStoriesFile) {
+      if (id === resolvedVirtualPath(virtualStoriesFile)) {
         return generateImportFnScriptCode(options);
       }
 
-      if (id === virtualAddonSetupFile) {
+      if (id === resolvedVirtualPath(virtualAddonSetupFile)) {
         return generateAddonSetupCode();
       }
 
-      if (id === virtualFileId) {
+      if (id === resolvedVirtualPath(virtualFileId)) {
         return generateModernIframeScriptCode(options, projectRoot);
       }
 

--- a/code/builders/builder-vite/src/virtual-file-names.ts
+++ b/code/builders/builder-vite/src/virtual-file-names.ts
@@ -1,4 +1,4 @@
-export const virtualFileId = '/virtual:/@storybook/builder-vite/vite-app.js';
-export const virtualStoriesFile = '/virtual:/@storybook/builder-vite/storybook-stories.js';
-export const virtualPreviewFile = '/virtual:/@storybook/builder-vite/preview-entry.js';
-export const virtualAddonSetupFile = '/virtual:/@storybook/builder-vite/setup-addons.js';
+export const virtualFileId = '\0virtual:/@storybook/builder-vite/vite-app.js';
+export const virtualStoriesFile = '\0virtual:/@storybook/builder-vite/storybook-stories.js';
+export const virtualPreviewFile = '\0virtual:/@storybook/builder-vite/preview-entry.js';
+export const virtualAddonSetupFile = '\0virtual:/@storybook/builder-vite/setup-addons.js';

--- a/code/builders/builder-vite/src/virtual-file-names.ts
+++ b/code/builders/builder-vite/src/virtual-file-names.ts
@@ -1,4 +1,4 @@
-export const virtualFileId = '\0virtual:/@storybook/builder-vite/vite-app.js';
-export const virtualStoriesFile = '\0virtual:/@storybook/builder-vite/storybook-stories.js';
-export const virtualPreviewFile = '\0virtual:/@storybook/builder-vite/preview-entry.js';
-export const virtualAddonSetupFile = '\0virtual:/@storybook/builder-vite/setup-addons.js';
+export const virtualFileId = 'virtual:/@storybook/builder-vite/vite-app.js';
+export const virtualStoriesFile = 'virtual:/@storybook/builder-vite/storybook-stories.js';
+export const virtualPreviewFile = 'virtual:/@storybook/builder-vite/preview-entry.js';
+export const virtualAddonSetupFile = 'virtual:/@storybook/builder-vite/setup-addons.js';


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Cleaned up the code for resolving and loading virtual files in the Vite builder.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the virtual file handling in the Vite builder for Storybook, improving compatibility with Vite's virtual module system.

- Added `resolvedVirtualPath` function in `code-generator-plugin.ts` to prefix virtual file IDs with a null byte
- Updated virtual file ID resolution throughout the plugin to use the new `resolvedVirtualPath` function
- Removed leading forward slashes from virtual file paths in `virtual-file-names.ts`
- These changes ensure better alignment with Vite's expected format for virtual modules

<!-- /greptile_comment -->