### PR TITLE
CLI: Select Vue renderer when initializing Nuxt projects

### DIFF
--- a/code/core/src/cli/project_types.ts
+++ b/code/core/src/cli/project_types.ts
@@ -242,10 +242,6 @@ export const supportedTemplates: TemplateConfiguration[] = [
 // users an "Unsupported framework" message
 export const unsupportedTemplate: TemplateConfiguration = {
   preset: ProjectType.UNSUPPORTED,
-  dependencies: {
-    // TODO(blaine): Remove when we support Nuxt 3
-    nuxt: (versionRange) => eqMajor(versionRange, 3),
-  },
   matcherFunction: ({ dependencies }) => {
     return dependencies?.some(Boolean) ?? false;
   },


### PR DESCRIPTION
Closes #29704

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 222 B | -0.61 | 0% |
| initSize |  130 MB | 130 MB | -32 B | **-2.99** | 0% |
| diffSize |  52.4 MB | 52.4 MB | -254 B | **-3** | 0% |
| buildSize |  6.83 MB | 6.83 MB | 0 B | **1.84** | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | 0.61 | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | 1.11 | 0% |
| buildSbPreviewSize |  271 kB | 271 kB | 0 B | 0.52 | 0% |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.84 MB | 3.84 MB | 0 B | 0.97 | 0% |
| buildPreviewSize |  3 MB | 3 MB | 0 B | **2.98** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  8.7s | 22s | 13.3s | 0.91 | 60.5% |
| generateTime |  28.8s | 21.2s | -7s -658ms | -0.19 | -36.1% |
| initTime |  19.7s | 14.1s | -5s -591ms | -0.32 | -39.5% |
| buildTime |  10s | 9.2s | -748ms | 0.46 | -8.1% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.4s | 4.2s | -163ms | **-1.34** | -3.8% |
| devManagerResponsive |  3.3s | 3.1s | -179ms | -0.85 | -5.7% |
| devManagerHeaderVisible |  539ms | 487ms | -52ms | -0.71 | -10.7% |
| devManagerIndexVisible |  601ms | 516ms | -85ms | -0.83 | -16.5% |
| devStoryVisibleUncached |  1.7s | 1.3s | -404ms | 0.3 | -29.6% |
| devStoryVisible |  566ms | 517ms | -49ms | -0.77 | -9.5% |
| devAutodocsVisible |  493ms | 454ms | -39ms | -0.49 | -8.6% |
| devMDXVisible |  482ms | 450ms | -32ms | -0.61 | -7.1% |
| buildManagerHeaderVisible |  476ms | 497ms | 21ms | -0.51 | 4.2% |
| buildManagerIndexVisible |  486ms | 516ms | 30ms | -0.5 | 5.8% |
| buildStoryVisible |  470ms | 495ms | 25ms | -0.51 | 5.1% |
| buildAutodocsVisible |  417ms | 401ms | -16ms | -0.61 | -4% |
| buildMDXVisible |  387ms | 406ms | 19ms | -0.52 | 4.7% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR removes Nuxt 3 from being marked as an unsupported framework in Storybook's project type detection system, allowing Nuxt projects to use the Vue renderer by default.

- Removed Nuxt-specific dependency check from `unsupportedTemplate` configuration in `code/core/src/cli/project_types.ts`
- Nuxt projects will now automatically fall back to using the Vue3 renderer and configuration
- Change simplifies framework detection by treating Nuxt as a Vue-based project
- Improves developer experience by enabling Storybook support for Nuxt projects without special handling



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->