### PR TITLE
React: Prebundle `frameworks/react-vite` as much as possible

### DIFF
--- a/code/.storybook/main.ts
+++ b/code/.storybook/main.ts
@@ -126,6 +126,9 @@ const config: StorybookConfig = {
     viewportStoryGlobals: true,
     backgroundsStoryGlobals: true,
   },
+  typescript: {
+    // reactDocgen: 'react-docgen',
+  },
   viteFinal: async (viteConfig, { configType }) => {
     const { mergeConfig } = await import('vite');
 

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -47,18 +47,19 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
-    "@rollup/pluginutils": "^5.0.2",
     "@storybook/builder-vite": "workspace:*",
     "@storybook/react": "workspace:*",
+    "json5": "^2.2.3"
+  },
+  "devDependencies": {
+    "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
+    "@rollup/pluginutils": "^5.0.2",
+    "@types/node": "^22.0.0",
     "find-up": "^5.0.0",
     "magic-string": "^0.30.0",
     "react-docgen": "^7.0.0",
     "resolve": "^1.22.8",
-    "tsconfig-paths": "^4.2.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.2",
     "vite": "^4.0.0"
   },
@@ -78,6 +79,9 @@
     "entries": [
       "./src/index.ts",
       "./src/preset.ts"
+    ],
+    "externals": [
+      "typescript"
     ],
     "platform": "node"
   },

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
-    "@rollup/pluginutils": "^5.0.2",
     "@types/node": "^22.0.0",
     "find-up": "^5.0.0",
     "magic-string": "^0.30.0",

--- a/code/frameworks/react-vite/src/plugins/react-docgen.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.ts
@@ -2,7 +2,6 @@ import { relative } from 'node:path';
 
 import { logger } from 'storybook/internal/node-logger';
 
-import { createFilter } from '@rollup/pluginutils';
 import findUp from 'find-up';
 import MagicString from 'magic-string';
 import type { Documentation } from 'react-docgen';
@@ -40,6 +39,7 @@ export async function reactDocgen({
   exclude = [/node_modules\/.*/],
 }: Options = {}): Promise<PluginOption> {
   const cwd = process.cwd();
+  const { createFilter } = await import('vite');
   const filter = createFilter(include, exclude);
 
   const tsconfigPath = await findUp('tsconfig.json', { cwd });

--- a/code/frameworks/react-vite/src/plugins/react-docgen.ts
+++ b/code/frameworks/react-vite/src/plugins/react-docgen.ts
@@ -13,7 +13,7 @@ import {
   makeFsImporter,
   parse,
 } from 'react-docgen';
-import * as TsconfigPaths from 'tsconfig-paths';
+import * as TsconfigPaths from 'tsconfig-paths/src/index';
 import type { PluginOption } from 'vite';
 
 import actualNameHandler from './docgen-handlers/actualNameHandler';

--- a/code/frameworks/react-vite/src/preset.ts
+++ b/code/frameworks/react-vite/src/preset.ts
@@ -31,7 +31,9 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (config, { presets 
 
   if (reactDocgenOption === 'react-docgen-typescript' && typescriptPresent) {
     plugins.push(
-      require('@joshwooding/vite-plugin-react-docgen-typescript')({
+      await (
+        await import('@joshwooding/vite-plugin-react-docgen-typescript')
+      ).default({
         ...reactDocgenTypescriptOptions,
         // We *need* this set so that RDT returns default values in the same format as react-docgen
         savePropValueAsString: true,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6706,6 +6706,7 @@ __metadata:
     "@storybook/react": "workspace:*"
     "@types/node": "npm:^22.0.0"
     find-up: "npm:^5.0.0"
+    json5: "npm:^2.2.3"
     magic-string: "npm:^0.30.0"
     react-docgen: "npm:^7.0.0"
     resolve: "npm:^1.22.8"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6701,7 +6701,6 @@ __metadata:
   resolution: "@storybook/react-vite@workspace:frameworks/react-vite"
   dependencies:
     "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.3.0"
-    "@rollup/pluginutils": "npm:^5.0.2"
     "@storybook/builder-vite": "workspace:*"
     "@storybook/react": "workspace:*"
     "@types/node": "npm:^22.0.0"


### PR DESCRIPTION
## What I did

- [x] prebundle as much as possible in `frameworks/react-vite`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 0 B | 0.83 | 0% |
| initSize |  148 MB | 152 MB | 4.01 MB | 1.19 | 2.6% |
| diffSize |  69.3 MB | 73.3 MB | 4.01 MB | 0.69 | 5.5% |
| buildSize |  6.79 MB | 6.77 MB | -16.3 kB | -0.07 | -0.2% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | 0.58 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | 0.58 | 0% |
| buildPreviewSize |  2.99 MB | 2.97 MB | -16.3 kB | -0.23 | -0.5% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  16.5s | 11.7s | -4s -864ms | -0.34 | -41.6% |
| generateTime |  20.6s | 21.9s | 1.3s | 0.18 | 6% |
| initTime |  13.5s | 15.4s | 1.8s | 0.17 | 11.8% |
| buildTime |  8.2s | 10.4s | 2.2s | 0.13 | 21.2% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.7s | 5.8s | -830ms | -1.15 | -14.1% |
| devManagerResponsive |  4.1s | 4.4s | 263ms | -0.34 | 5.9% |
| devManagerHeaderVisible |  587ms | 531ms | -56ms | -0.9 | -10.5% |
| devManagerIndexVisible |  618ms | 563ms | -55ms | -0.87 | -9.8% |
| devStoryVisibleUncached |  1s | 1s | -4ms | -0.45 | -0.4% |
| devStoryVisible |  617ms | 564ms | -53ms | -0.86 | -9.4% |
| devAutodocsVisible |  495ms | 492ms | -3ms | -0.34 | -0.6% |
| devMDXVisible |  519ms | 435ms | -84ms | -1.13 | -19.3% |
| buildManagerHeaderVisible |  492ms | 518ms | 26ms | -0.41 | 5% |
| buildManagerIndexVisible |  495ms | 524ms | 29ms | -0.52 | 5.5% |
| buildStoryVisible |  525ms | 555ms | 30ms | -0.53 | 5.4% |
| buildAutodocsVisible |  445ms | 515ms | 70ms | 0.09 | 13.6% |
| buildMDXVisible |  496ms | 507ms | 11ms | -0.08 | 2.2% |

<!-- BENCHMARK_SECTION -->