### PR TITLE
Addon Test: Only install it in Vite-based projects or Next.js projects

### DIFF
--- a/code/core/src/cli/detect.ts
+++ b/code/core/src/cli/detect.ts
@@ -111,7 +111,10 @@ export function detectFrameworkPreset(
  *
  * @returns CoreBuilder
  */
-export async function detectBuilder(packageManager: JsPackageManager, projectType: ProjectType) {
+export async function detectBuilder(
+  packageManager: JsPackageManager,
+  projectType: ProjectType
+): Promise<CoreBuilder> {
   const viteConfig = findUpSync(viteConfigFiles);
   const webpackConfig = findUpSync(webpackConfigFiles);
   const dependencies = await packageManager.getAllDependencies();

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -7,7 +7,6 @@ import invariant from 'tiny-invariant';
 import { dedent } from 'ts-dedent';
 
 import type { NpmOptions } from '../../../../core/src/cli/NpmOptions';
-import { detectBuilder } from '../../../../core/src/cli/detect';
 import { configureEslintPlugin, extractEslintInfo } from '../../../../core/src/cli/eslintPlugin';
 import { copyTemplateFiles } from '../../../../core/src/cli/helpers';
 import {
@@ -209,10 +208,6 @@ export async function baseGenerator(
 ) {
   const isStorybookInMonorepository = packageManager.isStorybookInMonorepo();
   const shouldApplyRequireWrapperOnPackageNames = isStorybookInMonorepository || pnp;
-
-  if (!builder) {
-    builder = await detectBuilder(packageManager as any, projectType);
-  }
 
   if (features.includes('test')) {
     const supportedFrameworks: ProjectType[] = [

--- a/code/lib/create-storybook/src/generators/baseGenerator.ts
+++ b/code/lib/create-storybook/src/generators/baseGenerator.ts
@@ -201,33 +201,13 @@ const hasFrameworkTemplates = (framework?: SupportedFrameworks) => {
 export async function baseGenerator(
   packageManager: JsPackageManager,
   npmOptions: NpmOptions,
-  { language, builder, pnp, frameworkPreviewParts, projectType, features }: GeneratorOptions,
+  { language, builder, pnp, frameworkPreviewParts, features }: GeneratorOptions,
   renderer: SupportedRenderers,
   options: FrameworkOptions = defaultOptions,
   framework?: SupportedFrameworks
 ) {
   const isStorybookInMonorepository = packageManager.isStorybookInMonorepo();
   const shouldApplyRequireWrapperOnPackageNames = isStorybookInMonorepository || pnp;
-
-  if (features.includes('test')) {
-    const supportedFrameworks: ProjectType[] = [
-      ProjectType.REACT,
-      ProjectType.VUE3,
-      ProjectType.NEXTJS,
-      ProjectType.NUXT,
-      ProjectType.PREACT,
-      ProjectType.SVELTE,
-      ProjectType.SVELTEKIT,
-      ProjectType.WEB_COMPONENTS,
-      ProjectType.REACT_NATIVE_WEB,
-    ];
-    const supportsTestAddon =
-      projectType === ProjectType.NEXTJS ||
-      (builder !== 'webpack5' && supportedFrameworks.includes(projectType));
-    if (!supportsTestAddon) {
-      features.splice(features.indexOf('test'), 1);
-    }
-  }
 
   const {
     packages: frameworkPackages,

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -429,9 +429,23 @@ export async function doInitiate(options: CommandOptions): Promise<
     }
   }
 
-  const isTestFeatureEnabled = () =>
-    selectedFeatures.has('test') &&
-    (options.builder === CoreBuilder.Vite || projectType === ProjectType.NEXTJS);
+  const isTestFeatureEnabled = () => {
+    const supportedFrameworks: ProjectType[] = [
+      ProjectType.REACT,
+      ProjectType.VUE3,
+      ProjectType.NEXTJS,
+      ProjectType.NUXT,
+      ProjectType.PREACT,
+      ProjectType.SVELTE,
+      ProjectType.SVELTEKIT,
+      ProjectType.WEB_COMPONENTS,
+      ProjectType.REACT_NATIVE_WEB,
+    ];
+    const supportsTestAddon =
+      projectType === ProjectType.NEXTJS ||
+      (options.builder !== 'webpack5' && supportedFrameworks.includes(projectType));
+    return selectedFeatures.has('test') && supportsTestAddon;
+  };
 
   if (isTestFeatureEnabled()) {
     const packageVersionsData = await packageVersions.condition({ packageManager }, {} as any);
@@ -490,9 +504,6 @@ export async function doInitiate(options: CommandOptions): Promise<
   options.features = Array.from(selectedFeatures);
 
   const installResult = await installStorybook(projectType as ProjectType, packageManager, options);
-
-  // Sync features back because they may have been mutated by the generator (e.g. in case of undetected project type)
-  selectedFeatures = new Set(options.features);
 
   if (!options.skipInstall) {
     await packageManager.installDependencies();


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have refactored the features.test handling to make it more obvious

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-30920-sha-261c952a`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-30920-sha-261c952a sandbox` or in an existing project with `npx storybook@0.0.0-pr-30920-sha-261c952a upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-30920-sha-261c952a`](https://npmjs.com/package/storybook/v/0.0.0-pr-30920-sha-261c952a) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/only-install-addon-test-for-vite-based-projects`](https://github.com/storybookjs/storybook/tree/valentin/only-install-addon-test-for-vite-based-projects) |
| **Commit** | [`261c952a`](https://github.com/storybookjs/storybook/commit/261c952a7a7e11d003a99759924fb78ad61f964f) |
| **Datetime** | Tue Mar 25 10:21:57 UTC 2025 (`1742898117`) |
| **Workflow run** | [14057212574](https://github.com/storybookjs/storybook/actions/runs/14057212574) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=30920`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR consolidates interaction testing functionality into Storybook core and ensures the test addon is only installed for Vite-based or Next.js projects where it's supported.

- Moves all interaction testing components from `code/addons/interactions` to `code/core/src/component-testing`
- Removes `@storybook/addon-interactions` package as it's now part of core in Storybook 9.0
- Adds builder detection to only install test addon for Vite/Next.js projects
- Updates documentation and migration guide to reflect interactions addon consolidation
- Removes interactions addon from sandbox projects and test storybooks



<!-- /greptile_comment -->