### PR TITLE
Core: Make `prettier` an optional peer dependency

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -419,6 +419,14 @@
     "use-resize-observer": "^9.1.0",
     "watchpack": "^2.2.0"
   },
+  "peerDependencies": {
+    "prettier": "^2 || ^3"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -28,7 +28,13 @@ export const getEntries = (cwd: string) => {
     define('src/preview-api/index.ts', ['browser', 'node'], true),
     define('src/manager-api/index.ts', ['browser', 'node'], true, ['react']),
     define('src/router/index.ts', ['browser', 'node'], true, ['react']),
-    define('src/components/index.ts', ['browser', 'node'], true, ['react', 'react-dom']),
+    define(
+      'src/components/index.ts',
+      ['browser', 'node'],
+      true,
+      ['react', 'react-dom'],
+      ['prettier'] // the syntax highlighter uses prettier/standalone to format the code
+    ),
     define('src/theming/index.ts', ['browser', 'node'], true, ['react']),
     define('src/theming/create.ts', ['browser', 'node'], true, ['react']),
     define('src/docs-tools/index.ts', ['browser', 'node'], true),

--- a/code/lib/cli/package.json
+++ b/code/lib/cli/package.json
@@ -322,6 +322,14 @@
   "devDependencies": {
     "typescript": "^5.3.2"
   },
+  "peerDependencies": {
+    "prettier": "^2 || ^3"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -26229,6 +26229,11 @@ __metadata:
   dependencies:
     "@storybook/core": "workspace:*"
     typescript: "npm:^5.3.2"
+  peerDependencies:
+    prettier: ^2 || ^3
+  peerDependenciesMeta:
+    prettier:
+      optional: true
   bin:
     getstorybook: ./bin/index.cjs
     sb: ./bin/index.cjs

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6137,6 +6137,11 @@ __metadata:
     util: "npm:^0.12.5"
     watchpack: "npm:^2.2.0"
     ws: "npm:^8.2.3"
+  peerDependencies:
+    prettier: ^2 || ^3
+  peerDependenciesMeta:
+    prettier:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes #29084

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

1. Made `prettier` an optional peer dependency of `@storybook/core`. The Save from Controls that is using Prettier to format the output according to the project's options, is already written to support environments where Prettier isn't installed. 
https://github.com/storybookjs/storybook/blob/d3f5ad98982d4320fde6dac9c901440d48496be8/code/core/src/common/utils/formatter.ts#L1-L6

2. kept `prettier` as an _internal_ for the `@storybook/core/components` entrypoint, because the syntax highlighter uses it when formatting is enabled. It uses the lighter weight `prettier/standalone` and html plugin.

https://github.com/storybookjs/storybook/blob/d3f5ad98982d4320fde6dac9c901440d48496be8/code/core/src/components/components/syntaxhighlighter/formatter.ts

(Given that it only supports formatting `html` and not `js`/`jsx`, etc. I question how valuable it is. I've added a bullet in the 9.0 changes to consider removing it)

<!-- Briefly describe what your PR does -->

### Before

![image](https://github.com/user-attachments/assets/54cf6907-521d-429d-b744-58daff2855d6)

![image](https://github.com/user-attachments/assets/e78a5d76-f917-4dda-93c6-27ed96af1709)

### After

![image](https://github.com/user-attachments/assets/9a5b2f7d-192d-437a-9eee-67ae9ff8410d)

![image](https://github.com/user-attachments/assets/26cd2d5b-624f-4fcd-b324-c8629e3f2b37)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
4. Open Storybook in your browser
5. Access X story

-->

1. install the canary version in a separate sandbox to ensure `prettier` isn't polluted into the project.
2. ensure prettier isn't in the project
3. start storybook, use the save from controls feature, test that the output is written to the file without any issues. (new component, update existing story, save new story) give the file some very bad formatting and see that the changes we write are still okay
4. install prettier
5. repeat 3, see that the story files are now formatted

to test formatting in the syntax highlighter:
1. ensure prettier is not in the project
2. add the following MDX file to your storybook:

```mdx
import { Source } from '@storybook/blocks';

# testing Source

<Source format="html" code={`<body><div>hello</div></body>`} />
```
3. ensure that it is properly formatted in the storybook.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29223-sha-d3f5ad98`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29223-sha-d3f5ad98 sandbox` or in an existing project with `npx storybook@0.0.0-pr-29223-sha-d3f5ad98 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29223-sha-d3f5ad98`](https://npmjs.com/package/storybook/v/0.0.0-pr-29223-sha-d3f5ad98) |
| **Triggered by** | @JReinhold |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`29084-minimize-the-bundling-of-prettier-in-storybookcore`](https://github.com/storybookjs/storybook/tree/29084-minimize-the-bundling-of-prettier-in-storybookcore) |
| **Commit** | [`d3f5ad98`](https://github.com/storybookjs/storybook/commit/d3f5ad98982d4320fde6dac9c901440d48496be8) |
| **Datetime** | Thu Sep 26 20:49:55 UTC 2024 (`1727383795`) |
| **Workflow run** | [11060034306](https://github.com/storybookjs/storybook/actions/runs/11060034306) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29223`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.5 MB | 77.7 MB | 202 kB | **4.29** | 0.3% |
| initSize |  162 MB | 152 MB | -10 MB | **-89.17** | 🔰-6.6% |
| diffSize |  84.8 MB | 74.6 MB | -10.2 MB | **-86.53** | 🔰-13.7% |
| buildSize |  6.96 MB | 6.96 MB | 0 B | **-2.08** | 0% |
| buildSbAddonsSize |  1.57 MB | 1.57 MB | 0 B | **-2.38** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.91 MB | 1.91 MB | 0 B | **-1.83** | 0% |
| buildSbPreviewSize |  311 kB | 311 kB | 0 B | **-2.38** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.98 MB | 3.98 MB | 0 B | **-2.03** | 0% |
| buildPreviewSize |  2.97 MB | 2.97 MB | 0 B | **-2.38** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  15.6s | 7.3s | -8s -253ms | -0.64 | -112.3% |
| generateTime |  20.8s | 24.4s | 3.5s | 0.45 | 14.5% |
| initTime |  16.3s | 16.4s | 126ms | -0.15 | 0.8% |
| buildTime |  8.6s | 9s | 346ms | **-1.49** | 3.8% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.3s | 6.3s | -48ms | -0.91 | -0.8% |
| devManagerResponsive |  4.2s | 4.1s | -65ms | -1.13 | -1.6% |
| devManagerHeaderVisible |  521ms | 527ms | 6ms | **-1.85** | 1.1% |
| devManagerIndexVisible |  548ms | 564ms | 16ms | **-1.73** | 2.8% |
| devStoryVisibleUncached |  970ms | 1.1s | 166ms | -0.5 | 14.6% |
| devStoryVisible |  549ms | 562ms | 13ms | **-1.81** | 2.3% |
| devAutodocsVisible |  493ms | 530ms | 37ms | -1.01 | 7% |
| devMDXVisible |  478ms | 464ms | -14ms | **-1.47** | -3% |
| buildManagerHeaderVisible |  520ms | 497ms | -23ms | **-1.6** | -4.6% |
| buildManagerIndexVisible |  558ms | 500ms | -58ms | **-1.68** | 🔰-11.6% |
| buildStoryVisible |  594ms | 537ms | -57ms | **-2.02** | 🔰-10.6% |
| buildAutodocsVisible |  442ms | 442ms | 0ms | **-1.87** | 0% |
| buildMDXVisible |  438ms | 459ms | 21ms | **-1.43** | 4.6% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR makes Prettier an optional peer dependency in @storybook/core and @storybook/cli, while retaining it as an internal dependency for specific components.

- Modified `code/core/package.json` to make Prettier an optional peer dependency
- Updated `code/core/scripts/entries.ts` to include Prettier as an internal dependency for the syntax highlighter component
- Added Prettier as an optional peer dependency in `code/lib/cli/package.json`
- Reduces bundle size for users who don't need Prettier functionality
- Maintains Prettier support for code formatting in specific components like the syntax highlighter

<!-- /greptile_comment -->