### PR TITLE
Addon Vitest: Add status update prototype

### DIFF
--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -35,6 +35,11 @@
       "import": "./dist/plugin/index.js",
       "require": "./dist/plugin/index.cjs"
     },
+    "./reporter": {
+      "types": "./dist/plugin/reporter.d.ts",
+      "import": "./dist/plugin/reporter.js",
+      "require": "./dist/plugin/reporter.cjs"
+    },
     "./internal/global-setup": {
       "types": "./dist/plugin/global-setup.d.ts",
       "import": "./dist/plugin/global-setup.js",
@@ -97,6 +102,7 @@
     "nodeEntries": [
       "./src/preset.ts",
       "./src/plugin/index.ts",
+      "./src/plugin/reporter.ts",
       "./src/plugin/global-setup.ts",
       "./src/postinstall.ts"
     ]

--- a/code/addons/vitest/src/manager.tsx
+++ b/code/addons/vitest/src/manager.tsx
@@ -1,5 +1,68 @@
-import { type API, addons } from 'storybook/internal/manager-api';
+import { addons } from 'storybook/internal/manager-api';
+
+import type { API_StatusUpdate, API_StatusValue, StoryId } from '@storybook/types';
 
 import { ADDON_ID } from './constants';
+import type { AssertionResult, TestReport } from './types';
+import { SharedState } from './utils/shared-state';
 
-addons.register(ADDON_ID, () => {});
+const statusMap: Record<AssertionResult['status'], API_StatusValue> = {
+  failed: 'error',
+  passed: 'success',
+  pending: 'pending',
+};
+
+function processTestReport(report: TestReport, onClick: any) {
+  const result: API_StatusUpdate = {};
+
+  report.testResults.forEach((testResult) => {
+    testResult.assertionResults.forEach((assertion) => {
+      const storyId = assertion.meta?.storyId;
+      if (storyId) {
+        result[storyId] = {
+          title: 'Vitest',
+          status: statusMap[assertion.status],
+          description:
+            assertion.failureMessages.length > 0 ? assertion.failureMessages.join('\n') : '',
+          onClick,
+        };
+      }
+    });
+  });
+
+  return result;
+}
+
+addons.register(ADDON_ID, (api) => {
+  const channel = api.getChannel();
+
+  if (!channel) {
+    return;
+  }
+
+  const testResultsState = SharedState.subscribe<TestReport>('TEST_RESULTS', channel);
+  const lastStoryIds = new Set<StoryId>();
+
+  testResultsState.on('change', async (report) => {
+    if (!report) {
+      return;
+    }
+
+    const storiesToClear = Object.fromEntries(Array.from(lastStoryIds).map((id) => [id, null]));
+
+    if (Object.keys(storiesToClear).length > 0) {
+      // Clear old statuses to avoid stale data
+      await api.experimental_updateStatus(ADDON_ID, storiesToClear);
+      lastStoryIds.clear();
+    }
+
+    const openInteractionsPanel = () => {
+      api.setSelectedPanel('storybook/interactions/panel');
+      api.togglePanel(true);
+    };
+
+    const final = processTestReport(report, openInteractionsPanel);
+
+    await api.experimental_updateStatus(ADDON_ID, final);
+  });
+});

--- a/code/addons/vitest/src/plugin/reporter.ts
+++ b/code/addons/vitest/src/plugin/reporter.ts
@@ -1,0 +1,12 @@
+import { join } from 'node:path';
+
+import { JsonReporter } from 'vitest/reporters';
+
+export default class StorybookReporter extends JsonReporter {
+  constructor({ configDir = '.storybook' }: { configDir: string }) {
+    const outputFile = join(configDir, 'test-results.json');
+    super({
+      outputFile,
+    });
+  }
+}

--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -1,7 +1,67 @@
+import { watch } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, basename } from 'node:path';
 import type { Channel } from 'storybook/internal/channels';
 import type { Options } from 'storybook/internal/types';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const experimental_serverChannel = async (channel: Channel, options: Options) => {
-  return channel;
+import type { TestReport } from './types';
+import { SharedState } from './utils/shared-state';
+
+async function getTestReport(reportFile: string): Promise<TestReport> {
+  const data = await readFile(reportFile, 'utf8');
+  // TODO: Streaming and parsing large files
+  return JSON.parse(data);
+}
+
+const watchTestReportDirectory = async (
+  reportFile: string | undefined,
+  onChange: (results: Awaited<ReturnType<typeof getTestReport>>) => Promise<void>
+) => {
+  if (!reportFile) return;
+
+  const directory = dirname(reportFile);
+  const targetFile = basename(reportFile);
+
+  const handleFileChange = async (eventType: string, filename: string | null) => {
+    if (filename && filename === targetFile) {
+      try {
+        await onChange(await getTestReport(reportFile));
+      } catch(err: any) {
+        if(err.code === 'ENOENT') {
+          console.log('File got deleted/renamed. What should we do?');
+          return;
+        }
+
+        throw err;
+      }
+    }
+  };
+
+  watch(directory, handleFileChange);
+
+  try {
+    const initialResults = await getTestReport(reportFile);
+    await onChange(initialResults);
+  } catch(err: any) {
+    if(err.code === 'ENOENT') {
+      return;
+    }
+
+    throw err;
+  }
 };
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export async function experimental_serverChannel(
+  channel: Channel,
+  options: Options & { reportFile?: string }
+) {
+  const { reportFile = join(process.cwd(), '.storybook', 'test-results.json') } = options;
+
+  const testReportState = SharedState.subscribe<TestReport>('TEST_RESULTS', channel);
+
+  watchTestReportDirectory(reportFile, async (results) => {
+    console.log('Updating test results:', Object.keys(results.testResults).length);
+    testReportState.value = results;
+  });
+}

--- a/code/addons/vitest/src/types.ts
+++ b/code/addons/vitest/src/types.ts
@@ -1,0 +1,61 @@
+interface FailureMessage {
+  line: number;
+  column: number;
+}
+
+interface Meta {
+  storyId: string;
+}
+
+export interface AssertionResult {
+  ancestorTitles: string[];
+  fullName: string;
+  status: 'passed' | 'failed' | 'pending';
+  title: string;
+  duration: number;
+  failureMessages: string[];
+  location?: FailureMessage;
+  meta?: Meta;
+}
+
+interface TestResult {
+  assertionResults: AssertionResult[];
+  startTime: number;
+  endTime: number;
+  status: 'passed' | 'failed' | 'pending';
+  message: string;
+  name: string;
+}
+
+interface Snapshot {
+  added: number;
+  failure: boolean;
+  filesAdded: number;
+  filesRemoved: number;
+  filesRemovedList: any[];
+  filesUnmatched: number;
+  filesUpdated: number;
+  matched: number;
+  total: number;
+  unchecked: number;
+  uncheckedKeysByFile: any[];
+  unmatched: number;
+  updated: number;
+  didUpdate: boolean;
+}
+
+export interface TestReport {
+  numTotalTestSuites: number;
+  numPassedTestSuites: number;
+  numFailedTestSuites: number;
+  numPendingTestSuites: number;
+  numTotalTests: number;
+  numPassedTests: number;
+  numFailedTests: number;
+  numPendingTests: number;
+  numTodoTests: number;
+  startTime: number;
+  success: boolean;
+  testResults: TestResult[];
+  snapshot: Snapshot;
+}

--- a/code/addons/vitest/src/utils/shared-state.test.ts
+++ b/code/addons/vitest/src/utils/shared-state.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SharedState } from './SharedState';
+
+class MockChannel {
+  private listeners: Record<string, ((...args: any[]) => void)[]> = {};
+
+  on(event: string, listener: (...args: any[]) => void) {
+    this.listeners[event] = [...(this.listeners[event] ?? []), listener];
+  }
+
+  off(event: string, listener: (...args: any[]) => void) {
+    this.listeners[event] = (this.listeners[event] ?? []).filter((l) => l !== listener);
+  }
+
+  emit(event: string, ...args: any[]) {
+    // setTimeout is used to simulate the asynchronous nature of the real channel
+    (this.listeners[event] || []).forEach((listener) => setTimeout(() => listener(...args)));
+  }
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('SharedState', () => {
+  let channel: MockChannel;
+  let a: SharedState;
+  let b: SharedState;
+
+  beforeEach(() => {
+    channel = new MockChannel();
+    a = new SharedState(channel);
+    b = new SharedState(channel);
+  });
+
+  it('should initialize with an empty object', () => {
+    expect(a.state).toEqual({});
+  });
+
+  it('should set and get values correctly', () => {
+    a.set('foo', 'bar');
+    a.set('baz', 123);
+
+    expect(a.get('foo')).toBe('bar');
+    expect(a.get('baz')).toBe(123);
+    expect(a.get('qux')).toBeUndefined();
+  });
+
+  it('should remove values correctly', () => {
+    a.set('foo', 'bar');
+    a.set('foo', undefined);
+
+    expect(a.get('foo')).toBeUndefined();
+  });
+
+  it('should (eventually) share state between instances', async () => {
+    a.set('foo', 'bar');
+    await tick(); // setState
+    expect(b.get('foo')).toBe('bar');
+  });
+
+  it('should (eventually) share state with new instances', async () => {
+    a.set('foo', 'bar');
+    const c = new SharedState(channel);
+
+    expect(c.get('foo')).toBeUndefined();
+    await tick(); // getState
+    await tick(); // setState
+    expect(c.get('foo')).toBe('bar');
+  });
+
+  it('should not overwrite newer values', async () => {
+    a.set('foo', 'bar');
+    b.set('foo', 'baz'); // conflict: "bar" was not yet synced
+    await tick(); // setState (one side)
+    await tick(); // setState (other side)
+
+    // Neither accepts the other's value
+    expect(a.get('foo')).toBe('bar');
+    expect(b.get('foo')).toBe('baz');
+
+    b.set('foo', 'baz'); // try again
+    await tick(); // setState
+    expect(a.get('foo')).toBe('baz');
+  });
+});

--- a/code/addons/vitest/src/utils/shared-state.ts
+++ b/code/addons/vitest/src/utils/shared-state.ts
@@ -1,0 +1,78 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
+import type { Channel } from '@storybook/channels';
+
+export const GET_VALUE = `experimental_useSharedState_getValue`;
+export const SET_VALUE = `experimental_useSharedState_setValue`;
+
+type ChannelLike = Pick<Channel, 'emit' | 'on' | 'off'>;
+
+const instances = new Map<string, SharedState>();
+
+export class SharedState<T = any> {
+  channel: ChannelLike;
+
+  listeners: ((value: T | undefined) => void)[];
+
+  state: { [key: string]: { index: number; value: T | undefined } };
+
+  constructor(channel: ChannelLike) {
+    this.channel = channel;
+    this.listeners = [];
+    this.state = {};
+
+    this.channel.on(SET_VALUE, (key: string, value: T | undefined, index: number) => {
+      if (this.state?.[key]?.index >= index) return;
+      this.state[key] = { index, value };
+    });
+
+    this.channel.on(GET_VALUE, (key: string) => {
+      const index = this.state[key]?.index ?? 0;
+      const value = this.state[key]?.value;
+      this.channel.emit(SET_VALUE, key, value, index);
+    });
+  }
+
+  get(key: string) {
+    if (!this.state[key]) this.channel.emit(GET_VALUE, key);
+    return this.state[key]?.value;
+  }
+
+  set(key: string, value: T | undefined) {
+    const index = (this.state[key]?.index ?? 0) + 1;
+    this.state[key] = { index, value };
+    this.channel.emit(SET_VALUE, key, value, index);
+  }
+
+  static subscribe<T>(key: string, channel: ChannelLike) {
+    const sharedState = instances.get(key) || new SharedState(channel);
+
+    if (!instances.has(key)) {
+      instances.set(key, sharedState);
+      sharedState.channel.on(SET_VALUE, (k: string, v: T | undefined) => {
+        if (k !== key) return;
+        sharedState.listeners.forEach((listener) => listener(v));
+      });
+    }
+
+    return {
+      get value(): T | undefined {
+        return sharedState.get(key);
+      },
+
+      set value(newValue: T | undefined) {
+        sharedState.set(key, newValue);
+      },
+
+      on(event: 'change', callback: (value: T | undefined) => void) {
+        if (event !== 'change') throw new Error('unsupported event');
+        sharedState.listeners.push(callback);
+      },
+
+      off(event: 'change', callback: (value: T | undefined) => void) {
+        if (event !== 'change') throw new Error('unsupported event');
+        const index = sharedState.listeners.indexOf(callback);
+        if (index >= 0) sharedState.listeners.splice(index, 1);
+      },
+    };
+  }
+}

--- a/code/vitest.config.ts
+++ b/code/vitest.config.ts
@@ -2,6 +2,7 @@ import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    reporters: ['default', '@storybook/experimental-addon-vitest/reporter'],
     coverage: {
       all: false,
       provider: 'istanbul',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This brings back the implementation from #28749 regarding updating Storybook's sidebar based on test reports, this time not using JUnit but rather json reports, which include test meta (we need it to extract the storyId).
It also introduces a storybook reporter from vitest addon, so that the json file is written in the right location.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.3 MB | 76.3 MB | 115 B | -0.45 | 0% |
| initSize |  169 MB | 169 MB | -85 kB | -1.13 | -0.1% |
| diffSize |  92.8 MB | 92.7 MB | -85.2 kB | -0.38 | -0.1% |
| buildSize |  7.46 MB | 7.46 MB | -2.08 kB | -0.39 | 0% |
| buildSbAddonsSize |  1.62 MB | 1.61 MB | -1.24 kB | -0.9 | -0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | 0.33 | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | -823 B | -0.78 | -0.2% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | -2.06 kB | -0.82 | 0% |
| buildPreviewSize |  3 MB | 3 MB | -20 B | 0.96 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.7s | 16.1s | 9.4s | 0 | 58.1% |
| generateTime |  20s | 23s | 3s | **1.97** | 🔺13.1% |
| initTime |  16.5s | 19.5s | 3s | **1.33** | 🔺15.5% |
| buildTime |  13s | 14.1s | 1.1s | 1.18 | 7.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  7.8s | 6.8s | -1s -23ms | -0.59 | -14.9% |
| devManagerResponsive |  5s | 4.6s | -449ms | -0.43 | -9.7% |
| devManagerHeaderVisible |  903ms | 762ms | -141ms | -0.41 | -18.5% |
| devManagerIndexVisible |  943ms | 804ms | -139ms | -0.39 | -17.3% |
| devStoryVisibleUncached |  1.2s | 1.4s | 132ms | 0.29 | 9.4% |
| devStoryVisible |  940ms | 803ms | -137ms | -0.41 | -17.1% |
| devAutodocsVisible |  695ms | 704ms | 9ms | -0.35 | 1.3% |
| devMDXVisible |  697ms | 669ms | -28ms | -0.42 | -4.2% |
| buildManagerHeaderVisible |  733ms | 692ms | -41ms | -0.56 | -5.9% |
| buildManagerIndexVisible |  739ms | 698ms | -41ms | -0.55 | -5.9% |
| buildStoryVisible |  807ms | 733ms | -74ms | -0.66 | -10.1% |
| buildAutodocsVisible |  718ms | 701ms | -17ms | -0.06 | -2.4% |
| buildMDXVisible |  633ms | 692ms | 59ms | 0.47 | 8.5% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR implements a status update prototype for the Vitest addon in Storybook, enhancing test result integration.

- Introduced a new StorybookReporter class in `src/plugin/reporter.ts` for JSON test report generation
- Implemented SharedState class in `src/utils/shared-state.ts` for managing state across addon components
- Added server-side channel in `src/preset.ts` for watching and processing test reports
- Updated `src/manager.tsx` to display real-time test statuses in Storybook's sidebar
- Modified `vitest.config.ts` to include the new Storybook reporter for Vitest

<!-- /greptile_comment -->