### PR TITLE
Angular: Fix addon-a11y installation in angular prerelease sandboxes

### DIFF
--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -127,10 +127,7 @@ export const install: Task['run'] = async ({ sandboxDir, key }, { link, dryRun, 
   }
 };
 
-export const init: Task['run'] = async (
-  { sandboxDir, template },
-  { dryRun, debug, addon: addons, skipTemplateStories }
-) => {
+export const init: Task['run'] = async ({ sandboxDir, template }, { dryRun, debug }) => {
   const cwd = sandboxDir;
 
   let extra = {};
@@ -175,18 +172,6 @@ export const init: Task['run'] = async (
       await prepareAngularSandbox(cwd, template.name);
       break;
     default:
-  }
-
-  if (!skipTemplateStories) {
-    for (const addon of addons) {
-      await executeCLIStep(steps.add, {
-        argument: addon,
-        cwd,
-        dryRun,
-        debug,
-        optionValues: { yes: true },
-      });
-    }
   }
 };
 

--- a/scripts/tasks/sandbox-parts.ts
+++ b/scripts/tasks/sandbox-parts.ts
@@ -127,7 +127,10 @@ export const install: Task['run'] = async ({ sandboxDir, key }, { link, dryRun, 
   }
 };
 
-export const init: Task['run'] = async ({ sandboxDir, template }, { dryRun, debug }) => {
+export const init: Task['run'] = async (
+  { sandboxDir, template },
+  { dryRun, debug, addon: addons, skipTemplateStories }
+) => {
   const cwd = sandboxDir;
 
   let extra = {};
@@ -172,6 +175,18 @@ export const init: Task['run'] = async ({ sandboxDir, template }, { dryRun, debu
       await prepareAngularSandbox(cwd, template.name);
       break;
     default:
+  }
+
+  if (!skipTemplateStories) {
+    for (const addon of addons) {
+      await executeCLIStep(steps.add, {
+        argument: addon,
+        cwd,
+        dryRun,
+        debug,
+        optionValues: { yes: true },
+      });
+    }
   }
 };
 

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -133,6 +133,13 @@ export const sandbox: Task = {
       await addStories(details, options);
     }
 
+    await addExtraDependencies({
+      cwd: details.sandboxDir,
+      debug: options.debug,
+      dryRun: options.dryRun,
+      extraDeps,
+    });
+
     if (!options.skipTemplateStories) {
       for (const addon of options.addon) {
         await executeCLIStep(steps.add, {
@@ -148,13 +155,6 @@ export const sandbox: Task = {
     if (shouldAddVitestIntegration) {
       await setupVitest(details, options);
     }
-
-    await addExtraDependencies({
-      cwd: details.sandboxDir,
-      debug: options.debug,
-      dryRun: options.dryRun,
-      extraDeps,
-    });
 
     await extendMain(details, options);
     await setImportMap(details.sandboxDir);

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -80,8 +80,6 @@ export const sandbox: Task = {
 
     const shouldAddVitestIntegration = !details.template.skipTasks?.includes('vitest-integration');
 
-    options.addon.push('@storybook/addon-a11y');
-
     if (shouldAddVitestIntegration) {
       extraDeps.push('happy-dom', 'vitest', 'playwright', '@vitest/browser');
 
@@ -99,6 +97,8 @@ export const sandbox: Task = {
 
       options.addon.push('@storybook/addon-test');
     }
+
+    options.addon.push('@storybook/addon-a11y');
 
     let startTime = now();
     await create(details, options);

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -144,15 +144,15 @@ export const sandbox: Task = {
 
     if (!options.skipTemplateStories) {
       console.log('!!!', options.addon);
-      // for (const addon of options.addon) {
-      //   await executeCLIStep(steps.add, {
-      //     argument: addon,
-      //     cwd: details.sandboxDir,
-      //     dryRun: options.dryRun,
-      //     debug: options.debug,
-      //     optionValues: { yes: true },
-      //   });
-      // }
+      for (const addon of options.addon) {
+        await executeCLIStep(steps.add, {
+          argument: addon,
+          cwd: details.sandboxDir,
+          dryRun: options.dryRun,
+          debug: true,
+          optionValues: { yes: true },
+        });
+      }
     }
 
     if (shouldAddVitestIntegration) {

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -8,6 +8,7 @@ import { promisify } from 'util';
 
 import { now, saveBench } from '../bench/utils';
 import type { Task, TaskKey } from '../task';
+import { executeCLIStep, steps } from '../utils/cli-step';
 
 const logger = console;
 
@@ -142,6 +143,18 @@ export const sandbox: Task = {
       dryRun: options.dryRun,
       extraDeps,
     });
+
+    if (!options.skipTemplateStories) {
+      for (const addon of options.addon) {
+        await executeCLIStep(steps.add, {
+          argument: addon,
+          cwd: details.sandboxDir,
+          dryRun: options.dryRun,
+          debug: options.debug,
+          optionValues: { yes: true },
+        });
+      }
+    }
 
     await extendMain(details, options);
 

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -8,7 +8,6 @@ import { promisify } from 'util';
 
 import { now, saveBench } from '../bench/utils';
 import type { Task, TaskKey } from '../task';
-import { executeCLIStep, steps } from '../utils/cli-step';
 
 const logger = console;
 
@@ -143,18 +142,6 @@ export const sandbox: Task = {
       dryRun: options.dryRun,
       extraDeps,
     });
-
-    if (!options.skipTemplateStories) {
-      for (const addon of options.addon) {
-        await executeCLIStep(steps.add, {
-          argument: addon,
-          cwd: details.sandboxDir,
-          dryRun: options.dryRun,
-          debug: options.debug,
-          optionValues: { yes: true },
-        });
-      }
-    }
 
     await extendMain(details, options);
     await setImportMap(details.sandboxDir);

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -133,17 +133,6 @@ export const sandbox: Task = {
       await addStories(details, options);
     }
 
-    if (shouldAddVitestIntegration) {
-      await setupVitest(details, options);
-    }
-
-    await addExtraDependencies({
-      cwd: details.sandboxDir,
-      debug: options.debug,
-      dryRun: options.dryRun,
-      extraDeps,
-    });
-
     if (!options.skipTemplateStories) {
       for (const addon of options.addon) {
         await executeCLIStep(steps.add, {
@@ -155,6 +144,17 @@ export const sandbox: Task = {
         });
       }
     }
+
+    if (shouldAddVitestIntegration) {
+      await setupVitest(details, options);
+    }
+
+    await addExtraDependencies({
+      cwd: details.sandboxDir,
+      debug: options.debug,
+      dryRun: options.dryRun,
+      extraDeps,
+    });
 
     await extendMain(details, options);
     await setImportMap(details.sandboxDir);

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -140,7 +140,10 @@ export const sandbox: Task = {
       extraDeps,
     });
 
+    console.log('!!!', extraDeps);
+
     if (!options.skipTemplateStories) {
+      console.log('!!!', options.addon);
       for (const addon of options.addon) {
         await executeCLIStep(steps.add, {
           argument: addon,

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -157,7 +157,6 @@ export const sandbox: Task = {
     }
 
     await extendMain(details, options);
-
     await setImportMap(details.sandboxDir);
 
     const { JsPackageManagerFactory } = await import('../../code/core/src/common');

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -144,15 +144,15 @@ export const sandbox: Task = {
 
     if (!options.skipTemplateStories) {
       console.log('!!!', options.addon);
-      for (const addon of options.addon) {
-        await executeCLIStep(steps.add, {
-          argument: addon,
-          cwd: details.sandboxDir,
-          dryRun: options.dryRun,
-          debug: options.debug,
-          optionValues: { yes: true },
-        });
-      }
+      // for (const addon of options.addon) {
+      //   await executeCLIStep(steps.add, {
+      //     argument: addon,
+      //     cwd: details.sandboxDir,
+      //     dryRun: options.dryRun,
+      //     debug: options.debug,
+      //     optionValues: { yes: true },
+      //   });
+      // }
     }
 
     if (shouldAddVitestIntegration) {

--- a/scripts/tasks/sandbox.ts
+++ b/scripts/tasks/sandbox.ts
@@ -8,6 +8,7 @@ import { promisify } from 'util';
 
 import { now, saveBench } from '../bench/utils';
 import type { Task, TaskKey } from '../task';
+import { executeCLIStep, steps } from '../utils/cli-step';
 
 const logger = console;
 
@@ -142,6 +143,18 @@ export const sandbox: Task = {
       dryRun: options.dryRun,
       extraDeps,
     });
+
+    if (!options.skipTemplateStories) {
+      for (const addon of options.addon) {
+        await executeCLIStep(steps.add, {
+          argument: addon,
+          cwd: details.sandboxDir,
+          dryRun: options.dryRun,
+          debug: options.debug,
+          optionValues: { yes: true },
+        });
+      }
+    }
 
     await extendMain(details, options);
     await setImportMap(details.sandboxDir);

--- a/scripts/utils/exec.ts
+++ b/scripts/utils/exec.ts
@@ -39,12 +39,12 @@ export const exec = async (
 
   try {
     if (typeof command === 'string') {
-      logger.debug(`> ${command}`);
+      logger.log(`> ${command}`);
       currentChild = execa(command, { ...defaultOptions, ...options });
       await currentChild;
     } else {
       for (const subcommand of command) {
-        logger.debug(`> ${subcommand}`);
+        logger.log(`> ${subcommand}`);
         currentChild = execa(subcommand, { ...defaultOptions, ...options });
         await currentChild;
       }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I fixed an issue with the a11y addon installation in Angular CLI prerelease sandboxes.

The core problem is a timing issue with dependency installation introduced in PR #30774 

1. PR #30774 added `options.addon.push('@storybook/addon-a11y')` to always include the a11y addon in sandboxes
2. The Angular CLI prerelease sandbox template specifies `extraDependencies: ['@angular-devkit/build-angular@next']` in its configuration
3. This extra dependency needs to be installed BEFORE the a11y addon, as it provides critical peer dependencies required by @storybook/angular
4. In the current code, addon installation was happening in the `init` function before these extra dependencies were properly installed
5. This resulted in peer dependency conflicts for packages like `@angular-devkit/architect`, `@angular-devkit/core`, and `@angular/platform-browser-dynamic`

My fix moves the addon installation code from the `init` function to the main `sandbox` function, which ensures the extra dependencies are installed first, fixing the timing issue.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [x] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

1. Run a sandbox for the Angular CLI prerelease template: `yarn task --task sandbox --template angular-cli/prerelease --no-link`
2. Verify that Storybook initializes correctly and the a11y addon is installed without errors

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - [x] `bug`: Internal changes that fixes incorrect behavior.
  - [ ] `maintenance`: User-facing maintenance tasks.
  - [ ] `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - [ ] `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - [ ] `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - [ ] `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - [ ] `feature request`: Introducing a new feature.
  - [ ] `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - [ ] `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->