### PR TITLE
Index: Add support for resolving import maps

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -397,6 +397,7 @@
     "react-transition-group": "^4.4.5",
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",
+    "resolve-pkg-maps": "^1.0.0",
     "slash": "^5.0.0",
     "source-map": "^0.7.4",
     "store2": "^2.14.2",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6089,6 +6089,7 @@ __metadata:
     recast: "npm:^0.23.5"
     require-from-string: "npm:^2.0.2"
     resolve-from: "npm:^5.0.0"
+    resolve-pkg-maps: "npm:^1.0.0"
     semver: "npm:^7.6.2"
     slash: "npm:^5.0.0"
     source-map: "npm:^0.7.4"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/pull/28949

## What I did

I added support for import maps getting resolved for `componentPath` in story indexer.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Untested for now, I think this needs to be tested somehow, but I'm not sure about exactly which approach to take.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  76.4 MB | 76.4 MB | 2.3 kB | **2.76** | 0% |
| initSize |  177 MB | 177 MB | 12.5 kB | **2.28** | 0% |
| diffSize |  101 MB | 101 MB | 10.2 kB | **2.24** | 0% |
| buildSize |  7.46 MB | 7.46 MB | 0 B | **1.88** | 0% |
| buildSbAddonsSize |  1.62 MB | 1.62 MB | 0 B | **2.23** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  2.3 MB | 2.3 MB | 0 B | **-2.24** | 0% |
| buildSbPreviewSize |  351 kB | 351 kB | 0 B | **2.24** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.46 MB | 4.46 MB | 0 B | **2.23** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | 0.66 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  23s | 7.6s | -15s -361ms | **-1.24** | 🔰-200.7% |
| generateTime |  18.9s | 22.5s | 3.5s | **1.72** | 🔺15.8% |
| initTime |  16.5s | 20.1s | 3.6s | **1.86** | 🔺17.9% |
| buildTime |  11.7s | 10.9s | -736ms | **-1.54** | 🔰-6.7% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.5s | 7.4s | 993ms | -0.85 | 13.2% |
| devManagerResponsive |  4.5s | 5.2s | 675ms | -0.29 | 13% |
| devManagerHeaderVisible |  731ms | 662ms | -69ms | **-1.84** | 🔰-10.4% |
| devManagerIndexVisible |  773ms | 696ms | -77ms | **-1.88** | 🔰-11.1% |
| devStoryVisibleUncached |  1s | 1.1s | 110ms | -1.03 | 9.5% |
| devStoryVisible |  781ms | 705ms | -76ms | **-1.93** | 🔰-10.8% |
| devAutodocsVisible |  748ms | 648ms | -100ms | -1.1 | -15.4% |
| devMDXVisible |  658ms | 580ms | -78ms | **-1.64** | 🔰-13.4% |
| buildManagerHeaderVisible |  694ms | 627ms | -67ms | **-1.56** | 🔰-10.7% |
| buildManagerIndexVisible |  726ms | 632ms | -94ms | **-1.57** | 🔰-14.9% |
| buildStoryVisible |  728ms | 663ms | -65ms | **-1.53** | 🔰-9.8% |
| buildAutodocsVisible |  683ms | 624ms | -59ms | -1.08 | -9.5% |
| buildMDXVisible |  665ms | 562ms | -103ms | **-1.61** | 🔰-18.3% |

<!-- BENCHMARK_SECTION -->