### PR TITLE
Addon Test: Allow any Vitest version in peerDependencies to avoid install errors

### DIFF
--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -108,10 +108,10 @@
     "vitest": "^2.1.3"
   },
   "peerDependencies": {
-    "@vitest/browser": "^2.1.1",
-    "@vitest/runner": "^2.1.1",
+    "@vitest/browser": "*",
+    "@vitest/runner": "*",
     "storybook": "workspace:^",
-    "vitest": "^2.1.1"
+    "vitest": "*"
   },
   "peerDependenciesMeta": {
     "@vitest/browser": {

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -6257,10 +6257,10 @@ __metadata:
     typescript: "npm:^5.3.2"
     vitest: "npm:^2.1.3"
   peerDependencies:
-    "@vitest/browser": ^2.1.1
-    "@vitest/runner": ^2.1.1
+    "@vitest/browser": "*"
+    "@vitest/runner": "*"
     storybook: "workspace:^"
-    vitest: ^2.1.1
+    vitest: "*"
   peerDependenciesMeta:
     "@vitest/browser":
       optional: true


### PR DESCRIPTION
Updates `peerDependencies` for addon-tests to allow any version for Vitest packages, in order to prevent the installation from failing when an older Vitest package version is already present. The `add` command will check version compatibility instead.

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-29424-sha-612c2fbc`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-29424-sha-612c2fbc sandbox` or in an existing project with `npx storybook@0.0.0-pr-29424-sha-612c2fbc upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-29424-sha-612c2fbc`](https://npmjs.com/package/storybook/v/0.0.0-pr-29424-sha-612c2fbc) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`relax-peer-deps`](https://github.com/storybookjs/storybook/tree/relax-peer-deps) |
| **Commit** | [`612c2fbc`](https://github.com/storybookjs/storybook/commit/612c2fbc4c8318e87b3fdbb4afbc19d31a2bc4dd) |
| **Datetime** | Tue Oct 22 12:37:58 UTC 2024 (`1729600678`) |
| **Workflow run** | [11460327527](https://github.com/storybookjs/storybook/actions/runs/11460327527) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=29424`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This pull request updates the peerDependencies in the @storybook/experimental-addon-test package to allow any version of Vitest-related packages, aiming to prevent installation errors with older Vitest versions.

- Modified `code/addons/test/package.json` to set `"*"` as version for `@vitest/browser`, `@vitest/runner`, and `vitest` in peerDependencies
- Changed peerDependencies to be more flexible, allowing compatibility with various Vitest versions
- Aims to resolve potential conflicts when projects have pre-existing Vitest installations
- Shifts version compatibility check to the `add` command instead of installation time

<!-- /greptile_comment -->