### PR TITLE
Addon Vitest: Cleanup unnecessary parameters

### DIFF
--- a/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer.test.ts
@@ -56,6 +56,12 @@ describe('transformer', () => {
 
       expect(result.code).toMatchInlineSnapshot(`console.log('Not a story file');`);
     });
+
+    it('should not transform non-story files', async () => {
+      const code = 'foo';
+      const result = await transform({ code, fileName: 'index.js' });
+      expect(result.code).toBe('foo');
+    });
   });
 
   describe('CSF v1/v2/v3', () => {
@@ -174,6 +180,72 @@ describe('transformer', () => {
           const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
           if (_isRunningFromThisFile) {
             _test("Story", _testStory("Story", Story, meta, []));
+          }
+        `);
+      });
+
+      it('should remove parameters.docs from meta object', async () => {
+        const code = `
+          export default {
+            title: 'Custom/Title',
+            parameters: {
+              docs: {
+                page: someMdx,
+              },
+              layout: 'fullscreen',
+            },
+          };
+          
+          export const Story = {};
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect } from "vitest";
+          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title",
+            parameters: {
+              layout: 'fullscreen'
+            }
+          };
+          export default _meta;
+          export const Story = {};
+          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _test("Story", _testStory("Story", Story, _meta, []));
+          }
+        `);
+      });
+
+      it('should remove empty parameters object after docs removal', async () => {
+        const code = `
+          export default {
+            title: 'Custom/Title',
+            parameters: {
+              docs: {
+                page: null,
+              },
+            },
+          };
+          
+          export const Story = {};
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect } from "vitest";
+          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Story = {};
+          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _test("Story", _testStory("Story", Story, _meta, []));
           }
         `);
       });
@@ -420,6 +492,71 @@ describe('transformer', () => {
           export default _meta;
           export const Story = {};
           _describe.skip("No valid tests found");
+        `);
+      });
+
+      it('should remove parameters.docs from story objects', async () => {
+        const code = `
+          export default { title: 'Custom/Title' };
+          
+          export const Story = {
+            parameters: {
+              docs: {
+                page: null,
+              },
+              layout: 'fullscreen',
+            },
+          };
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect } from "vitest";
+          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Story = {
+            parameters: {
+              layout: 'fullscreen'
+            }
+          };
+          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _test("Story", _testStory("Story", Story, _meta, []));
+          }
+        `);
+      });
+
+      it('should remove empty parameters object from story after docs removal', async () => {
+        const code = `
+          export default { title: 'Custom/Title' };
+          
+          export const Story = {
+            parameters: {
+              docs: {
+                page: null,
+              },
+            },
+          };
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, expect as _expect } from "vitest";
+          import { testStory as _testStory } from "@storybook/addon-vitest/internal/test-utils";
+          const _meta = {
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Story = {};
+          const _isRunningFromThisFile = import.meta.url.includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            _test("Story", _testStory("Story", Story, _meta, []));
+          }
         `);
       });
     });


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31305

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Potential solution for the listed issue. Needs discussion

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Here's my summary of the PR changes:

Adds parameter cleanup functionality to the Storybook Vitest transformer to prevent issues with MDX file parsing in portable stories testing.

- Added `cleanupParameters` function in `code/core/src/csf-tools/vitest-plugin/transformer.ts` to remove `parameters.docs` from story metadata
- Function removes docs parameters from both meta objects and individual story objects
- Added test coverage in `transformer.test.ts` to verify parameter cleanup behavior
- Maintains other parameters while only removing docs-related ones to preserve other functionality
- Fixes issue #31305 where Vitest breaks when trying to parse MDX files referenced in parameters.docs



<!-- /greptile_comment -->