### PR TITLE
Addon Test: Fix root entry files to point at correct dist files

### DIFF
--- a/code/addons/test/postinstall.cjs
+++ b/code/addons/test/postinstall.cjs
@@ -1,1 +1,1 @@
-module.exports = require('./dist/postinstall.cjs');
+module.exports = require('./dist/postinstall.js');

--- a/code/addons/test/preset.cjs
+++ b/code/addons/test/preset.cjs
@@ -1,3 +1,1 @@
-module.exports = {
-  ...require('./dist/preset.cjs'),
-};
+module.exports = require('./dist/preset.js');

--- a/code/addons/test/preset.js
+++ b/code/addons/test/preset.js
@@ -1,10 +1,1 @@
-const { checkActionsLoaded } = require('./dist/preset');
-
-function previewAnnotations(entry = [], options) {
-  checkActionsLoaded(options.configDir);
-  return entry;
-}
-
-module.exports = {
-  previewAnnotations,
-};
+export * from './dist/preset';


### PR DESCRIPTION
Several plain JS files at the root of the test addon were pointing at nonexistent/incorrect dist files. Also, preset.js was overriding the exports set in src/preset.ts causing the serverChannel to be missing.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.6 MB | 77.6 MB | 76 B | 0.6 | 0% |
| initSize |  143 MB | 143 MB | 76 B | **-1.98** | 0% |
| diffSize |  65.1 MB | 65.1 MB | 0 B | **-1.99** | 0% |
| buildSize |  6.87 MB | 6.87 MB | 0 B | -0.29 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | -0.62 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | 0 B | **2.38** | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | -0.42 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 0 B | -0.29 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | -0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  20.7s | 19.9s | -768ms | 0.98 | -3.8% |
| generateTime |  24.4s | 24s | -479ms | 1.03 | -2% |
| initTime |  16.6s | 17.3s | 689ms | **1.83** | 4% |
| buildTime |  7.8s | 8.6s | 717ms | -1.19 | 8.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.7s | 6.1s | 431ms | -0.83 | 7% |
| devManagerResponsive |  3.5s | 3.8s | 334ms | -1.1 | 8.6% |
| devManagerHeaderVisible |  543ms | 626ms | 83ms | -0.26 | 13.3% |
| devManagerIndexVisible |  622ms | 697ms | 75ms | -0.22 | 10.8% |
| devStoryVisibleUncached |  1.1s | 951ms | -184ms | -0.78 | -19.3% |
| devStoryVisible |  620ms | 695ms | 75ms | -0.1 | 10.8% |
| devAutodocsVisible |  486ms | 586ms | 100ms | -0.21 | 17.1% |
| devMDXVisible |  403ms | 539ms | 136ms | -0.54 | 25.2% |
| buildManagerHeaderVisible |  526ms | 564ms | 38ms | -0.8 | 6.7% |
| buildManagerIndexVisible |  542ms | 575ms | 33ms | -0.84 | 5.7% |
| buildStoryVisible |  518ms | 562ms | 44ms | -0.79 | 7.8% |
| buildAutodocsVisible |  447ms | 464ms | 17ms | -1.02 | 3.7% |
| buildMDXVisible |  434ms | 470ms | 36ms | -0.73 | 7.7% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Fixed incorrect distribution file paths in the test addon's root entry files and simplified preset exports to ensure proper serverChannel functionality.

- Changed `preset.js` to use ES module exports from `./dist/preset` instead of custom logic
- Updated `postinstall.cjs` to correctly require `./dist/postinstall.js`
- Modified `preset.cjs` to properly require `dist/preset.js` maintaining serverChannel exports
- Aligned all file paths with `package.json` exports configuration

<!-- /greptile_comment -->