### PR TITLE
Build: Remove JS templates in sandboxes generation/testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -912,19 +912,19 @@ workflows:
           requires:
             - unit-tests
       - create-sandboxes:
-          parallelism: 20
+          parallelism: 19
           requires:
             - build
       - build-sandboxes:
-          parallelism: 20
+          parallelism: 19
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 17
+          parallelism: 16
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 15
+          parallelism: 14
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -932,7 +932,7 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 15
+          parallelism: 14
           requires:
             - build-sandboxes
       - vitest-integration:
@@ -986,22 +986,22 @@ workflows:
           requires:
             - build
       - create-sandboxes:
-          parallelism: 38
+          parallelism: 29
           requires:
             - build
       # - smoke-test-sandboxes: # disabled for now
       #     requires:
       #       - create-sandboxes
       - build-sandboxes:
-          parallelism: 38
+          parallelism: 29
           requires:
             - create-sandboxes
       - chromatic-sandboxes:
-          parallelism: 35
+          parallelism: 26
           requires:
             - build-sandboxes
       - e2e-production:
-          parallelism: 33
+          parallelism: 24
           requires:
             - build-sandboxes
       - e2e-dev:
@@ -1009,11 +1009,11 @@ workflows:
           requires:
             - create-sandboxes
       - test-runner-production:
-          parallelism: 33
+          parallelism: 24
           requires:
             - build-sandboxes
       - vitest-integration:
-          parallelism: 11
+          parallelism: 7
           requires:
             - create-sandboxes
       - test-portable-stories:

--- a/code/lib/cli-storybook/src/sandbox-templates.ts
+++ b/code/lib/cli-storybook/src/sandbox-templates.ts
@@ -1,5 +1,5 @@
 import type { ConfigFile } from 'storybook/internal/csf-tools';
-import type { StoriesEntry, StorybookConfigRaw } from 'storybook/internal/types';
+import type { StorybookConfigRaw } from 'storybook/internal/types';
 
 export type SkippableTask =
   | 'smoke-test'
@@ -91,54 +91,6 @@ type BaseTemplates = Template & {
 };
 
 const baseTemplates = {
-  'cra/default-js': {
-    name: 'Create React App Latest (Webpack | JavaScript)',
-    script: `
-      npx create-react-app {{beforeDir}} && cd {{beforeDir}} && \
-      jq '.browserslist.production[0] = ">0.9%"' package.json > tmp.json && mv tmp.json package.json
-    `,
-    expected: {
-      // TODO: change this to @storybook/cra once that package is created
-      framework: '@storybook/react-webpack5',
-      renderer: '@storybook/react',
-      builder: '@storybook/builder-webpack5',
-    },
-
-    skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
-    modifications: {
-      extraDependencies: ['prop-types'],
-      mainConfig: (config) => {
-        const stories = config.getFieldValue<Array<StoriesEntry>>(['stories']);
-        return {
-          stories: stories?.map((s) => {
-            if (typeof s === 'string') {
-              return s.replace(/\|(tsx?|ts)\b|\b(tsx?|ts)\|/g, '');
-            } else {
-              return s;
-            }
-          }),
-        };
-      },
-    },
-  },
-  'cra/default-ts': {
-    name: 'Create React App Latest (Webpack | TypeScript)',
-    script: `
-      npx create-react-app {{beforeDir}} --template typescript && cd {{beforeDir}} && \
-      jq '.browserslist.production[0] = ">0.9%"' package.json > tmp.json && mv tmp.json package.json
-    `,
-    // Re-enable once https://github.com/storybookjs/storybook/issues/19351 is fixed.
-    skipTasks: ['smoke-test', 'bench', 'vitest-integration'],
-    expected: {
-      // TODO: change this to @storybook/cra once that package is created
-      framework: '@storybook/react-webpack5',
-      renderer: '@storybook/react',
-      builder: '@storybook/builder-webpack5',
-    },
-    modifications: {
-      extraDependencies: ['prop-types'],
-    },
-  },
   'nextjs/13-ts': {
     name: 'Next.js v13.5 (Webpack | TypeScript)',
     script:
@@ -172,7 +124,6 @@ const baseTemplates = {
       extraDependencies: ['server-only', 'prop-types'],
     },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
-    inDevelopment: true,
   },
   'nextjs/default-ts': {
     name: 'Next.js Latest (Webpack | TypeScript)',
@@ -229,7 +180,6 @@ const baseTemplates = {
         'prop-types',
       ],
     },
-    inDevelopment: true,
     skipTasks: ['e2e-tests-dev', 'bench'],
   },
   'experimental-nextjs-vite/default-ts': {
@@ -252,19 +202,6 @@ const baseTemplates = {
         'vite',
         'prop-types',
       ],
-    },
-    skipTasks: ['e2e-tests-dev', 'bench'],
-  },
-  'react-vite/default-js': {
-    name: 'React Latest (Vite | JavaScript)',
-    script: 'npm create vite --yes {{beforeDir}} -- --template react',
-    expected: {
-      framework: '@storybook/react-vite',
-      renderer: '@storybook/react',
-      builder: '@storybook/builder-vite',
-    },
-    modifications: {
-      extraDependencies: ['prop-types'],
     },
     skipTasks: ['e2e-tests-dev', 'bench'],
   },
@@ -318,7 +255,7 @@ const baseTemplates = {
     modifications: {
       extraDependencies: ['prop-types'],
     },
-    skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
+    skipTasks: ['bench', 'vitest-integration'],
   },
   'react-webpack/17-ts': {
     name: 'React v17 (Webpack | TypeScript)',
@@ -358,18 +295,6 @@ const baseTemplates = {
     },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
   },
-  'solid-vite/default-js': {
-    name: 'SolidJS Latest (Vite | JavaScript)',
-    script: 'npx degit solidjs/templates/js {{beforeDir}}',
-    expected: {
-      framework: 'storybook-solidjs-vite',
-      renderer: 'storybook-solidjs',
-      builder: '@storybook/builder-vite',
-    },
-    // TODO: remove this once solid-vite framework is released
-    inDevelopment: true,
-    skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
-  },
   'solid-vite/default-ts': {
     name: 'SolidJS Latest (Vite | TypeScript)',
     script: 'npx degit solidjs/templates/ts {{beforeDir}}',
@@ -380,16 +305,6 @@ const baseTemplates = {
     },
     // TODO: remove this once solid-vite framework is released
     inDevelopment: true,
-    skipTasks: ['e2e-tests-dev', 'bench'],
-  },
-  'vue3-vite/default-js': {
-    name: 'Vue v3 (Vite | JavaScript)',
-    script: 'npm create vite --yes {{beforeDir}} -- --template vue',
-    expected: {
-      framework: '@storybook/vue3-vite',
-      renderer: '@storybook/vue3',
-      builder: '@storybook/builder-vite',
-    },
     skipTasks: ['e2e-tests-dev', 'bench'],
   },
   'vue3-vite/default-ts': {
@@ -412,17 +327,6 @@ const baseTemplates = {
     },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
   },
-  'html-vite/default-js': {
-    name: 'HTML Latest (Vite | JavaScript)',
-    script:
-      'npm create vite --yes {{beforeDir}} -- --template vanilla && cd {{beforeDir}} && echo "export default {}" > vite.config.js',
-    expected: {
-      framework: '@storybook/html-vite',
-      renderer: '@storybook/html',
-      builder: '@storybook/builder-vite',
-    },
-    skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
-  },
   'html-vite/default-ts': {
     name: 'HTML Latest (Vite | TypeScript)',
     script:
@@ -433,16 +337,6 @@ const baseTemplates = {
       builder: '@storybook/builder-vite',
     },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
-  },
-  'svelte-vite/default-js': {
-    name: 'Svelte Latest (Vite | JavaScript)',
-    script: 'npm create vite --yes {{beforeDir}} -- --template svelte',
-    expected: {
-      framework: '@storybook/svelte-vite',
-      renderer: '@storybook/svelte',
-      builder: '@storybook/builder-vite',
-    },
-    skipTasks: ['e2e-tests-dev', 'bench'],
   },
   'svelte-vite/default-ts': {
     name: 'Svelte Latest (Vite | TypeScript)',
@@ -488,17 +382,6 @@ const baseTemplates = {
     },
     skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
   },
-  'svelte-kit/skeleton-js': {
-    name: 'SvelteKit Latest (Vite | JavaScript)',
-    script:
-      'yarn create svelte-with-args --name=svelte-kit/skeleton-js --directory={{beforeDir}} --template=skeleton --types=null --no-prettier --no-eslint --no-playwright --no-vitest --no-svelte5',
-    expected: {
-      framework: '@storybook/sveltekit',
-      renderer: '@storybook/svelte',
-      builder: '@storybook/builder-vite',
-    },
-    skipTasks: ['e2e-tests-dev', 'bench'],
-  },
   'svelte-kit/skeleton-ts': {
     name: 'SvelteKit Latest (Vite | TypeScript)',
     script:
@@ -520,18 +403,6 @@ const baseTemplates = {
       builder: '@storybook/builder-vite',
     },
     skipTasks: ['e2e-tests-dev', 'bench'],
-  },
-  'lit-vite/default-js': {
-    name: 'Lit Latest (Vite | JavaScript)',
-    script:
-      'npm create vite --yes {{beforeDir}} -- --template lit && cd {{beforeDir}} && echo "export default {}" > vite.config.js',
-    expected: {
-      framework: '@storybook/web-components-vite',
-      renderer: '@storybook/web-components',
-      builder: '@storybook/builder-vite',
-    },
-    // Remove smoke-test from the list once https://github.com/storybookjs/storybook/issues/19351 is fixed.
-    skipTasks: ['smoke-test', 'e2e-tests-dev', 'bench', 'vitest-integration'],
   },
   'lit-vite/default-ts': {
     name: 'Lit Latest (Vite | TypeScript)',
@@ -556,19 +427,6 @@ const baseTemplates = {
     },
     // Remove smoke-test from the list once https://github.com/storybookjs/storybook/issues/19351 is fixed.
     skipTasks: ['smoke-test', 'e2e-tests-dev', 'bench', 'vitest-integration'],
-  },
-  'preact-vite/default-js': {
-    name: 'Preact Latest (Vite | JavaScript)',
-    script: 'npm create vite --yes {{beforeDir}} -- --template preact',
-    expected: {
-      framework: '@storybook/preact-vite',
-      renderer: '@storybook/preact',
-      builder: '@storybook/builder-vite',
-    },
-    modifications: {
-      extraDependencies: ['preact-render-to-string'],
-    },
-    skipTasks: ['e2e-tests-dev', 'bench', 'vitest-integration'],
   },
   'preact-vite/default-ts': {
     name: 'Preact Latest (Vite | TypeScript)',
@@ -706,13 +564,6 @@ const internalTemplates = {
     isInternal: true,
     skipTasks: ['bench', 'vitest-integration'],
   },
-  // 'internal/pnp': {
-  //   ...baseTemplates['cra/default-ts'],
-  //   name: 'PNP (cra/default-ts)',
-  //   script: 'yarn create react-app . --use-pnp',
-  //   isInternal: true,
-  //   inDevelopment: true,
-  // },
 } satisfies Record<`internal/${string}`, Template & { isInternal: true }>;
 
 const benchTemplates = {
@@ -806,7 +657,7 @@ export const allTemplates: Record<TemplateKey, Template> = {
 };
 
 export const normal: TemplateKey[] = [
-  'cra/default-ts',
+  'react-webpack/18-ts',
   'react-vite/default-ts',
   'angular-cli/default-ts',
   'vue3-vite/default-ts',
@@ -825,7 +676,6 @@ export const normal: TemplateKey[] = [
 
 export const merged: TemplateKey[] = [
   ...normal,
-  'react-webpack/18-ts',
   'react-webpack/17-ts',
   'angular-cli/15-ts',
   'preact-vite/default-ts',
@@ -836,21 +686,13 @@ export const merged: TemplateKey[] = [
 export const daily: TemplateKey[] = [
   ...merged,
   'angular-cli/prerelease',
-  'cra/default-js',
-  'react-vite/default-js',
   'react-vite/prerelease-ts',
   'react-webpack/prerelease-ts',
-  'vue3-vite/default-js',
   'vue-cli/default-js',
-  'lit-vite/default-js',
-  'svelte-kit/skeleton-js',
   'svelte-kit/prerelease-ts',
-  'svelte-vite/default-js',
   'nextjs/13-ts',
   'nextjs/prerelease',
   'qwik-vite/default-ts',
-  'preact-vite/default-js',
-  'html-vite/default-js',
   'internal/react16-webpack',
   'internal/react18-webpack-babel',
   'react-native-web-vite/expo-ts',


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Our sandbox structure is getting quite large, so this PR proposes getting rid of the JS sandboxes as much as we can (some are left there), so all of the sandboxes that had TS/JS versions, will now only be TS.

This PR also replaces the generation and usage of CRA with a react-webpack sandbox instead, given that CRA is incredibly outdated by now.

This will decrease testing surface but I believe it won't penalize us much because of the features we test in Storybook. Also there is an upside of CI costs which will definitely go down by a lot because the sandbox count will be much lower

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | -4.28 kB | **-3.73** | 0% |
| initSize |  130 MB | 130 MB | 14.7 kB | -1.2 | 0% |
| diffSize |  52.4 MB | 52.5 MB | 19 kB | **1.94** | 0% |
| buildSize |  6.75 MB | 6.75 MB | 0 B | -0.65 | 0% |
| buildSbAddonsSize |  1.51 MB | 1.51 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **1.33** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | -0.65 | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.57 MB | 3.57 MB | 0 B | -0.65 | 0% |
| buildPreviewSize |  3.19 MB | 3.19 MB | 0 B | 0.65 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  6.8s | 7.5s | 709ms | -0.96 | 9.4% |
| generateTime |  25.5s | 20.7s | -4s -799ms | 0.02 | -23.2% |
| initTime |  15.9s | 14.6s | -1s -270ms | 0.5 | -8.6% |
| buildTime |  8.1s | 8.5s | 451ms | -0.55 | 5.3% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  5.4s | 4.4s | -974ms | **-1.3** | 🔰-22% |
| devManagerResponsive |  3.8s | 3.2s | -588ms | -1.09 | -17.9% |
| devManagerHeaderVisible |  555ms | 605ms | 50ms | 0.4 | 8.3% |
| devManagerIndexVisible |  629ms | 680ms | 51ms | 0.34 | 7.5% |
| devStoryVisibleUncached |  1.9s | 1s | -855ms | **-3.23** | 🔰-79.5% |
| devStoryVisible |  627ms | 679ms | 52ms | 0.37 | 7.7% |
| devAutodocsVisible |  408ms | 494ms | 86ms | -0.49 | 17.4% |
| devMDXVisible |  562ms | 519ms | -43ms | -0.04 | -8.3% |
| buildManagerHeaderVisible |  549ms | 616ms | 67ms | 0.53 | 10.9% |
| buildManagerIndexVisible |  622ms | 706ms | 84ms | 0.7 | 11.9% |
| buildStoryVisible |  498ms | 569ms | 71ms | 0.41 | 12.5% |
| buildAutodocsVisible |  440ms | 516ms | 76ms | 1.05 | 14.7% |
| buildMDXVisible |  404ms | 458ms | 54ms | 0.49 | 11.8% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my concise review of the changes:

Reduces CI testing surface by removing duplicate JavaScript templates in favor of TypeScript-only templates, significantly decreasing the number of sandbox tests while maintaining core functionality coverage.

- Reduced parallelism in CircleCI from 14 to 9 jobs for test-runner and e2e testing
- Removed JS templates for React, Vue, Lit, Svelte, HTML, and Preact frameworks where TS equivalents exist
- Retained essential JS-only templates like vue-cli/default-js and html-webpack/default
- Removed inDevelopment flags from stable templates to reflect production readiness
- Updated skipTasks configurations to align with new template structure



<!-- /greptile_comment -->