### PR TITLE
Vue: Prebundle `renderer/vue`

### DIFF
--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -67,17 +67,17 @@
     "@storybook/preview-api": "workspace:^",
     "@storybook/theming": "workspace:^",
     "@vue/compiler-core": "^3.0.0",
-    "ts-dedent": "^2.0.0",
-    "type-fest": "~2.19",
-    "vue-component-type-helpers": "latest"
+    "ts-dedent": "^2.0.0"
   },
   "devDependencies": {
     "@digitak/esrun": "^3.2.2",
     "@testing-library/vue": "^8.0.0",
     "@types/prettier": "^3.0.0",
     "@vitejs/plugin-vue": "^4.4.0",
+    "type-fest": "~2.19",
     "typescript": "^5.3.2",
     "vue": "^3.2.47",
+    "vue-component-type-helpers": "latest",
     "vue-tsc": "latest"
   },
   "peerDependencies": {

--- a/code/renderers/vue3/src/docs/extractArgTypes.ts
+++ b/code/renderers/vue3/src/docs/extractArgTypes.ts
@@ -7,7 +7,11 @@ import {
 } from 'storybook/internal/docs-tools';
 import type { SBType, StrictArgTypes, StrictInputType } from 'storybook/internal/types';
 
-import type { VueDocgenInfo, VueDocgenInfoEntry, VueDocgenPlugin } from '@storybook/vue3-vite';
+import type {
+  VueDocgenInfo,
+  VueDocgenInfoEntry,
+  VueDocgenPlugin,
+} from '../../../../frameworks/vue3-vite/src/index';
 
 type PropertyMetaSchema = VueDocgenInfoEntry<'vue-component-meta', 'props'>['schema'];
 


### PR DESCRIPTION
## What I did

Prebundle `renderers/vue`, since it was a success for `renderers/react`...

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.7 MB | 78.7 MB | 1.67 kB | 0.75 | 0% |
| initSize |  148 MB | 148 MB | 1.67 kB | **-2.45** | 0% |
| diffSize |  69.3 MB | 69.3 MB | 0 B | **-2.35** | 0% |
| buildSize |  6.79 MB | 6.79 MB | 0 B | **2.96** | 0% |
| buildSbAddonsSize |  1.5 MB | 1.5 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.83 MB | 1.83 MB | 0 B | 0.5 | 0% |
| buildSbPreviewSize |  270 kB | 270 kB | 0 B | - | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.8 MB | 3.8 MB | 0 B | 0.5 | 0% |
| buildPreviewSize |  2.99 MB | 2.99 MB | 0 B | **3** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.3s | 5.9s | -5s -386ms | **-1.28** | 🔰-90.1% |
| generateTime |  19.7s | 21.6s | 1.9s | 0.22 | 9.1% |
| initTime |  12.8s | 14.6s | 1.8s | -0.13 | 12.4% |
| buildTime |  8.9s | 10.4s | 1.4s | 0.11 | 14.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6.7s | 5.6s | -1s -147ms | **-1.32** | 🔰-20.3% |
| devManagerResponsive |  4.6s | 3.7s | -823ms | **-1.39** | 🔰-21.8% |
| devManagerHeaderVisible |  616ms | 544ms | -72ms | -0.72 | -13.2% |
| devManagerIndexVisible |  647ms | 575ms | -72ms | -0.7 | -12.5% |
| devStoryVisibleUncached |  815ms | 609ms | -206ms | **-1.47** | 🔰-33.8% |
| devStoryVisible |  648ms | 577ms | -71ms | -0.69 | -12.3% |
| devAutodocsVisible |  537ms | 473ms | -64ms | -0.67 | -13.5% |
| devMDXVisible |  530ms | 435ms | -95ms | -1.11 | -21.8% |
| buildManagerHeaderVisible |  831ms | 485ms | -346ms | -0.73 | -71.3% |
| buildManagerIndexVisible |  856ms | 489ms | -367ms | -0.83 | -75.1% |
| buildStoryVisible |  857ms | 545ms | -312ms | -0.62 | -57.2% |
| buildAutodocsVisible |  477ms | 456ms | -21ms | -0.61 | -4.6% |
| buildMDXVisible |  466ms | 476ms | 10ms | -0.34 | 2.1% |

<!-- BENCHMARK_SECTION -->