### PR TITLE
Core: Centralize prebundling of execa

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -73,7 +73,6 @@
     "@radix-ui/react-tabs": "1.0.4",
     "@storybook/icons": "^1.4.0",
     "@testing-library/react": "^14.0.0",
-    "execa": "^9.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-resize-detector": "^7.1.2",

--- a/code/addons/a11y/src/postinstall.ts
+++ b/code/addons/a11y/src/postinstall.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line depend/ban-dependencies
-import { execa } from 'execa';
+import { execa } from 'storybook/internal/execa';
 
 import type { PostinstallOptions } from '../../../lib/cli-storybook/src/add';
 

--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -103,7 +103,6 @@
     "@vitest/runner": "^3.1.1",
     "boxen": "^8.0.1",
     "es-toolkit": "^1.36.0",
-    "execa": "^8.0.1",
     "find-up": "^7.0.0",
     "istanbul-lib-report": "^3.0.1",
     "pathe": "^1.1.2",

--- a/code/addons/vitest/src/node/boot-test-runner.test.ts
+++ b/code/addons/vitest/src/node/boot-test-runner.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Channel, type ChannelTransport } from 'storybook/internal/channels';
-
-// eslint-disable-next-line depend/ban-dependencies
-import { execaNode } from 'execa';
+import { execaNode } from 'storybook/internal/execa';
 
 import { storeOptions } from '../constants';
 import { log } from '../logger';
@@ -33,7 +31,7 @@ const child = vi.hoisted(() => ({
   kill: vi.fn(),
 }));
 
-vi.mock('execa', () => ({
+vi.mock('storybook/internal/execa', () => ({
   execaNode: vi.fn().mockReturnValue(child),
 }));
 

--- a/code/addons/vitest/src/node/boot-test-runner.ts
+++ b/code/addons/vitest/src/node/boot-test-runner.ts
@@ -5,10 +5,9 @@ import {
   internal_universalStatusStore,
   internal_universalTestProviderStore,
 } from 'storybook/internal/core-server';
+import { execaNode } from 'storybook/internal/execa';
 import type { EventInfo } from 'storybook/internal/types';
 
-// eslint-disable-next-line depend/ban-dependencies
-import { execaNode } from 'execa';
 import { join } from 'pathe';
 
 import {

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -16,10 +16,9 @@ import {
   versions,
 } from 'storybook/internal/common';
 import { readConfig, writeConfig } from 'storybook/internal/csf-tools';
+import { execa } from 'storybook/internal/execa';
 import { colors, logger } from 'storybook/internal/node-logger';
 
-// eslint-disable-next-line depend/ban-dependencies
-import { execa } from 'execa';
 import { findUp } from 'find-up';
 import { dirname, extname, join, relative, resolve } from 'pathe';
 import picocolors from 'picocolors';

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -349,6 +349,11 @@
       "import": "./dist/babel/index.js",
       "require": "./dist/babel/index.cjs"
     },
+    "./internal/execa": {
+      "types": "./dist/execa/index.d.ts",
+      "import": "./dist/execa/index.js",
+      "require": "./dist/execa/index.cjs"
+    },
     "./internal/cli/bin": {
       "types": "./dist/cli/bin/index.d.ts",
       "import": "./dist/cli/bin/index.js",
@@ -583,6 +588,9 @@
       "internal/babel": [
         "./dist/babel/index.d.ts"
       ],
+      "internal/execa": [
+        "./dist/execa/index.d.ts"
+      ],
       "internal/cli/bin": [
         "./dist/cli/bin/index.d.ts"
       ],
@@ -695,7 +703,7 @@
     "ejs": "^3.1.10",
     "es-toolkit": "^1.36.0",
     "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
-    "execa": "^8.0.1",
+    "execa": "^9.5.2",
     "fd-package-json": "^1.2.0",
     "fetch-retry": "^6.0.0",
     "find-cache-dir": "^5.0.0",

--- a/code/core/scripts/entries.ts
+++ b/code/core/scripts/entries.ts
@@ -68,6 +68,7 @@ export const getEntries = (cwd: string) => {
     define('src/preview/globals.ts', ['node'], true),
     define('src/cli/index.ts', ['node'], true),
     define('src/babel/index.ts', ['node'], true),
+    define('src/execa/index.ts', ['node'], true),
     define('src/cli/bin/index.ts', ['node'], true),
     define('src/bin/index.ts', ['node'], false),
 

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-// eslint-disable-next-line depend/ban-dependencies
-import { type CommonOptions, execaCommand, execaCommandSync } from 'execa';
+import { type CommonOptions, execaCommand, execaCommandSync } from 'storybook/internal/execa';
+
 import picocolors from 'picocolors';
 import { gt, satisfies } from 'semver';
 import invariant from 'tiny-invariant';

--- a/code/core/src/common/js-package-manager/JsPackageManager.ts
+++ b/code/core/src/common/js-package-manager/JsPackageManager.ts
@@ -2,7 +2,12 @@ import { existsSync, readFileSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import { type CommonOptions, execaCommand, execaCommandSync } from 'storybook/internal/execa';
+import {
+  type Options,
+  type SyncOptions,
+  execaCommand,
+  execaCommandSync,
+} from 'storybook/internal/execa';
 
 import picocolors from 'picocolors';
 import { gt, satisfies } from 'semver';
@@ -527,7 +532,7 @@ export abstract class JsPackageManager {
     ignoreError = false,
     env,
     ...execaOptions
-  }: CommonOptions<'utf8'> & {
+  }: SyncOptions & {
     command: string;
     args: string[];
     cwd?: string;
@@ -538,7 +543,6 @@ export abstract class JsPackageManager {
         cwd: cwd ?? this.cwd,
         stdio: stdio ?? 'pipe',
         shell: true,
-        cleanup: true,
         env: {
           ...COMMON_ENV_VARS,
           ...env,
@@ -546,7 +550,7 @@ export abstract class JsPackageManager {
         ...execaOptions,
       });
 
-      return commandResult.stdout ?? '';
+      return commandResult.stdout?.toString() ?? '';
     } catch (err) {
       if (ignoreError !== true) {
         throw err;
@@ -573,7 +577,7 @@ export abstract class JsPackageManager {
     ignoreError = false,
     env,
     ...execaOptions
-  }: CommonOptions<'utf8'> & {
+  }: Options & {
     command: string;
     args: string[];
     cwd?: string;
@@ -585,7 +589,6 @@ export abstract class JsPackageManager {
         stdio: stdio ?? 'pipe',
         encoding: 'utf8',
         shell: true,
-        cleanup: true,
         env: {
           ...COMMON_ENV_VARS,
           ...env,
@@ -593,7 +596,7 @@ export abstract class JsPackageManager {
         ...execaOptions,
       });
 
-      return commandResult.stdout ?? '';
+      return commandResult.stdout?.toString() ?? '';
     } catch (err) {
       if (ignoreError !== true) {
         throw err;

--- a/code/core/src/execa/index.ts
+++ b/code/core/src/execa/index.ts
@@ -1,0 +1,1 @@
+export * from 'execa';

--- a/code/core/src/telemetry/exec-command-count-lines.test.ts
+++ b/code/core/src/telemetry/exec-command-count-lines.test.ts
@@ -3,12 +3,11 @@ import { PassThrough } from 'node:stream';
 
 import { beforeEach, describe, expect, it, vitest } from 'vitest';
 
-// eslint-disable-next-line depend/ban-dependencies
-import { execaCommand as rawExecaCommand } from 'execa';
+import { execaCommand as rawExecaCommand } from 'storybook/internal/execa';
 
 import { execCommandCountLines } from './exec-command-count-lines';
 
-vitest.mock('execa');
+vitest.mock('storybook/internal/execa');
 
 const execaCommand = vitest.mocked(rawExecaCommand);
 beforeEach(() => {

--- a/code/core/src/telemetry/exec-command-count-lines.ts
+++ b/code/core/src/telemetry/exec-command-count-lines.ts
@@ -1,7 +1,6 @@
 import { createInterface } from 'node:readline';
 
-// eslint-disable-next-line depend/ban-dependencies
-import { execaCommand } from 'execa';
+import { execaCommand } from 'storybook/internal/execa';
 
 /**
  * Execute a command in the local terminal and count the lines in the result

--- a/code/lib/cli-storybook/package.json
+++ b/code/lib/cli-storybook/package.json
@@ -48,7 +48,6 @@
     "create-storybook": "workspace:*",
     "cross-spawn": "^7.0.6",
     "envinfo": "^7.7.3",
-    "execa": "^9.5.2",
     "giget": "^1.0.0",
     "globby": "^14.0.1",
     "jscodeshift": "^0.15.1",

--- a/code/lib/cli-storybook/src/automigrate/fixes/rnstorybook-config.test.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/rnstorybook-config.test.ts
@@ -2,10 +2,9 @@ import { existsSync } from 'node:fs';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { $ } from 'storybook/internal/execa';
 import type { StorybookConfigRaw } from 'storybook/internal/types';
 
-// eslint-disable-next-line depend/ban-dependencies
-import { $ } from 'execa';
 // eslint-disable-next-line depend/ban-dependencies
 import { globby } from 'globby';
 
@@ -19,7 +18,7 @@ const mockMainConfig: StorybookConfigRaw = {
 };
 
 vi.mock('node:fs');
-vi.mock('execa');
+vi.mock('storybook/internal/execa');
 vi.mock('globby');
 
 describe('react-native-config fix', () => {

--- a/code/lib/cli-storybook/src/automigrate/fixes/rnstorybook-config.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/rnstorybook-config.ts
@@ -26,8 +26,7 @@ async function renameInFile(filePath: string, oldText: string, newText: string):
 
 const getDotStorybookReferences = async () => {
   try {
-    // eslint-disable-next-line depend/ban-dependencies
-    const { $ } = await import('execa');
+    const { $ } = await import('storybook/internal/execa');
     const { stdout } = await $`git grep -l \\.storybook`;
     return stdout.split('\n').filter(Boolean);
   } catch (error) {

--- a/code/lib/create-storybook/package.json
+++ b/code/lib/create-storybook/package.json
@@ -46,7 +46,6 @@
     "@types/semver": "^7.3.4",
     "boxen": "^7.1.1",
     "commander": "^12.1.0",
-    "execa": "^5.0.0",
     "find-up": "^7.0.0",
     "ora": "^5.4.1",
     "picocolors": "^1.1.0",

--- a/code/lib/create-storybook/src/scaffold-new-project.ts
+++ b/code/lib/create-storybook/src/scaffold-new-project.ts
@@ -1,9 +1,9 @@
 import { readdirSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 
+import { execaCommand } from 'storybook/internal/execa';
+
 import boxen from 'boxen';
-// eslint-disable-next-line depend/ban-dependencies
-import execa from 'execa';
 import picocolors from 'picocolors';
 import prompts from 'prompts';
 import { dedent } from 'ts-dedent';
@@ -190,7 +190,7 @@ export const scaffoldNewProject = async (
 
   try {
     // Create new project in temp directory
-    await execa.command(createScript, {
+    await execaCommand(createScript, {
       stdio: 'pipe',
       shell: true,
       cwd: targetDir,

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -5889,7 +5889,6 @@ __metadata:
     "@storybook/icons": "npm:^1.4.0"
     "@testing-library/react": "npm:^14.0.0"
     axe-core: "npm:^4.2.0"
-    execa: "npm:^9.5.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-resize-detector: "npm:^7.1.2"
@@ -6024,7 +6023,6 @@ __metadata:
     "@vitest/runner": "npm:^3.1.1"
     boxen: "npm:^8.0.1"
     es-toolkit: "npm:^1.36.0"
-    execa: "npm:^8.0.1"
     find-up: "npm:^7.0.0"
     istanbul-lib-report: "npm:^3.0.1"
     pathe: "npm:^1.1.2"
@@ -6215,7 +6213,6 @@ __metadata:
     create-storybook: "workspace:*"
     cross-spawn: "npm:^7.0.6"
     envinfo: "npm:^7.7.3"
-    execa: "npm:^9.5.2"
     giget: "npm:^1.0.0"
     globby: "npm:^14.0.1"
     jscodeshift: "npm:^0.15.1"
@@ -11764,7 +11761,6 @@ __metadata:
     "@types/semver": "npm:^7.3.4"
     boxen: "npm:^7.1.1"
     commander: "npm:^12.1.0"
-    execa: "npm:^5.0.0"
     find-up: "npm:^7.0.0"
     ora: "npm:^5.4.1"
     picocolors: "npm:^1.1.0"
@@ -14332,23 +14328,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "execa@npm:8.0.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.3"
-    get-stream: "npm:^8.0.1"
-    human-signals: "npm:^5.0.0"
-    is-stream: "npm:^3.0.0"
-    merge-stream: "npm:^2.0.0"
-    npm-run-path: "npm:^5.1.0"
-    onetime: "npm:^6.0.0"
-    signal-exit: "npm:^4.1.0"
-    strip-final-newline: "npm:^3.0.0"
-  checksum: 10c0/2c52d8775f5bf103ce8eec9c7ab3059909ba350a5164744e9947ed14a53f51687c040a250bda833f906d1283aa8803975b84e6c8f7a7c42f99dc8ef80250d1af
-  languageName: node
-  linkType: hard
-
 "execa@npm:^9.5.2":
   version: 9.5.2
   resolution: "execa@npm:9.5.2"
@@ -15374,13 +15353,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "get-stream@npm:8.0.1"
-  checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^9.0.0":
   version: 9.0.1
   resolution: "get-stream@npm:9.0.1"
@@ -16364,13 +16336,6 @@ __metadata:
   version: 4.3.1
   resolution: "human-signals@npm:4.3.1"
   checksum: 10c0/40498b33fe139f5cc4ef5d2f95eb1803d6318ac1b1c63eaf14eeed5484d26332c828de4a5a05676b6c83d7b9e57727c59addb4b1dea19cb8d71e83689e5b336c
-  languageName: node
-  linkType: hard
-
-"human-signals@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "human-signals@npm:5.0.0"
-  checksum: 10c0/5a9359073fe17a8b58e5a085e9a39a950366d9f00217c4ff5878bd312e09d80f460536ea6a3f260b5943a01fe55c158d1cea3fc7bee3d0520aeef04f6d915c82
   languageName: node
   linkType: hard
 
@@ -24511,7 +24476,7 @@ __metadata:
     es-toolkit: "npm:^1.36.0"
     esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0"
     esbuild-register: "npm:^3.5.0"
-    execa: "npm:^8.0.1"
+    execa: "npm:^9.5.2"
     fd-package-json: "npm:^1.2.0"
     fetch-retry: "npm:^6.0.0"
     find-cache-dir: "npm:^5.0.0"


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have centralized the execa dependency into `storybook`, exporting now a `storybook/internal/execa` entry, which all the other packages can use. This optimization takes care of reducing the bundle size of all packages, which are requiring execa.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Centralizes the `execa` dependency across Storybook packages by introducing a shared import path `storybook/internal/execa`, reducing bundle size and maintaining consistent versioning.

- Added new entry point `code/core/src/execa/index.ts` to serve as the central export for execa functionality
- Updated `code/core/package.json` to export `storybook/internal/execa` and upgraded execa from 8.0.1 to 9.5.2
- Removed direct `execa` dependencies from multiple packages including `@storybook/cli`, `@storybook/vitest`, and `@storybook/a11y`
- Modified import statements across codebase to use new centralized path `storybook/internal/execa`



<!-- /greptile_comment -->