### PR TITLE
Core: Implement afterEach

### DIFF
--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -65,7 +65,7 @@
     "prep": "jiti ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@storybook/global": "^5.0.0",
     "ts-dedent": "^2.0.0"
   },

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -65,7 +65,7 @@
     "prep": "jiti ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@storybook/global": "^5.0.0",
     "ts-dedent": "^2.0.0"
   },

--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -75,7 +75,7 @@
     "prep": "jiti ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@storybook/global": "^5.0.0",
     "@storybook/icons": "^1.2.12",
     "@storybook/instrumenter": "workspace:*",

--- a/code/addons/test/package.json
+++ b/code/addons/test/package.json
@@ -75,7 +75,7 @@
     "prep": "jiti ../../../scripts/prepare/addon-bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@storybook/global": "^5.0.0",
     "@storybook/icons": "^1.2.12",
     "@storybook/instrumenter": "workspace:*",

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -277,7 +277,7 @@
     "prep": "jiti ./scripts/prep.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "better-opn": "^3.0.2",
     "browser-assert": "^1.2.1",
     "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -277,7 +277,7 @@
     "prep": "jiti ./scripts/prep.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "better-opn": "^3.0.2",
     "browser-assert": "^1.2.1",
     "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.test.ts
@@ -40,6 +40,7 @@ const buildStory = (overrides: Partial<PreparedStory> = {}): PreparedStory =>
     tags: [],
     applyLoaders: vi.fn(),
     applyBeforeEach: vi.fn(),
+    applyAfterEach: vi.fn(),
     unboundStoryFn: vi.fn(),
     playFunction: vi.fn(),
     mount: (context: StoryContext) => () => mountSpy(context),

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
@@ -317,15 +317,15 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
           }
           this.checkIfAborted(abortSignal);
 
-          await this.runPhase(abortSignal, 'afterEach', async () => {
-            await applyAfterEach(context);
-          });
-
           if (!ignoreUnhandledErrors && unhandledErrors.size > 0) {
             await this.runPhase(abortSignal, 'errored');
           } else {
             await this.runPhase(abortSignal, 'played');
           }
+
+          await this.runPhase(abortSignal, 'afterEach', async () => {
+            await applyAfterEach(context);
+          });
         } catch (error) {
           // Remove the loading screen, even if there was an error before rendering
           this.callbacks.showStoryDuringRender?.();

--- a/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
+++ b/code/core/src/preview-api/modules/preview-web/render/StoryRender.ts
@@ -33,6 +33,7 @@ export type RenderPhase =
   | 'rendering'
   | 'playing'
   | 'played'
+  | 'afterEach'
   | 'completed'
   | 'aborted'
   | 'errored';
@@ -132,7 +133,9 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
   }
 
   isPending() {
-    return ['loading', 'beforeEach', 'rendering', 'playing'].includes(this.phase as RenderPhase);
+    return ['loading', 'beforeEach', 'rendering', 'playing', 'afterEach'].includes(
+      this.phase as RenderPhase
+    );
   }
 
   async renderToElement(canvasElement: TRenderer['canvasElement']) {
@@ -180,6 +183,7 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
       tags,
       applyLoaders,
       applyBeforeEach,
+      applyAfterEach,
       unboundStoryFn,
       playFunction,
       runStep,
@@ -312,6 +316,10 @@ export class StoryRender<TRenderer extends Renderer> implements Render<TRenderer
             throw new NoStoryMountedError();
           }
           this.checkIfAborted(abortSignal);
+
+          await this.runPhase(abortSignal, 'afterEach', async () => {
+            await applyAfterEach(context);
+          });
 
           if (!ignoreUnhandledErrors && unhandledErrors.size > 0) {
             await this.runPhase(abortSignal, 'errored');

--- a/code/core/src/preview-api/modules/store/StoryStore.test.ts
+++ b/code/core/src/preview-api/modules/store/StoryStore.test.ts
@@ -645,6 +645,7 @@ describe('StoryStore', () => {
       expect(store.raw()).toMatchInlineSnapshot(`
         [
           {
+            "applyAfterEach": [Function],
             "applyBeforeEach": [Function],
             "applyLoaders": [Function],
             "argTypes": {
@@ -698,6 +699,7 @@ describe('StoryStore', () => {
             "usesMount": false,
           },
           {
+            "applyAfterEach": [Function],
             "applyBeforeEach": [Function],
             "applyLoaders": [Function],
             "argTypes": {
@@ -751,6 +753,7 @@ describe('StoryStore', () => {
             "usesMount": false,
           },
           {
+            "applyAfterEach": [Function],
             "applyBeforeEach": [Function],
             "applyLoaders": [Function],
             "argTypes": {

--- a/code/core/src/preview-api/modules/store/csf/composeConfigs.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/composeConfigs.test.ts
@@ -25,6 +25,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -53,6 +54,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -85,6 +87,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -123,6 +126,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -164,6 +168,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -196,6 +201,7 @@ describe('composeConfigs', () => {
       loaders: ['1', '2', '3', '4'],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -228,6 +234,7 @@ describe('composeConfigs', () => {
       loaders: ['1', '2', '3'],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -256,6 +263,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -285,6 +293,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       runStep: expect.any(Function),
       tags: [],
     });
@@ -317,6 +326,7 @@ describe('composeConfigs', () => {
       loaders: [],
       beforeAll: expect.any(Function),
       beforeEach: [],
+      afterEach: [],
       render: 'render-2',
       renderToCanvas: 'renderToCanvas-2',
       applyDecorators: 'applyDecorators-2',

--- a/code/core/src/preview-api/modules/store/csf/composeConfigs.ts
+++ b/code/core/src/preview-api/modules/store/csf/composeConfigs.ts
@@ -64,6 +64,7 @@ export function composeConfigs<TRenderer extends Renderer>(
     loaders: getArrayField(moduleExportList, 'loaders'),
     beforeAll: composeBeforeAllHooks(beforeAllHooks),
     beforeEach: getArrayField(moduleExportList, 'beforeEach'),
+    afterEach: getArrayField(moduleExportList, 'afterEach'),
     render: getSingletonField(moduleExportList, 'render'),
     renderToCanvas: getSingletonField(moduleExportList, 'renderToCanvas'),
     renderToDOM: getSingletonField(moduleExportList, 'renderToDOM'), // deprecated

--- a/code/core/src/preview-api/modules/store/csf/normalizeProjectAnnotations.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeProjectAnnotations.ts
@@ -26,6 +26,7 @@ export function normalizeProjectAnnotations<TRenderer extends Renderer>({
   decorators,
   loaders,
   beforeEach,
+  afterEach,
   globals,
   initialGlobals,
   ...annotations
@@ -44,6 +45,7 @@ export function normalizeProjectAnnotations<TRenderer extends Renderer>({
     decorators: normalizeArrays(decorators),
     loaders: normalizeArrays(loaders),
     beforeEach: normalizeArrays(beforeEach),
+    afterEach: normalizeArrays(afterEach),
     argTypesEnhancers: [
       ...(argTypesEnhancers || []),
       inferArgTypes,

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.test.ts
@@ -52,6 +52,7 @@ describe('normalizeStory', () => {
       const meta = { id: 'title', title: 'title' };
       expect(normalizeStory('storyExport', storyFn, meta)).toMatchInlineSnapshot(`
         {
+          "afterEach": [],
           "argTypes": {},
           "args": {},
           "beforeEach": [],
@@ -123,6 +124,7 @@ describe('normalizeStory', () => {
         const normalized = normalizeStory('storyExport', storyObj, meta);
         expect(normalized).toMatchInlineSnapshot(`
           {
+            "afterEach": [],
             "argTypes": {},
             "args": {},
             "beforeEach": [],
@@ -152,6 +154,7 @@ describe('normalizeStory', () => {
         const { moduleExport, ...normalized } = normalizeStory('storyExport', storyObj, meta);
         expect(normalized).toMatchInlineSnapshot(`
           {
+            "afterEach": [],
             "argTypes": {
               "storyArgType": {
                 "name": "storyArgType",
@@ -202,6 +205,7 @@ describe('normalizeStory', () => {
         const { moduleExport, ...normalized } = normalizeStory('storyExport', storyObj, meta);
         expect(normalized).toMatchInlineSnapshot(`
           {
+            "afterEach": [],
             "argTypes": {
               "storyArgType": {
                 "name": "storyArgType",

--- a/code/core/src/preview-api/modules/store/csf/normalizeStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/normalizeStory.ts
@@ -60,6 +60,10 @@ export function normalizeStory<TRenderer extends Renderer>(
     ...normalizeArrays(storyObject.beforeEach),
     ...normalizeArrays(story?.beforeEach),
   ];
+  const afterEach = [
+    ...normalizeArrays(storyObject.afterEach),
+    ...normalizeArrays(story?.afterEach),
+  ];
   const { render, play, tags = [], globals = {} } = storyObject;
 
   // eslint-disable-next-line no-underscore-dangle
@@ -75,6 +79,7 @@ export function normalizeStory<TRenderer extends Renderer>(
     argTypes: normalizeInputTypes(argTypes),
     loaders,
     beforeEach,
+    afterEach,
     globals,
     ...(render && { render }),
     ...(userStoryFn && { userStoryFn }),

--- a/code/core/src/preview-api/modules/store/csf/portable-stories.ts
+++ b/code/core/src/preview-api/modules/store/csf/portable-stories.ts
@@ -408,4 +408,6 @@ async function runStory<TRenderer extends Renderer>(
     }
     await playFunction(context);
   }
+
+  await story.applyAfterEach(context);
 }

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
@@ -792,6 +792,7 @@ describe('prepareMeta', () => {
       story,
       applyLoaders,
       applyBeforeEach,
+      applyAfterEach,
       originalStoryFn,
       unboundStoryFn,
       undecoratedStoryFn,

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.ts
@@ -92,6 +92,20 @@ export function prepareStory<TRenderer extends Renderer>(
     return cleanupCallbacks;
   };
 
+  const applyAfterEach = async (context: StoryContext<TRenderer>): Promise<void> => {
+    const reversedFinalizers = [
+      ...normalizeArrays(projectAnnotations.afterEach),
+      ...normalizeArrays(componentAnnotations.afterEach),
+      ...normalizeArrays(storyAnnotations.afterEach),
+    ].reverse();
+    for (const finalizer of reversedFinalizers) {
+      if (context.abortSignal.aborted) {
+        return;
+      }
+      await finalizer(context);
+    }
+  };
+
   const undecoratedStoryFn = (context: StoryContext<TRenderer>) =>
     (context.originalStoryFn as ArgsStoryFn<TRenderer>)(context.args, context);
 
@@ -150,6 +164,7 @@ export function prepareStory<TRenderer extends Renderer>(
     unboundStoryFn,
     applyLoaders,
     applyBeforeEach,
+    applyAfterEach,
     playFunction,
     runStep,
     mount,

--- a/code/core/src/types/modules/story.ts
+++ b/code/core/src/types/modules/story.ts
@@ -109,6 +109,7 @@ export type PreparedStory<TRenderer extends Renderer = Renderer> =
     unboundStoryFn: LegacyStoryFn<TRenderer>;
     applyLoaders: (context: StoryContext<TRenderer>) => Promise<StoryContext<TRenderer>['loaded']>;
     applyBeforeEach: (context: StoryContext<TRenderer>) => Promise<CleanupCallback[]>;
+    applyAfterEach: (context: StoryContext<TRenderer>) => Promise<void>;
     playFunction?: (context: StoryContext<TRenderer>) => Promise<void> | void;
     runStep: StepRunner<TRenderer>;
     mount: (context: StoryContext<TRenderer>) => () => Promise<Canvas>;

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -43,7 +43,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@storybook/icons": "^1.2.12",
     "ts-dedent": "^2.0.0"
   },

--- a/code/lib/blocks/package.json
+++ b/code/lib/blocks/package.json
@@ -43,7 +43,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@storybook/icons": "^1.2.12",
     "ts-dedent": "^2.0.0"
   },

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -58,7 +58,7 @@
     "@babel/preset-env": "^7.24.4",
     "@babel/types": "^7.24.0",
     "@storybook/core": "workspace:*",
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@types/cross-spawn": "^6.0.2",
     "cross-spawn": "^7.0.3",
     "es-toolkit": "^1.22.0",

--- a/code/lib/codemod/package.json
+++ b/code/lib/codemod/package.json
@@ -58,7 +58,7 @@
     "@babel/preset-env": "^7.24.4",
     "@babel/types": "^7.24.0",
     "@storybook/core": "workspace:*",
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@types/cross-spawn": "^6.0.2",
     "cross-spawn": "^7.0.3",
     "es-toolkit": "^1.22.0",

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -44,7 +44,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "es-toolkit": "^1.22.0",
     "estraverse": "^5.2.0",
     "prettier": "^3.1.1"

--- a/code/lib/source-loader/package.json
+++ b/code/lib/source-loader/package.json
@@ -44,7 +44,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "es-toolkit": "^1.22.0",
     "estraverse": "^5.2.0",
     "prettier": "^3.1.1"

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -43,7 +43,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@storybook/global": "^5.0.0",
     "@storybook/instrumenter": "workspace:*",
     "@testing-library/dom": "10.4.0",

--- a/code/lib/test/package.json
+++ b/code/lib/test/package.json
@@ -43,7 +43,7 @@
     "prep": "jiti ../../../scripts/prepare/bundle.ts"
   },
   "dependencies": {
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@storybook/global": "^5.0.0",
     "@storybook/instrumenter": "workspace:*",
     "@testing-library/dom": "10.4.0",

--- a/code/lib/test/template/stories/before-each.stories.ts
+++ b/code/lib/test/template/stories/before-each.stories.ts
@@ -3,44 +3,10 @@ import { expect, getByRole, mocked, spyOn, userEvent } from '@storybook/test';
 
 const meta = {
   component: globalThis.Components.Button,
-  loaders() {
-    spyOn(console, 'log').mockName('console.log');
-    console.log('1 - [from loaders]');
-  },
-  beforeEach() {
-    console.log('2 - [from meta beforeEach]');
-  },
+  args: { label: 'Button' },
 };
 
 export default meta;
-
-export const BeforeEachOrder = {
-  parameters: { chromatic: { disable: true } },
-  beforeEach() {
-    console.log('3 - [from story beforeEach]');
-  },
-  decorators: (StoryFn: any) => {
-    console.log('4 - [from decorator]');
-    return StoryFn();
-  },
-  args: {
-    label: 'Button',
-    onClick: () => {
-      console.log('5 - [from onClick]');
-    },
-  },
-  async play({ canvasElement }: any) {
-    await userEvent.click(getByRole(canvasElement, 'button'));
-
-    await expect(mocked(console.log).mock.calls).toEqual([
-      ['1 - [from loaders]'],
-      ['2 - [from meta beforeEach]'],
-      ['3 - [from story beforeEach]'],
-      ['4 - [from decorator]'],
-      ['5 - [from onClick]'],
-    ]);
-  },
-};
 
 export const before_each_and_loaders_can_extend_context = {
   parameters: { chromatic: { disable: true } },

--- a/code/lib/test/template/stories/mount-in-play.stories.ts
+++ b/code/lib/test/template/stories/mount-in-play.stories.ts
@@ -1,57 +1,8 @@
-import { expect, fn, getByRole, mocked, spyOn, userEvent } from '@storybook/test';
+import { expect, fn } from '@storybook/test';
 
-const meta = {
-  component: globalThis.Components.Button,
-  loaders() {
-    spyOn(console, 'log').mockName('console.log');
-    console.log('1 - [from loaders]');
-  },
-  beforeEach() {
-    console.log('2 - [from meta beforeEach]');
-  },
-  async afterEach() {
-    console.log('9 - [from meta afterEach]');
-
-    await expect(mocked(console.log).mock.calls).toEqual([
-      ['1 - [from loaders]'],
-      ['2 - [from meta beforeEach]'],
-      ['3 - [from story beforeEach]'],
-      ['4 - [before mount]'],
-      ['5 - [from decorator]'],
-      ['6 - [after mount]'],
-      ['7 - [from onClick]'],
-      ['8 - [from story afterEach]'],
-      ['9 - [from meta afterEach]'],
-    ]);
-  },
-};
+const meta = { component: globalThis.Components.Button };
 
 export default meta;
-
-export const OrderOfHooks = {
-  beforeEach() {
-    console.log('3 - [from story beforeEach]');
-  },
-  decorators: (storyFn) => {
-    console.log('5 - [from decorator]');
-    return storyFn();
-  },
-  args: {
-    label: 'Button',
-    onClick: () => {
-      console.log('7 - [from onClick]');
-    },
-  },
-  async play({ mount, canvasElement }) {
-    console.log('4 - [before mount]');
-    await mount();
-    console.log('6 - [after mount]');
-    await userEvent.click(getByRole(canvasElement, 'button'));
-  },
-  async afterEach() {
-    console.log('8 - [from story afterEach]');
-  },
-};
 
 export const MountShouldBeDestructured = {
   parameters: { chromatic: { disable: true } },

--- a/code/lib/test/template/stories/mount-in-play.stories.ts
+++ b/code/lib/test/template/stories/mount-in-play.stories.ts
@@ -49,7 +49,6 @@ export const OrderOfHooks = {
     await userEvent.click(getByRole(canvasElement, 'button'));
   },
   async afterEach() {
-    console.log(1);
     console.log('8 - [from story afterEach]');
   },
 };

--- a/code/lib/test/template/stories/mount-in-play.stories.ts
+++ b/code/lib/test/template/stories/mount-in-play.stories.ts
@@ -49,6 +49,7 @@ export const OrderOfHooks = {
     await userEvent.click(getByRole(canvasElement, 'button'));
   },
   async afterEach() {
+    console.log(1);
     console.log('8 - [from story afterEach]');
   },
 };

--- a/code/lib/test/template/stories/mount-in-play.stories.ts
+++ b/code/lib/test/template/stories/mount-in-play.stories.ts
@@ -9,11 +9,26 @@ const meta = {
   beforeEach() {
     console.log('2 - [from meta beforeEach]');
   },
+  async afterEach() {
+    console.log('9 - [from meta afterEach]');
+
+    await expect(mocked(console.log).mock.calls).toEqual([
+      ['1 - [from loaders]'],
+      ['2 - [from meta beforeEach]'],
+      ['3 - [from story beforeEach]'],
+      ['4 - [before mount]'],
+      ['5 - [from decorator]'],
+      ['6 - [after mount]'],
+      ['7 - [from onClick]'],
+      ['8 - [from story afterEach]'],
+      ['9 - [from meta afterEach]'],
+    ]);
+  },
 };
 
 export default meta;
 
-export const MountInPlay = {
+export const OrderOfHooks = {
   beforeEach() {
     console.log('3 - [from story beforeEach]');
   },
@@ -32,15 +47,9 @@ export const MountInPlay = {
     await mount();
     console.log('6 - [after mount]');
     await userEvent.click(getByRole(canvasElement, 'button'));
-    await expect(mocked(console.log).mock.calls).toEqual([
-      ['1 - [from loaders]'],
-      ['2 - [from meta beforeEach]'],
-      ['3 - [from story beforeEach]'],
-      ['4 - [before mount]'],
-      ['5 - [from decorator]'],
-      ['6 - [after mount]'],
-      ['7 - [from onClick]'],
-    ]);
+  },
+  async afterEach() {
+    console.log('8 - [from story afterEach]');
   },
 };
 

--- a/code/lib/test/template/stories/order-of-hooks.ts
+++ b/code/lib/test/template/stories/order-of-hooks.ts
@@ -1,0 +1,54 @@
+import { expect, fn, getByRole, mocked, spyOn, userEvent } from '@storybook/test';
+
+const meta = {
+  component: globalThis.Components.Button,
+  loaders() {
+    spyOn(console, 'log').mockName('console.log');
+    console.log('1 - [from loaders]');
+  },
+  beforeEach() {
+    console.log('2 - [from meta beforeEach]');
+  },
+  async afterEach() {
+    console.log('9 - [from meta afterEach]');
+
+    await expect(mocked(console.log).mock.calls).toEqual([
+      ['1 - [from loaders]'],
+      ['2 - [from meta beforeEach]'],
+      ['3 - [from story beforeEach]'],
+      ['4 - [before mount]'],
+      ['5 - [from decorator]'],
+      ['6 - [after mount]'],
+      ['7 - [from onClick]'],
+      ['8 - [from story afterEach]'],
+      ['9 - [from meta afterEach]'],
+    ]);
+  },
+};
+
+export default meta;
+
+export const OrderOfHooks = {
+  beforeEach() {
+    console.log('3 - [from story beforeEach]');
+  },
+  decorators: (storyFn) => {
+    console.log('5 - [from decorator]');
+    return storyFn();
+  },
+  args: {
+    label: 'Button',
+    onClick: () => {
+      console.log('7 - [from onClick]');
+    },
+  },
+  async play({ mount, canvasElement }) {
+    console.log('4 - [before mount]');
+    await mount();
+    console.log('6 - [after mount]');
+    await userEvent.click(getByRole(canvasElement, 'button'));
+  },
+  async afterEach() {
+    console.log('8 - [from story afterEach]');
+  },
+};

--- a/code/package.json
+++ b/code/package.json
@@ -123,7 +123,7 @@
     "@storybook/codemod": "workspace:*",
     "@storybook/core": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/ember": "workspace:*",
     "@storybook/eslint-config-storybook": "^4.0.0",

--- a/code/package.json
+++ b/code/package.json
@@ -123,7 +123,7 @@
     "@storybook/codemod": "workspace:*",
     "@storybook/core": "workspace:*",
     "@storybook/core-webpack": "workspace:*",
-    "@storybook/csf": "0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@storybook/csf-plugin": "workspace:*",
     "@storybook/ember": "workspace:*",
     "@storybook/eslint-config-storybook": "^4.0.0",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@storybook/components": "workspace:*",
-    "@storybook/csf": "^0.1.11",
+    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "workspace:*",
     "@storybook/preview-api": "workspace:*",

--- a/code/renderers/server/package.json
+++ b/code/renderers/server/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@storybook/components": "workspace:*",
-    "@storybook/csf": "0.1.12--canary.109.4d1d54a.0",
+    "@storybook/csf": "0.1.12--canary.109.1cc9957.0",
     "@storybook/global": "^5.0.0",
     "@storybook/manager-api": "workspace:*",
     "@storybook/preview-api": "workspace:*",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5541,7 +5541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-links@workspace:addons/links"
   dependencies:
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/global": "npm:^5.0.0"
     ts-dedent: "npm:^2.0.0"
     typescript: "npm:^5.3.2"
@@ -5767,7 +5767,7 @@ __metadata:
   resolution: "@storybook/blocks@workspace:lib/blocks"
   dependencies:
     "@storybook/addon-actions": "workspace:*"
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/icons": "npm:^1.2.12"
     "@storybook/react": "workspace:*"
     "@storybook/test": "workspace:*"
@@ -5937,7 +5937,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.24.4"
     "@babel/types": "npm:^7.24.0"
     "@storybook/core": "workspace:*"
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@types/cross-spawn": "npm:^6.0.2"
     "@types/jscodeshift": "npm:^0.11.10"
     ansi-regex: "npm:^6.0.1"
@@ -6033,7 +6033,7 @@ __metadata:
     "@radix-ui/react-dialog": "npm:^1.0.5"
     "@radix-ui/react-scroll-area": "npm:1.2.0-rc.7"
     "@radix-ui/react-slot": "npm:^1.0.2"
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/docs-mdx": "npm:4.0.0-next.1"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.12"
@@ -6172,12 +6172,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.1.11, @storybook/csf@npm:^0.1.11":
-  version: 0.1.11
-  resolution: "@storybook/csf@npm:0.1.11"
+"@storybook/csf@npm:0.1.12--canary.109.4d1d54a.0":
+  version: 0.1.12--canary.109.4d1d54a.0
+  resolution: "@storybook/csf@npm:0.1.12--canary.109.4d1d54a.0"
   dependencies:
     type-fest: "npm:^2.19.0"
-  checksum: 10c0/c5329fc13e7d762049b5c91df1bc1c0e510a1a898c401b72b68f1ff64139a85ab64a92f8e681d2fcb226c0a4a55d0f23b569b2bdb517e0f067bd05ea46228356
+  checksum: 10c0/a86057da006075bff2dfd6a155d7553dfe5878bf2459151a90df9d123f3744aa7c8ccee713adfc77c4e82d9364619c09bebbca0a9d65685f969dc041a22937f7
   languageName: node
   linkType: hard
 
@@ -6244,7 +6244,7 @@ __metadata:
   resolution: "@storybook/experimental-addon-test@workspace:addons/test"
   dependencies:
     "@devtools-ds/object-inspector": "npm:^1.1.2"
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.12"
     "@storybook/instrumenter": "workspace:*"
@@ -6866,7 +6866,7 @@ __metadata:
     "@storybook/codemod": "workspace:*"
     "@storybook/core": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": "npm:0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/ember": "workspace:*"
     "@storybook/eslint-config-storybook": "npm:^4.0.0"
@@ -7012,7 +7012,7 @@ __metadata:
   resolution: "@storybook/server@workspace:renderers/server"
   dependencies:
     "@storybook/components": "workspace:*"
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
     "@storybook/preview-api": "workspace:*"
@@ -7029,7 +7029,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     es-toolkit: "npm:^1.22.0"
     estraverse: "npm:^5.2.0"
     prettier: "npm:^3.1.1"
@@ -7143,7 +7143,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/test@workspace:lib/test"
   dependencies:
-    "@storybook/csf": "npm:^0.1.11"
+    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/instrumenter": "workspace:*"
     "@testing-library/dom": "npm:10.4.0"

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5541,7 +5541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/addon-links@workspace:addons/links"
   dependencies:
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/global": "npm:^5.0.0"
     ts-dedent: "npm:^2.0.0"
     typescript: "npm:^5.3.2"
@@ -5767,7 +5767,7 @@ __metadata:
   resolution: "@storybook/blocks@workspace:lib/blocks"
   dependencies:
     "@storybook/addon-actions": "workspace:*"
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/icons": "npm:^1.2.12"
     "@storybook/react": "workspace:*"
     "@storybook/test": "workspace:*"
@@ -5937,7 +5937,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.24.4"
     "@babel/types": "npm:^7.24.0"
     "@storybook/core": "workspace:*"
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@types/cross-spawn": "npm:^6.0.2"
     "@types/jscodeshift": "npm:^0.11.10"
     ansi-regex: "npm:^6.0.1"
@@ -6033,7 +6033,7 @@ __metadata:
     "@radix-ui/react-dialog": "npm:^1.0.5"
     "@radix-ui/react-scroll-area": "npm:1.2.0-rc.7"
     "@radix-ui/react-slot": "npm:^1.0.2"
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/docs-mdx": "npm:4.0.0-next.1"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.12"
@@ -6172,12 +6172,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook/csf@npm:0.1.12--canary.109.4d1d54a.0":
-  version: 0.1.12--canary.109.4d1d54a.0
-  resolution: "@storybook/csf@npm:0.1.12--canary.109.4d1d54a.0"
+"@storybook/csf@npm:0.1.12--canary.109.1cc9957.0":
+  version: 0.1.12--canary.109.1cc9957.0
+  resolution: "@storybook/csf@npm:0.1.12--canary.109.1cc9957.0"
   dependencies:
     type-fest: "npm:^2.19.0"
-  checksum: 10c0/a86057da006075bff2dfd6a155d7553dfe5878bf2459151a90df9d123f3744aa7c8ccee713adfc77c4e82d9364619c09bebbca0a9d65685f969dc041a22937f7
+  checksum: 10c0/2c76529d168a7bfc39f6a8d42b5485df7e1e6d08af43a420e476cdc850689c0ce999e659a3e491b30a512034c668ed594872d11f51d0fd5222714d7a85911287
   languageName: node
   linkType: hard
 
@@ -6244,7 +6244,7 @@ __metadata:
   resolution: "@storybook/experimental-addon-test@workspace:addons/test"
   dependencies:
     "@devtools-ds/object-inspector": "npm:^1.1.2"
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^1.2.12"
     "@storybook/instrumenter": "workspace:*"
@@ -6866,7 +6866,7 @@ __metadata:
     "@storybook/codemod": "workspace:*"
     "@storybook/core": "workspace:*"
     "@storybook/core-webpack": "workspace:*"
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/csf-plugin": "workspace:*"
     "@storybook/ember": "workspace:*"
     "@storybook/eslint-config-storybook": "npm:^4.0.0"
@@ -7012,7 +7012,7 @@ __metadata:
   resolution: "@storybook/server@workspace:renderers/server"
   dependencies:
     "@storybook/components": "workspace:*"
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/manager-api": "workspace:*"
     "@storybook/preview-api": "workspace:*"
@@ -7029,7 +7029,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/source-loader@workspace:lib/source-loader"
   dependencies:
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     es-toolkit: "npm:^1.22.0"
     estraverse: "npm:^5.2.0"
     prettier: "npm:^3.1.1"
@@ -7143,7 +7143,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@storybook/test@workspace:lib/test"
   dependencies:
-    "@storybook/csf": "npm:0.1.12--canary.109.4d1d54a.0"
+    "@storybook/csf": "npm:0.1.12--canary.109.1cc9957.0"
     "@storybook/global": "npm:^5.0.0"
     "@storybook/instrumenter": "workspace:*"
     "@testing-library/dom": "npm:10.4.0"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Working on top of this csf canary:
https://github.com/ComponentDriven/csf/pull/109

To implement this RFC:
https://github.com/storybookjs/storybook/discussions/29583

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  78.2 MB | 78.2 MB | 0 B | 1.13 | 0% |
| initSize |  143 MB | 143 MB | 2.15 kB | **1.38** | 0% |
| diffSize |  65.2 MB | 65.2 MB | 2.15 kB | 0.91 | 0% |
| buildSize |  6.88 MB | 6.88 MB | 1.32 kB | **28.17** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 820 B | **123.53** | 0.1% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.9 MB | 1.9 MB | -100 B | -0.65 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 596 B | **Infinity** | 0.2% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.88 MB | 3.88 MB | 1.32 kB | **28.17** | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | - | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  22.9s | 25.8s | 2.8s | **1.69** | 🔺11% |
| generateTime |  23s | 21.9s | -1s -72ms | -0.11 | -4.9% |
| initTime |  15.5s | 15s | -452ms | -0.19 | -3% |
| buildTime |  8.3s | 9.1s | 811ms | 0.21 | 8.9% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 5.6s | 234ms | -0.4 | 4.1% |
| devManagerResponsive |  3.4s | 3.6s | 201ms | -0.18 | 5.6% |
| devManagerHeaderVisible |  519ms | 589ms | 70ms | 0.29 | 11.9% |
| devManagerIndexVisible |  594ms | 621ms | 27ms | -0.15 | 4.3% |
| devStoryVisibleUncached |  862ms | 1.1s | 322ms | 0.41 | 27.2% |
| devStoryVisible |  592ms | 620ms | 28ms | 0.01 | 4.5% |
| devAutodocsVisible |  507ms | 534ms | 27ms | 0.08 | 5.1% |
| devMDXVisible |  520ms | 498ms | -22ms | -0.38 | -4.4% |
| buildManagerHeaderVisible |  490ms | 491ms | 1ms | -1.19 | 0.2% |
| buildManagerIndexVisible |  502ms | 507ms | 5ms | -1.15 | 1% |
| buildStoryVisible |  492ms | 486ms | -6ms | -1.23 | -1.2% |
| buildAutodocsVisible |  467ms | 419ms | -48ms | -0.85 | -11.5% |
| buildMDXVisible |  406ms | 443ms | 37ms | -0.25 | 8.4% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my summary of the PR implementing afterEach functionality in Storybook:

Adds afterEach lifecycle hook to Storybook's story execution pipeline, allowing cleanup operations to be performed after each story runs, with proper phase management and error handling.

- Added `applyAfterEach` to `PreparedStory` type and implementation to execute finalizers in reverse order (story -> component -> project)
- Added 'afterEach' phase to `RenderPhase` and updated `StoryRender` to run afterEach hooks before transitioning to 'played' or 'errored' states
- Added `afterEach` field to `composeConfigs` return object using existing `getArrayField` helper
- Added `story.applyAfterEach(context)` call in `runStory` function with proper abort signal handling
- Updated CSF dependency to canary version 0.1.12--canary.109.4d1d54a.0 across multiple packages

<!-- /greptile_comment -->