### PR TITLE
Svelte: Update `addon-svelte-csf` to specific version for CPC compliance

### DIFF
--- a/code/lib/create-storybook/src/generators/SVELTE/index.ts
+++ b/code/lib/create-storybook/src/generators/SVELTE/index.ts
@@ -14,7 +14,7 @@ export const getAddonSvelteCsfVersion = async (packageManager: JsPackageManager)
     }
     // TODO: update when addon-svelte-csf v5 is released
     if (svelteMajor === 5) {
-      return '5.0.0-next.25';
+      return '4.2.1--canary.16f8a20.1';
     }
   } catch {
     // fallback to latest version

--- a/code/lib/create-storybook/src/generators/SVELTE/index.ts
+++ b/code/lib/create-storybook/src/generators/SVELTE/index.ts
@@ -14,7 +14,7 @@ export const getAddonSvelteCsfVersion = async (packageManager: JsPackageManager)
     }
     // TODO: update when addon-svelte-csf v5 is released
     if (svelteMajor === 5) {
-      return '^5.0.0-next.0';
+      return '5.0.0-next.25';
     }
   } catch {
     // fallback to latest version


### PR DESCRIPTION
## What I did

This pull request includes a small change to the `code/lib/create-storybook/src/generators/SVELTE/index.ts` file. The change updates the version of `addon-svelte-csf` to a more recent pre-release version for Svelte major version 5.

* [`code/lib/create-storybook/src/generators/SVELTE/index.ts`](diffhunk://#diff-76280818ab6c9c1a4430fb82cb0ab2615d2b00d2f7b43653b03a974c8df1de1aL17-R17): Updated `addon-svelte-csf` version from `^5.0.0-next.0` to `5.0.0-next.25` for Svelte major version 5.


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR updates the `addon-svelte-csf` dependency version from `^5.0.0-next.0` to an exact version `5.0.0-next.25` in the Svelte generator for better CPC (Coordinated Package Compliance).

- Modified `code/lib/create-storybook/src/generators/SVELTE/index.ts` to use a specific pre-release version instead of a range
- Removed the caret (^) prefix to ensure projects use exactly version 5.0.0-next.25
- This change helps maintain consistency across Svelte 5 projects using Storybook
- Prevents potential compatibility issues by locking to a tested pre-release version



<!-- /greptile_comment -->