### PR TITLE
WIP - Addon Test: Discrepancy detection instrumenter data

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -7,92 +7,98 @@ const managerApiPath = join(__dirname, '../core/src/manager-api');
 
 const config: StorybookConfig = {
   stories: [
-    './*.stories.@(js|jsx|ts|tsx)',
-    {
-      directory: '../core/template/stories',
-      titlePrefix: 'core',
-    },
-    {
-      directory: '../core/src/manager',
-      titlePrefix: 'manager',
-    },
-    {
-      directory: '../core/src/preview-api',
-      titlePrefix: 'preview',
-    },
-    {
-      directory: '../core/src/components/brand',
-      titlePrefix: 'brand',
-    },
-    {
-      directory: '../core/src/components/components',
-      titlePrefix: 'components',
-    },
-    {
-      directory: '../lib/blocks/src',
-      titlePrefix: 'blocks',
-    },
-    {
-      directory: '../addons/a11y/template/stories',
-      titlePrefix: 'addons/a11y',
-    },
-    {
-      directory: '../addons/actions/template/stories',
-      titlePrefix: 'addons/actions',
-    },
-    {
-      directory: '../addons/backgrounds/template/stories',
-      titlePrefix: 'addons/backgrounds',
-    },
-    {
-      directory: '../addons/controls/src',
-      titlePrefix: 'addons/controls',
-    },
-    {
-      directory: '../addons/controls/template/stories',
-      titlePrefix: 'addons/controls',
-    },
-    {
-      directory: '../addons/docs/template/stories',
-      titlePrefix: 'addons/docs',
-    },
-    {
-      directory: '../addons/links/template/stories',
-      titlePrefix: 'addons/links',
-    },
-    {
-      directory: '../addons/viewport/template/stories',
-      titlePrefix: 'addons/viewport',
-    },
-    {
-      directory: '../addons/toolbars/template/stories',
-      titlePrefix: 'addons/toolbars',
-    },
-    {
-      directory: '../addons/themes/template/stories',
-      titlePrefix: 'addons/themes',
-    },
-    {
-      directory: '../addons/onboarding/src',
-      titlePrefix: 'addons/onboarding',
-    },
-    {
-      directory: '../addons/interactions/src',
-      titlePrefix: 'addons/interactions',
-    },
-    {
-      directory: '../addons/interactions/template/stories',
-      titlePrefix: 'addons/interactions/tests',
-    },
-    {
-      directory: '../addons/test/template/stories',
-      titlePrefix: 'addons/test',
-    },
+    // './*.stories.@(js|jsx|ts|tsx)',
+    // {
+    //   directory: '../core/template/stories',
+    //   titlePrefix: 'core',
+    // },
+    // {
+    //   directory: '../core/src/manager',
+    //   titlePrefix: 'manager',
+    // },
+    // {
+    //   directory: '../core/src/preview-api',
+    //   titlePrefix: 'preview',
+    // },
+    // {
+    //   directory: '../core/src/components/brand',
+    //   titlePrefix: 'brand',
+    // },
+    // {
+    //   directory: '../core/src/components/components',
+    //   titlePrefix: 'components',
+    // },
+    // {
+    //   directory: '../lib/blocks/src',
+    //   titlePrefix: 'blocks',
+    // },
+    // {
+    //   directory: '../addons/a11y/template/stories',
+    //   titlePrefix: 'addons/a11y',
+    // },
+    // {
+    //   directory: '../addons/actions/template/stories',
+    //   titlePrefix: 'addons/actions',
+    // },
+    // {
+    //   directory: '../addons/backgrounds/template/stories',
+    //   titlePrefix: 'addons/backgrounds',
+    // },
+    // {
+    //   directory: '../addons/controls/src',
+    //   titlePrefix: 'addons/controls',
+    // },
+    // {
+    //   directory: '../addons/controls/template/stories',
+    //   titlePrefix: 'addons/controls',
+    // },
+    // {
+    //   directory: '../addons/docs/template/stories',
+    //   titlePrefix: 'addons/docs',
+    // },
+    // {
+    //   directory: '../addons/links/template/stories',
+    //   titlePrefix: 'addons/links',
+    // },
+    // {
+    //   directory: '../addons/viewport/template/stories',
+    //   titlePrefix: 'addons/viewport',
+    // },
+    // {
+    //   directory: '../addons/toolbars/template/stories',
+    //   titlePrefix: 'addons/toolbars',
+    // },
+    // {
+    //   directory: '../addons/themes/template/stories',
+    //   titlePrefix: 'addons/themes',
+    // },
+    // {
+    //   directory: '../addons/onboarding/src',
+    //   titlePrefix: 'addons/onboarding',
+    // },
+    // {
+    //   directory: '../addons/interactions/src',
+    //   titlePrefix: 'addons/interactions',
+    // },
+    // {
+    //   directory: '../addons/interactions/template/stories',
+    //   titlePrefix: 'addons/interactions/tests',
+    // },
+    // {
+    //   directory: '../addons/test/src',
+    //   titlePrefix: 'addons/test',
+    // },
+    // {
+    //   directory: '../addons/test/template/stories',
+    //   titlePrefix: 'addons/test',
+    // },
+    // '../addons/test/src/components/InteractionsPanel.stories.tsx',
+    '../addons/test/template/stories/basics.stories.ts',
   ],
   addons: [
     '@storybook/addon-themes',
     '@storybook/addon-essentials',
-    '@storybook/addon-interactions',
+    // '@storybook/addon-interactions',
     '@storybook/addon-storysource',
     '@storybook/addon-designs',
     '@storybook/experimental-addon-test',

--- a/code/.storybook/vitest.config.ts
+++ b/code/.storybook/vitest.config.ts
@@ -35,11 +35,12 @@ export default mergeConfig(
     test: {
       name: 'storybook-ui',
       include: [
-        '../addons/**/*.{story,stories}.?(c|m)[jt]s?(x)',
+        '../addons/test/template/stories/basics.stories.ts',
+        // '../addons/**/*.{story,stories}.?(c|m)[jt]s?(x)',
         // '../core/template/stories/**/*.{story,stories}.?(c|m)[jt]s?(x)',
-        '../core/src/manager/**/*.{story,stories}.?(c|m)[jt]s?(x)',
-        '../core/src/preview-api/**/*.{story,stories}.?(c|m)[jt]s?(x)',
-        '../core/src/components/{brand,components}/**/*.{story,stories}.?(c|m)[jt]s?(x)',
+        // '../core/src/manager/**/*.{story,stories}.?(c|m)[jt]s?(x)',
+        // '../core/src/preview-api/**/*.{story,stories}.?(c|m)[jt]s?(x)',
+        // '../core/src/components/{brand,components}/**/*.{story,stories}.?(c|m)[jt]s?(x)',
       ],
       exclude: [
         ...defaultExclude,

--- a/code/addons/test/src/Panel.tsx
+++ b/code/addons/test/src/Panel.tsx
@@ -261,6 +261,23 @@ export const Panel = memo<{ storyId: string }>(function PanelMemoized({ storyId 
     );
   }, [testRunStatus, storyStatus]);
 
+  if (interactions.length > 0) {
+    console.log({
+      storyStatuses,
+      storyStatus,
+      testRunStatus,
+      calls,
+      interactions,
+    });
+
+    console.log({
+      originalCalls: calls,
+      vitestCalls: new Map(
+        storyStatus.data.instrumenterState.calls.map((call: any) => [call.id, call])
+      ),
+    });
+  }
+
   if (isErrored) {
     return <Fragment key="component-tests" />;
   }

--- a/code/addons/test/src/sanitize-instrumented-state.ts
+++ b/code/addons/test/src/sanitize-instrumented-state.ts
@@ -1,0 +1,9 @@
+import type { State as InstrumentedState } from '@storybook/instrumenter';
+
+type SanitizedState = { calls: InstrumentedState['calls'] };
+
+export function sanitizeInstrumentedState(state: InstrumentedState): SanitizedState {
+  return {
+    calls: state.calls.map(({ args, ...rest }) => ({ ...rest, args: [] })),
+  };
+}

--- a/code/addons/test/src/vitest-plugin/test-utils.ts
+++ b/code/addons/test/src/vitest-plugin/test-utils.ts
@@ -22,10 +22,33 @@ export const testStory = (
 
     context.story = composedStory;
 
-    const _task = context.task as RunnerTask & { meta: TaskMeta & { storyId: string } };
+    const _task = context.task as RunnerTask & {
+      meta: TaskMeta & { storyId: string; instrumenterState: any };
+    };
     _task.meta.storyId = composedStory.id;
+    globalThis.__STORYBOOK_PREVIEW__ = {
+      selectionStore: {
+        // @ts-expect-error xyz
+        selection: {
+          storyId: composedStory.id,
+        },
+      },
+    };
+    const instrumenter = globalThis.window.__STORYBOOK_ADDON_INTERACTIONS_INSTRUMENTER__;
+    instrumenter.cleanup();
 
     await setViewport(composedStory.parameters.viewport);
     await composedStory.run();
+
+    _task.meta.instrumenterState = (
+      globalThis.window?.parent as any
+    )?.__STORYBOOK_ADDON_INTERACTIONS_INSTRUMENTER_STATE__;
+
+    console.log(
+      'final state',
+      JSON.stringify(
+        (globalThis.window?.parent as any)?.__STORYBOOK_ADDON_INTERACTIONS_INSTRUMENTER_STATE__
+      )
+    );
   };
 };

--- a/code/core/src/core-events/data/testing-module.ts
+++ b/code/core/src/core-events/data/testing-module.ts
@@ -58,12 +58,14 @@ export type TestingModuleRunAssertionResultPayload =
       status: 'success' | 'pending';
       duration: number;
       storyId: string;
+      data: any;
     }
   | {
       status: 'failed';
       duration: number;
       failureMessages: string[];
       storyId: string;
+      data: any;
     };
 
 export type Status = 'success' | 'failed' | 'pending';

--- a/code/core/src/manager/components/sidebar/SidebarBottom.tsx
+++ b/code/core/src/manager/components/sidebar/SidebarBottom.tsx
@@ -86,12 +86,13 @@ function processTestReport(payload: TestingModuleRunResponsePayload) {
   const result: API_StatusUpdate = {};
 
   payload.testResults.forEach((testResult: any) => {
-    testResult.results.forEach(({ storyId, status, failureMessages }: any) => {
+    testResult.results.forEach(({ storyId, status, failureMessages, data = {} }: any) => {
       if (storyId) {
         result[storyId] = {
           title: 'Vitest',
           status: statusMap[status],
           description: failureMessages?.length ? failureMessages.join('\n') : '',
+          data,
         };
       }
     });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR adds extra checks for discrepancy, including the entire instrumented logs coming from node.
Challenges:
- The instrumenter relies on Storybook events to be emitted and changes the shape of the interaction logs based on them. Such events don't happen in portable stories
- The instrumented logs might not match, as users might not have the same annotations in Storybook vs Portable stories (e.g. if they do not add some addon annotations manually such as @storybook/experimental-addon-test, which would then not have an instrumented `step` function)
- In order to construct the UI based on the logs from Vitest, things might look a bit different

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR adds instrumented state data capture and logging for discrepancy detection in Storybook tests, focusing on the test addon and related components.

- Modified `Panel.tsx` to log detailed story statuses, test run status, and interactions
- Updated `reporter.ts` to include instrumenter data in test results and improve progress reporting
- Added `sanitize-instrumented-state.ts` to remove 'args' from instrumented state calls
- Enhanced `test-utils.ts` to capture and log final instrumenter state after running stories
- Added 'data' field to `TestingModuleRunAssertionResultPayload` type for more detailed test results
- Updated `SidebarBottom.tsx` to include additional test data in status updates

<!-- /greptile_comment -->