### PR TITLE
Component test: Fix wording

### DIFF
--- a/code/addons/interactions/src/components/EmptyState.tsx
+++ b/code/addons/interactions/src/components/EmptyState.tsx
@@ -43,8 +43,8 @@ export const Empty = () => {
       title="Component testing"
       description={
         <>
-          Component tests allow you to verify the functional aspects of UIs. Write a play function
-          for your story and you&apos;ll see it run here.
+          Your component rendered successfully. Add a play function to this story to test its
+          functionality, which will be displayed here.
         </>
       }
       footer={

--- a/code/addons/interactions/src/components/EmptyState.tsx
+++ b/code/addons/interactions/src/components/EmptyState.tsx
@@ -4,20 +4,14 @@ import { EmptyTabContent, Link } from 'storybook/internal/components';
 import { useStorybookApi } from 'storybook/internal/manager-api';
 import { styled } from 'storybook/internal/theming';
 
-import { DocumentIcon, VideoIcon } from '@storybook/icons';
+import { DocumentIcon } from '@storybook/icons';
 
-import { DOCUMENTATION_LINK, TUTORIAL_VIDEO_LINK } from '../constants';
+import { DOCUMENTATION_LINK } from '../constants';
 
 const Links = styled.div(({ theme }) => ({
   display: 'flex',
   fontSize: theme.typography.size.s2 - 1,
   gap: 25,
-}));
-
-const Divider = styled.div(({ theme }) => ({
-  width: 1,
-  height: 16,
-  backgroundColor: theme.appBorderColor,
 }));
 
 export const Empty = () => {
@@ -46,19 +40,15 @@ export const Empty = () => {
 
   return (
     <EmptyTabContent
-      title="Interaction testing"
+      title="Component testing"
       description={
         <>
-          Interaction tests allow you to verify the functional aspects of UIs. Write a play function
+          Component tests allow you to verify the functional aspects of UIs. Write a play function
           for your story and you&apos;ll see it run here.
         </>
       }
       footer={
         <Links>
-          <Link href={TUTORIAL_VIDEO_LINK} target="_blank" withArrow>
-            <VideoIcon /> Watch 8m video
-          </Link>
-          <Divider />
           <Link href={docsUrl} target="_blank" withArrow>
             <DocumentIcon /> Read docs
           </Link>

--- a/code/addons/interactions/src/constants.ts
+++ b/code/addons/interactions/src/constants.ts
@@ -2,4 +2,4 @@ export const ADDON_ID = 'storybook/interactions';
 export const PANEL_ID = `${ADDON_ID}/panel`;
 
 export const TUTORIAL_VIDEO_LINK = 'https://youtu.be/Waht9qq7AoA';
-export const DOCUMENTATION_LINK = 'writing-tests/interaction-testing';
+export const DOCUMENTATION_LINK = 'writing-tests/component-testing';

--- a/code/addons/test/src/components/EmptyState.tsx
+++ b/code/addons/test/src/components/EmptyState.tsx
@@ -43,8 +43,8 @@ export const Empty = () => {
       title="Component testing"
       description={
         <>
-          Component tests allow you to verify the functional aspects of UIs. Write a play function
-          for your story and you&apos;ll see it run here.
+          Your component rendered successfully. Add a play function to this story to test its
+          functionality, which will be displayed here.
         </>
       }
       footer={

--- a/code/addons/test/src/components/EmptyState.tsx
+++ b/code/addons/test/src/components/EmptyState.tsx
@@ -4,20 +4,14 @@ import { EmptyTabContent, Link } from 'storybook/internal/components';
 import { useStorybookApi } from 'storybook/internal/manager-api';
 import { styled } from 'storybook/internal/theming';
 
-import { DocumentIcon, VideoIcon } from '@storybook/icons';
+import { DocumentIcon } from '@storybook/icons';
 
-import { DOCUMENTATION_LINK, TUTORIAL_VIDEO_LINK } from '../constants';
+import { DOCUMENTATION_LINK } from '../constants';
 
 const Links = styled.div(({ theme }) => ({
   display: 'flex',
   fontSize: theme.typography.size.s2 - 1,
   gap: 25,
-}));
-
-const Divider = styled.div(({ theme }) => ({
-  width: 1,
-  height: 16,
-  backgroundColor: theme.appBorderColor,
 }));
 
 export const Empty = () => {
@@ -46,19 +40,15 @@ export const Empty = () => {
 
   return (
     <EmptyTabContent
-      title="Interaction testing"
+      title="Component testing"
       description={
         <>
-          Interaction tests allow you to verify the functional aspects of UIs. Write a play function
+          Component tests allow you to verify the functional aspects of UIs. Write a play function
           for your story and you&apos;ll see it run here.
         </>
       }
       footer={
         <Links>
-          <Link href={TUTORIAL_VIDEO_LINK} target="_blank" withArrow>
-            <VideoIcon /> Watch 8m video
-          </Link>
-          <Divider />
           <Link href={docsUrl} target="_blank" withArrow>
             <DocumentIcon /> Read docs
           </Link>

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -126,7 +126,7 @@ export const babel = async (_: unknown, options: Options) => {
     ...babelDefault,
     // This override makes sure that we will never transpile babel further down then the browsers that storybook supports.
     // This is needed to support the mount property of the context described here:
-    // https://storybook.js.org/docs/writing-tests/interaction-testing#run-code-before-each-test
+    // https://storybook.js.org/docs/writing-tests/component-testing#run-code-before-each-test
     overrides: [
       ...(babelDefault?.overrides ?? []),
       {

--- a/code/core/src/preview-errors.ts
+++ b/code/core/src/preview-errors.ts
@@ -228,7 +228,7 @@ export class MountMustBeDestructuredError extends StorybookError {
       
       Note that Angular is not supported. As async/await is transpiled to support the zone.js polyfill. 
       
-      More info: https://storybook.js.org/docs/writing-tests/interaction-testing#run-code-before-the-component-gets-rendered
+      More info: https://storybook.js.org/docs/writing-tests/component-testing#run-code-before-the-component-gets-rendered
       
       Received the following play function:
       ${data.playFunction}`,

--- a/code/core/template/stories/indexer.stories.ts
+++ b/code/core/template/stories/indexer.stories.ts
@@ -4,7 +4,7 @@ import { expect } from '@storybook/test';
 
 export default {
   component: globalThis.Components.Pre,
-  args: { text: 'Check that id assertions in interaction tests are passing' },
+  args: { text: 'Check that id assertions in component tests are passing' },
   id: 'indexer-custom-meta-id',
 };
 

--- a/code/frameworks/angular/template/cli/page.stories.ts
+++ b/code/frameworks/angular/template/cli/page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<PageComponent>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/experimental-nextjs-vite/template/cli/js/Page.stories.js
+++ b/code/frameworks/experimental-nextjs-vite/template/cli/js/Page.stories.js
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/experimental-nextjs-vite/template/cli/ts-3-8/Page.stories.ts
+++ b/code/frameworks/experimental-nextjs-vite/template/cli/ts-3-8/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/experimental-nextjs-vite/template/cli/ts-4-9/Page.stories.ts
+++ b/code/frameworks/experimental-nextjs-vite/template/cli/ts-4-9/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/nextjs/template/cli/js/Page.stories.js
+++ b/code/frameworks/nextjs/template/cli/js/Page.stories.js
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/nextjs/template/cli/ts-3-8/Page.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts-3-8/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/frameworks/nextjs/template/cli/ts-4-9/Page.stories.ts
+++ b/code/frameworks/nextjs/template/cli/ts-4-9/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/html/template/cli/js/Page.stories.js
+++ b/code/renderers/html/template/cli/js/Page.stories.js
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/html/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/html/template/cli/ts-3-8/Page.stories.ts
@@ -16,7 +16,7 @@ export default meta;
 
 export const LoggedOut: StoryObj = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: StoryObj = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/html/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/html/template/cli/ts-4-9/Page.stories.ts
@@ -16,7 +16,7 @@ export default meta;
 
 export const LoggedOut: StoryObj = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: StoryObj = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/preact/template/cli/Page.stories.jsx
+++ b/code/renderers/preact/template/cli/Page.stories.jsx
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/react/template/cli/js/Page.stories.js
+++ b/code/renderers/react/template/cli/js/Page.stories.js
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/react/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/react/template/cli/ts-3-8/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/react/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/react/template/cli/ts-4-9/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/svelte/template/cli/js/Page.stories.js
+++ b/code/renderers/svelte/template/cli/js/Page.stories.js
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/svelte/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-3-8/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<Page>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/svelte/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/svelte/template/cli/ts-4-9/Page.stories.ts
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const LoggedOut: Story = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/code/renderers/vue3/template/cli/js/Page.stories.js
+++ b/code/renderers/vue3/template/cli/js/Page.stories.js
@@ -13,7 +13,7 @@ export default {
 
 export const LoggedOut = {};
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn = {
   render: () => ({
     components: {

--- a/code/renderers/vue3/template/cli/ts-3-8/Page.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-3-8/Page.stories.ts
@@ -21,7 +21,7 @@ const meta: Meta<typeof MyPage> = {
 export default meta;
 type Story = StoryObj<typeof MyPage>;
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }: any) => {
     const canvas = within(canvasElement);

--- a/code/renderers/vue3/template/cli/ts-4-9/Page.stories.ts
+++ b/code/renderers/vue3/template/cli/ts-4-9/Page.stories.ts
@@ -21,7 +21,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on interaction testing: https://storybook.js.org/docs/writing-tests/interaction-testing
+// More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
 export const LoggedIn: Story = {
   play: async ({ canvasElement }: any) => {
     const canvas = within(canvasElement);

--- a/docs/writing-tests/component-testing.mdx
+++ b/docs/writing-tests/component-testing.mdx
@@ -49,7 +49,7 @@ The test itself is defined inside a `play` function connected to a story. Here's
 
 {/* prettier-ignore-start */}
 
-<CodeSnippets path="login-form-with-play-function.md" usesCsf3 csf2Path="writing-tests/interaction-testing#snippet-login-form-with-play-function" />
+<CodeSnippets path="login-form-with-play-function.md" usesCsf3 csf2Path="writing-tests/component-testing#snippet-login-form-with-play-function" />
 
 {/* prettier-ignore-end */}
 
@@ -213,7 +213,7 @@ For complex flows, it can be worthwhile to group sets of related interactions to
 
 {/* prettier-ignore-start */}
 
-<CodeSnippets path="storybook-interactions-step-function.md" usesCsf3 csf2Path="writing-tests/interaction-testing#snippet-storybook-interactions-step-function" />
+<CodeSnippets path="storybook-interactions-step-function.md" usesCsf3 csf2Path="writing-tests/component-testing#snippet-storybook-interactions-step-function" />
 
 {/* prettier-ignore-end */}
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.2 MB | 78.2 MB | 0 B | 1.13 | 0% |
| initSize |  143 MB | 143 MB | -16.5 kB | 0.19 | 0% |
| diffSize |  65.2 MB | 65.1 MB | -16.5 kB | -0.29 | 0% |
| buildSize |  6.88 MB | 6.87 MB | -1.51 kB | **-28.98** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | -266 B | **-39.1** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | -967 B | **-19.57** | -0.1% |
| buildSbPreviewSize |  271 kB | 271 kB | -2 B | **-Infinity** | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | -1.24 kB | **-23.49** | 0% |
| buildPreviewSize |  3 MB | 3 MB | -271 B | **-Infinity** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.9s | 17.4s | -5s -486ms | 0.45 | -31.4% |
| generateTime |  23s | 20.9s | -2s -121ms | -0.34 | -10.1% |
| initTime |  15.5s | 15.6s | 142ms | 0.2 | 0.9% |
| buildTime |  8.3s | 7.6s | -727ms | -1.22 | -9.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5.8s | 389ms | -0.16 | 6.6% |
| devManagerResponsive |  3.4s | 3.4s | 89ms | -0.5 | 2.5% |
| devManagerHeaderVisible |  519ms | 623ms | 104ms | 0.81 | 16.7% |
| devManagerIndexVisible |  594ms | 695ms | 101ms | 0.78 | 14.5% |
| devStoryVisibleUncached |  862ms | 1.1s | 319ms | 0.39 | 27% |
| devStoryVisible |  592ms | 693ms | 101ms | 0.98 | 14.6% |
| devAutodocsVisible |  507ms | 517ms | 10ms | -0.15 | 1.9% |
| devMDXVisible |  520ms | 584ms | 64ms | 0.67 | 11% |
| buildManagerHeaderVisible |  490ms | 580ms | 90ms | 0.09 | 15.5% |
| buildManagerIndexVisible |  502ms | 598ms | 96ms | 0.09 | 16.1% |
| buildStoryVisible |  492ms | 573ms | 81ms | 0.02 | 14.1% |
| buildAutodocsVisible |  467ms | 517ms | 50ms | 0.89 | 9.7% |
| buildMDXVisible |  406ms | 455ms | 49ms | -0.06 | 10.8% |

<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of the pull request changes:

Updates terminology from 'interaction testing' to 'component testing' across Storybook's codebase for better consistency and clarity.

- Updated `EmptyState` components in interactions and test addons to use 'Component testing' title and description
- Changed documentation links from 'writing-tests/interaction-testing' to 'writing-tests/component-testing' across multiple files
- Updated comments and references in template files for all frameworks (React, Vue, Svelte, etc.) to use consistent terminology
- Simplified UI by removing video tutorial links and dividers from EmptyState components
- Updated error messages and documentation paths in core files to reflect new terminology

<!-- /greptile_comment -->