### PR TITLE
Automigration: Migrate @storybook/test to storybook/test

### DIFF
--- a/code/lib/cli-storybook/src/automigrate/fixes/__snapshots__/storybook-test-migration.test.ts.snap
+++ b/code/lib/cli-storybook/src/automigrate/fixes/__snapshots__/storybook-test-migration.test.ts.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`storybook-test-migration > should show the correct prompt message 1`] = `
+"We detected that you're using @storybook/test in your project. This package has been merged into storybook/test.
+
+We'll help you migrate by:
+1. Removing @storybook/test from your dependencies
+2. Updating all imports from @storybook/test to storybook/test
+
+We'll scan the following files:
+- All files in .storybook directory
+- All *.stories.* files
+- All *.test.* files
+
+The default glob pattern we'll use is: {.storybook/**/*,**/*.{stories.*,test.*}}
+
+In the next step, you can provide a custom glob pattern to fine-tune the files we'll scan."
+`;

--- a/code/lib/cli-storybook/src/automigrate/fixes/index.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/index.ts
@@ -24,6 +24,7 @@ import { removedGlobalClientAPIs } from './remove-global-client-apis';
 import { removeLegacyMDX1 } from './remove-legacymdx1';
 import { sbBinary } from './sb-binary';
 import { sbScripts } from './sb-scripts';
+import { storybookTestMigration } from './storybook-test-migration';
 import { storyshotsMigration } from './storyshots-migration';
 import { upgradeStorybookRelatedDependencies } from './upgrade-storybook-related-dependencies';
 import { viteConfigFile } from './vite-config-file';
@@ -68,6 +69,7 @@ export const allFixes: Fix[] = [
   initialGlobals,
   addonA11yAddonTest,
   addonExperimentalTest,
+  storybookTestMigration,
 ];
 
 export const initFixes: Fix[] = [eslintPlugin];

--- a/code/lib/cli-storybook/src/automigrate/fixes/storybook-test-migration.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/storybook-test-migration.test.ts
@@ -1,0 +1,179 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { JsPackageManager } from 'storybook/internal/common';
+
+import prompts from 'prompts';
+
+import { storybookTestMigration } from './storybook-test-migration';
+
+// Mock fs promises
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+// Mock prompts
+vi.mock('prompts', () => ({
+  default: vi.fn(),
+}));
+
+// Mock globby
+vi.mock('globby', () => ({
+  globby: vi.fn(),
+}));
+
+vi.mock('picocolors', () => ({
+  default: {
+    magenta: vi.fn().mockImplementation((text) => text),
+    yellow: vi.fn().mockImplementation((text) => text),
+  },
+}));
+
+describe('storybook-test-migration', () => {
+  const mockPackageManager = {
+    getPackageVersion: vi.fn(),
+    removeDependencies: vi.fn(),
+    type: 'npm',
+    getPackageJson: vi.fn(),
+  } as unknown as JsPackageManager;
+
+  const mockConfigDir = '.storybook';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return null if @storybook/test is not in dependencies', async () => {
+    vi.mocked(mockPackageManager.getPackageVersion).mockResolvedValue(null);
+
+    const result = await storybookTestMigration.check({
+      packageManager: mockPackageManager,
+      configDir: mockConfigDir,
+    } as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return migration result if @storybook/test is in dependencies', async () => {
+    vi.mocked(mockPackageManager.getPackageVersion).mockResolvedValue('^7.0.0');
+
+    const result = await storybookTestMigration.check({
+      packageManager: mockPackageManager,
+      configDir: mockConfigDir,
+    } as any);
+
+    expect(result).toEqual({
+      hasDependency: true,
+      defaultGlob: '{.storybook/**/*,**/*.{stories.*,test.*}}',
+    });
+  });
+
+  it('should show the correct prompt message', () => {
+    const result = {
+      hasDependency: true,
+      defaultGlob: '{.storybook/**/*,**/*.{stories.*,test.*}}',
+    };
+
+    const prompt = storybookTestMigration.prompt(result);
+    expect(prompt).toMatchSnapshot();
+  });
+
+  it('should remove @storybook/test dependency and update imports', async () => {
+    // Mock package.json
+    vi.mocked(mockPackageManager.getPackageVersion).mockResolvedValue('^7.0.0');
+
+    // Mock globby to return test files
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    (globby as any).mockResolvedValue(['test1.ts', 'test2.ts']);
+
+    // Mock prompts to return default glob
+    (prompts as any).mockResolvedValue({ glob: '{.storybook/**/*,**/*.{stories.*,test.*}}' });
+
+    // Mock file contents
+    (readFile as any).mockResolvedValue('import { expect } from "@storybook/test";');
+
+    // Run the migration
+    await storybookTestMigration.run?.({
+      packageManager: mockPackageManager,
+      dryRun: false,
+      result: {
+        hasDependency: true,
+        defaultGlob: '{.storybook/**/*,**/*.{stories.*,test.*}}',
+      },
+    } as any);
+
+    // Verify dependency removal
+    expect(mockPackageManager.removeDependencies).toHaveBeenCalledWith({}, ['@storybook/test']);
+
+    // Verify file updates
+    expect(writeFile).toHaveBeenCalledWith('test1.ts', 'import { expect } from "storybook/test";');
+    expect(writeFile).toHaveBeenCalledWith('test2.ts', 'import { expect } from "storybook/test";');
+  });
+
+  it('should handle dry run mode', async () => {
+    // Mock package.json
+    vi.mocked(mockPackageManager.getPackageVersion).mockResolvedValue('^7.0.0');
+
+    // Mock globby to return test files
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    (globby as any).mockResolvedValue(['test1.ts']);
+
+    // Mock prompts to return default glob
+    (prompts as any).mockResolvedValue({ glob: '{.storybook/**/*,**/*.{stories.*,test.*}}' });
+
+    // Mock file contents
+    (readFile as any).mockResolvedValue('import { expect } from "@storybook/test";');
+
+    // Run the migration in dry run mode
+    await storybookTestMigration.run?.({
+      packageManager: mockPackageManager,
+      dryRun: true,
+      result: {
+        hasDependency: true,
+        defaultGlob: '{.storybook/**/*,**/*.{stories.*,test.*}}',
+      },
+    } as any);
+
+    // Verify no changes were made
+    expect(mockPackageManager.removeDependencies).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should handle different quote styles in imports', async () => {
+    // Mock package.json
+    vi.mocked(mockPackageManager.getPackageVersion).mockResolvedValue('^7.0.0');
+
+    // Mock globby to return test files
+    // eslint-disable-next-line depend/ban-dependencies
+    const { globby } = await import('globby');
+    (globby as any).mockResolvedValue(['test1.ts']);
+
+    // Mock prompts to return default glob
+    (prompts as any).mockResolvedValue({ glob: '{.storybook/**/*,**/*.{stories.*,test.*}}' });
+
+    // Mock file contents with different quote styles
+    (readFile as any).mockResolvedValue(
+      'import { expect } from "@storybook/test";\nimport { expect } from \'@storybook/test\';'
+    );
+
+    // Run the migration
+    await storybookTestMigration.run?.({
+      packageManager: mockPackageManager,
+      dryRun: false,
+      result: {
+        hasDependency: true,
+        defaultGlob: '{.storybook/**/*,**/*.{stories.*,test.*}}',
+      },
+    } as any);
+
+    // Verify quote styles were preserved
+    expect(writeFile).toHaveBeenCalledWith(
+      'test1.ts',
+      'import { expect } from "storybook/test";\nimport { expect } from \'storybook/test\';'
+    );
+  });
+});

--- a/code/lib/cli-storybook/src/automigrate/fixes/storybook-test-migration.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/storybook-test-migration.ts
@@ -1,0 +1,94 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+import picocolors from 'picocolors';
+import prompts from 'prompts';
+import { dedent } from 'ts-dedent';
+
+import type { Fix } from '../types';
+
+interface StorybookTestMigrationResult {
+  hasDependency: boolean;
+  defaultGlob: string;
+}
+
+export const storybookTestMigration: Fix<StorybookTestMigrationResult> = {
+  id: 'storybook-test-migration',
+  versionRange: ['<9.0.0', '>=9.0.0-0'],
+  check: async ({ packageManager, configDir }) => {
+    const storybookTestPackageVersion = await packageManager.getPackageVersion('@storybook/test');
+
+    if (!storybookTestPackageVersion) {
+      return null;
+    }
+
+    // Default glob pattern to scan for files
+    const defaultGlob = `{${configDir}/**/*,**/*.{stories.*,test.*}}`;
+
+    return {
+      hasDependency: !!storybookTestPackageVersion,
+      defaultGlob,
+    };
+  },
+  prompt: (result) => {
+    return dedent`
+      We detected that you're using ${picocolors.magenta('@storybook/test')} in your project. This package has been merged into ${picocolors.magenta('storybook/test')}.
+      
+      We'll help you migrate by:
+      1. Removing ${picocolors.magenta('@storybook/test')} from your dependencies
+      2. Updating all imports from ${picocolors.magenta('@storybook/test')} to ${picocolors.magenta('storybook/test')}
+      
+      We'll scan the following files:
+      - All files in .storybook directory
+      - All *.stories.* files
+      - All *.test.* files
+      
+      The default glob pattern we'll use is: ${picocolors.yellow(result.defaultGlob)}
+      
+      In the next step, you can provide a custom glob pattern to fine-tune the files we'll scan.
+    `;
+  },
+  promptType: 'auto',
+  run: async ({ packageManager, dryRun, result }) => {
+    // Remove @storybook/test from dependencies
+    if (!dryRun) {
+      await packageManager.removeDependencies({}, ['@storybook/test']);
+    }
+
+    // Find all files matching the glob pattern
+    const { glob } = await prompts({
+      type: 'text',
+      name: 'glob',
+      message: 'Enter a custom glob pattern to scan (or press enter to use default):',
+      initial: result.defaultGlob,
+    });
+
+    // eslint-disable-next-line depend/ban-dependencies
+    const globby = (await import('globby')).globby;
+
+    const files = await globby(glob, {
+      ignore: ['node_modules/**', 'dist/**', 'build/**'],
+      cwd: process.cwd(),
+      gitignore: true,
+    });
+
+    let updatedFilesCount = 0;
+
+    // Process each file
+    for (const file of files) {
+      const content = await readFile(file, 'utf-8');
+
+      // Replace imports
+      const updatedContent = content.replace(/(['"])@storybook\/test\1/g, '$1storybook/test$1');
+
+      if (content !== updatedContent) {
+        if (!dryRun) {
+          await writeFile(file, updatedContent);
+        }
+        // Track updated files count to show at the end
+        updatedFilesCount = (updatedFilesCount || 0) + 1;
+      }
+    }
+
+    console.log(`Updated ${updatedFilesCount} files`);
+  },
+};


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- added an automigration to migrate users from `@storybook/test` to `storybook/test`

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30761-sha-a2b89812`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30761-sha-a2b89812 sandbox` or in an existing project with `npx storybook@0.0.0-pr-30761-sha-a2b89812 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30761-sha-a2b89812`](https://npmjs.com/package/storybook/v/0.0.0-pr-30761-sha-a2b89812) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/write-automigration-for-core-test-integration`](https://github.com/storybookjs/storybook/tree/valentin/write-automigration-for-core-test-integration) |
| **Commit** | [`a2b89812`](https://github.com/storybookjs/storybook/commit/a2b89812dd987533931c173a4c671b534abec67c) |
| **Datetime** | Thu Mar  6 08:23:18 UTC 2025 (`1741249398`) |
| **Workflow run** | [13694261393](https://github.com/storybookjs/storybook/actions/runs/13694261393) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30761`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->

| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createSize |  0 B | 0 B | 0 B | - | - |
| generateSize |  79.9 MB | 79.9 MB | 0 B | 1.22 | 0% |
| initSize |  79.9 MB | 79.9 MB | 0 B | 1.22 | 0% |
| diffSize |  97 B | 97 B | 0 B | - | 0% |
| buildSize |  7.47 MB | 7.47 MB | 0 B | -1.22 | 0% |
| buildSbAddonsSize |  1.98 MB | 1.98 MB | 0 B | - | 0% |
| buildSbCommonSize |  195 kB | 195 kB | 0 B | - | 0% |
| buildSbManagerSize |  1.88 MB | 1.88 MB | 0 B | - | 0% |
| buildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| buildStaticSize |  0 B | 0 B | 0 B | - | - |
| buildPrebuildSize |  4.06 MB | 4.06 MB | 0 B | - | 0% |
| buildPreviewSize |  3.42 MB | 3.42 MB | 0 B | -1.22 | 0% |
| testBuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbAddonsSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbCommonSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbManagerSize |  0 B | 0 B | 0 B | - | - |
| testBuildSbPreviewSize |  0 B | 0 B | 0 B | - | - |
| testBuildStaticSize |  0 B | 0 B | 0 B | - | - |
| testBuildPrebuildSize |  0 B | 0 B | 0 B | - | - |
| testBuildPreviewSize |  0 B | 0 B | 0 B | - | - |



| name | before | after | diff | z | % |
| ---- | ------ | ----- | ---- | - | - |
| createTime |  11.8s | 18.5s | 6.7s | -0.38 | 36.1% |
| generateTime |  30.1s | 17.9s | -12s -181ms | -0.96 | -67.9% |
| initTime |  5.7s | 4.2s | -1s -535ms | **-1.26** | 🔰-36.1% |
| buildTime |  9.3s | 8.6s | -736ms | -1.05 | -8.5% |
| testBuildTime |  0ms | 0ms | 0ms | - | - |
| devPreviewResponsive |  4.9s | 5.5s | 616ms | 1.16 | 11.1% |
| devManagerResponsive |  4.7s | 5.2s | 570ms | 0.99 | 10.8% |
| devManagerHeaderVisible |  760ms | 826ms | 66ms | **3.56** | 🔺8% |
| devManagerIndexVisible |  849ms | 838ms | -11ms | **1.61** | -1.3% |
| devStoryVisibleUncached |  2.4s | 2.5s | 124ms | -0.19 | 4.8% |
| devStoryVisible |  1.2s | 1.3s | 142ms | **4.95** | 🔺10.3% |
| devAutodocsVisible |  1.2s | 1.3s | 182ms | **3.71** | 🔺13.2% |
| devMDXVisible |  1.1s | 1.3s | 157ms | **2.53** | 🔺11.7% |
| buildManagerHeaderVisible |  661ms | 835ms | 174ms | **28.62** | 🔺20.8% |
| buildManagerIndexVisible |  682ms | 841ms | 159ms | **15.85** | 🔺18.9% |
| buildStoryVisible |  655ms | 795ms | 140ms | **24.59** | 🔺17.6% |
| buildAutodocsVisible |  535ms | 763ms | 228ms | **6.46** | 🔺29.9% |
| buildMDXVisible |  570ms | 696ms | 126ms | **8.23** | 🔺18.1% |

<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Introduces an automigration feature to help users transition from '@storybook/test' to 'storybook/test', including dependency checks and automated import updates.

- Added `code/lib/cli-storybook/src/automigrate/fixes/storybook-test-migration.ts` implementing core migration logic with dependency checks and import updates
- Added `code/lib/cli-storybook/src/automigrate/fixes/storybook-test-migration.test.ts` with comprehensive test coverage for migration scenarios
- Modified `code/lib/cli-storybook/src/automigrate/fixes/index.ts` to register the new migration fix in `allFixes` array



<!-- /greptile_comment -->