### PR TITLE
Addon Test: Clear `coverageSummary` when disabling the coverage feature

### DIFF
--- a/code/addons/test/src/manager.tsx
+++ b/code/addons/test/src/manager.tsx
@@ -73,64 +73,74 @@ addons.register(ADDON_ID, (api) => {
       },
 
       stateUpdater: (state, update) => {
-        if (!update.details?.testResults) {
-          return;
+        const updated = {
+          ...state,
+          ...update,
+          details: { ...state.details, ...update.details },
+        };
+
+        if (update.config?.coverage === false) {
+          delete updated.details.coverageSummary;
         }
 
-        (async () => {
-          await api.experimental_updateStatus(
-            TEST_PROVIDER_ID,
-            Object.fromEntries(
-              update.details.testResults.flatMap((testResult) =>
-                testResult.results
-                  .filter(({ storyId }) => storyId)
-                  .map(({ storyId, status, testRunId, ...rest }) => [
-                    storyId,
-                    {
-                      title: 'Component tests',
-                      status: statusMap[status],
-                      description:
-                        'failureMessages' in rest && rest.failureMessages
-                          ? rest.failureMessages.join('\n')
-                          : '',
-                      data: { testRunId },
-                      onClick: openTestsPanel,
-                      sidebarContextMenu: false,
-                    } satisfies API_StatusObject,
-                  ])
-              )
-            )
-          );
-
-          await api.experimental_updateStatus(
-            'storybook/addon-a11y/test-provider',
-            Object.fromEntries(
-              update.details.testResults.flatMap((testResult) =>
-                testResult.results
-                  .filter(({ storyId }) => storyId)
-                  .map(({ storyId, testRunId, reports }) => {
-                    const a11yReport = reports.find((r: any) => r.type === 'a11y');
-                    return [
+        if (update.details?.testResults) {
+          (async () => {
+            await api.experimental_updateStatus(
+              TEST_PROVIDER_ID,
+              Object.fromEntries(
+                update.details.testResults.flatMap((testResult) =>
+                  testResult.results
+                    .filter(({ storyId }) => storyId)
+                    .map(({ storyId, status, testRunId, ...rest }) => [
                       storyId,
-                      a11yReport
-                        ? ({
-                            title: 'Accessibility tests',
-                            description: '',
-                            status: statusMap[a11yReport.status],
-                            data: { testRunId },
-                            onClick: () => {
-                              api.setSelectedPanel('storybook/a11y/panel');
-                              api.togglePanel(true);
-                            },
-                            sidebarContextMenu: false,
-                          } satisfies API_StatusObject)
-                        : null,
-                    ];
-                  })
+                      {
+                        title: 'Component tests',
+                        status: statusMap[status],
+                        description:
+                          'failureMessages' in rest && rest.failureMessages
+                            ? rest.failureMessages.join('\n')
+                            : '',
+                        data: { testRunId },
+                        onClick: openTestsPanel,
+                        sidebarContextMenu: false,
+                      } satisfies API_StatusObject,
+                    ])
+                )
               )
-            )
-          );
-        })();
+            );
+
+            await api.experimental_updateStatus(
+              'storybook/addon-a11y/test-provider',
+              Object.fromEntries(
+                update.details.testResults.flatMap((testResult) =>
+                  testResult.results
+                    .filter(({ storyId }) => storyId)
+                    .map(({ storyId, testRunId, reports }) => {
+                      const a11yReport = reports.find((r: any) => r.type === 'a11y');
+                      return [
+                        storyId,
+                        a11yReport
+                          ? ({
+                              title: 'Accessibility tests',
+                              description: '',
+                              status: statusMap[a11yReport.status],
+                              data: { testRunId },
+                              onClick: () => {
+                                api.setSelectedPanel('storybook/a11y/panel');
+                                api.togglePanel(true);
+                              },
+                              sidebarContextMenu: false,
+                            } satisfies API_StatusObject)
+                          : null,
+                      ];
+                    })
+                )
+              )
+            );
+          })();
+        }
+
+        return updated;
       },
     } as Addon_TestProviderType<Details, Config>);
   }


### PR DESCRIPTION
## What I did

This clears the coverage data when disabling the coverage feature, in order to prevent stale data from lingering.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  77.7 MB | 77.7 MB | 0 B | 0.42 | 0% |
| initSize |  133 MB | 133 MB | 0 B | 0.72 | 0% |
| diffSize |  55.3 MB | 55.3 MB | 0 B | 0.72 | 0% |
| buildSize |  7.24 MB | 7.24 MB | 0 B | **4.36** | 0% |
| buildSbAddonsSize |  1.88 MB | 1.88 MB | 0 B | **4.36** | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.86 MB | 1.86 MB | 0 B | **3.03** | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  3.93 MB | 3.93 MB | 0 B | **4.36** | 0% |
| buildPreviewSize |  3.3 MB | 3.3 MB | 0 B | **3.74** | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  26.7s | 24.8s | -1s -941ms | **1.5** | 🔰-7.8% |
| generateTime |  23.2s | 21s | -2s -196ms | -0.32 | -10.4% |
| initTime |  14.9s | 14.1s | -774ms | -0.4 | -5.5% |
| buildTime |  9.1s | 8.4s | -626ms | -0.85 | -7.4% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  6s | 5.7s | -384ms | 0.72 | -6.7% |
| devManagerResponsive |  4.5s | 4.3s | -220ms | 0.78 | -5.1% |
| devManagerHeaderVisible |  606ms | 603ms | -3ms | 0.22 | -0.5% |
| devManagerIndexVisible |  637ms | 633ms | -4ms | -0.15 | -0.6% |
| devStoryVisibleUncached |  1.9s | 1.7s | -161ms | -0.09 | -9% |
| devStoryVisible |  635ms | 632ms | -3ms | -0.11 | -0.5% |
| devAutodocsVisible |  459ms | 575ms | 116ms | 0.84 | 20.2% |
| devMDXVisible |  636ms | 550ms | -86ms | 0.16 | -15.6% |
| buildManagerHeaderVisible |  704ms | 659ms | -45ms | 0.54 | -6.8% |
| buildManagerIndexVisible |  806ms | 768ms | -38ms | 0.63 | -4.9% |
| buildStoryVisible |  658ms | 613ms | -45ms | 0.62 | -7.3% |
| buildAutodocsVisible |  540ms | 506ms | -34ms | 0.42 | -6.7% |
| buildMDXVisible |  581ms | 434ms | -147ms | -0.23 | -33.9% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a concise summary of this PR's changes:

Updates the test addon's state management to properly clear coverage data when the coverage feature is disabled, preventing stale coverage information from persisting.

- Modified `stateUpdater` function in `code/addons/test/src/manager.tsx` to remove `coverageSummary` when coverage is disabled
- Ensures clean state management by preventing outdated coverage data from displaying
- Improves user experience by only showing coverage data when the feature is actively enabled
- Restructures code to handle test results updates more systematically



<!-- /greptile_comment -->