### PR TITLE
Init: Fixing initialization issues with yarn

### DIFF
--- a/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.test.ts
@@ -117,14 +117,14 @@ describe('Yarn 2 Proxy', () => {
     it('without constraint it returns the latest version', async () => {
       const executeCommandSpy = vi
         .spyOn(yarn2Proxy, 'executeCommand')
-        .mockResolvedValueOnce('{"name":"storybook","version":"5.3.19"}');
+        .mockResolvedValueOnce('5.3.19');
 
       const version = await yarn2Proxy.latestVersion('storybook');
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          command: 'yarn',
-          args: ['npm', 'info', 'storybook', '--fields', 'version', '--json'],
+          command: 'npm',
+          args: ['info', 'storybook', 'version'],
         })
       );
       expect(version).toEqual('5.3.19');
@@ -133,16 +133,14 @@ describe('Yarn 2 Proxy', () => {
     it('with constraint it returns the latest version satisfying the constraint', async () => {
       const executeCommandSpy = vi
         .spyOn(yarn2Proxy, 'executeCommand')
-        .mockResolvedValueOnce(
-          '{"name":"storybook","versions":["4.25.3","5.3.19","6.0.0-beta.23"]}'
-        );
+        .mockResolvedValueOnce('["4.25.3","5.3.19","6.0.0-beta.23"]');
 
       const version = await yarn2Proxy.latestVersion('storybook', '5.X');
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          command: 'yarn',
-          args: ['npm', 'info', 'storybook', '--fields', 'versions', '--json'],
+          command: 'npm',
+          args: ['info', 'storybook', 'versions', '--json'],
         })
       );
       expect(version).toEqual('5.3.19');
@@ -151,7 +149,7 @@ describe('Yarn 2 Proxy', () => {
     it('throws an error if command output is not a valid JSON', async () => {
       vi.spyOn(yarn2Proxy, 'executeCommand').mockResolvedValueOnce('NOT A JSON');
 
-      await expect(yarn2Proxy.latestVersion('storybook')).rejects.toThrow();
+      await expect(yarn2Proxy.latestVersion('storybook', '5.X')).rejects.toThrow();
     });
   });
 

--- a/code/core/src/common/js-package-manager/Yarn2Proxy.ts
+++ b/code/core/src/common/js-package-manager/Yarn2Proxy.ts
@@ -259,16 +259,21 @@ export class Yarn2Proxy extends JsPackageManager {
     packageName: string,
     fetchAllVersions: T
   ): Promise<T extends true ? string[] : string> {
-    const field = fetchAllVersions ? 'versions' : 'version';
-    const args = ['--fields', field, '--json'];
+    const args = fetchAllVersions ? ['versions', '--json'] : ['version'];
     try {
       const commandResult = await this.executeCommand({
-        command: 'yarn',
-        args: ['npm', 'info', packageName, ...args],
+        command: 'npm',
+        args: ['info', packageName, ...args],
       });
 
-      const parsedOutput = JSON.parse(commandResult);
-      return parsedOutput[field];
+      const parsedOutput = fetchAllVersions ? JSON.parse(commandResult) : commandResult.trim();
+
+      if (parsedOutput.error?.summary) {
+        // this will be handled in the catch block below
+        throw parsedOutput.error.summary;
+      }
+
+      return parsedOutput;
     } catch (error) {
       throw new FindPackageVersionsError({
         error,

--- a/docs/_snippets/create-command-custom-version.md
+++ b/docs/_snippets/create-command-custom-version.md
@@ -5,7 +5,3 @@ npm create storybook@8.3
 ```shell renderer="common" language="js" packageManager="pnpm"
 pnpm create storybook@8.3
 ```
-
-```shell renderer="common" language="js" packageManager="yarn"
-yarn create storybook@8.3
-```

--- a/docs/_snippets/create-command.md
+++ b/docs/_snippets/create-command.md
@@ -7,5 +7,5 @@ pnpm create storybook@latest
 ```
 
 ```shell renderer="common" language="js" packageManager="yarn"
-yarn create storybook@latest
+yarn create storybook
 ```

--- a/docs/get-started/install.mdx
+++ b/docs/get-started/install.mdx
@@ -24,7 +24,7 @@ Use the Storybook CLI to install it in a single command. Run this inside your pr
 
   {/* prettier-ignore-end */}
 
-  To install a Storybook version prior to 8.3, you must use the `init` command:
+  To install a Storybook version prior to 8.3 or with yarn, you must use the `init` command:
 
   {/* prettier-ignore-start */}
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31426

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Yarn's create command doesn't support versions or tags, hence we have to use `yarn dlx` instead.

Second, during init, `yarn npm info ...` requires a package.json, which does not exist when Storybook is initialized in empty directories. Therefore, to check the latest version of Storybook, we will use the `npm info` command in `yarn` projects to avoid this error.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31428-sha-c6e494c2`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31428-sha-c6e494c2 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31428-sha-c6e494c2 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31428-sha-c6e494c2`](https://npmjs.com/package/storybook/v/0.0.0-pr-31428-sha-c6e494c2) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/fix-init-with-yarn`](https://github.com/storybookjs/storybook/tree/valentin/fix-init-with-yarn) |
| **Commit** | [`c6e494c2`](https://github.com/storybookjs/storybook/commit/c6e494c2cd728b54129b87fcf2ec275beecda5b2) |
| **Datetime** | Fri May  9 13:46:57 UTC 2025 (`1746798417`) |
| **Workflow run** | [14930388227](https://github.com/storybookjs/storybook/actions/runs/14930388227) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31428`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Updates Storybook's initialization process to fix compatibility issues with Yarn, particularly addressing problems with version checking and empty directory initialization.

- Modified `code/core/src/common/js-package-manager/Yarn2Proxy.ts` to use `npm info` instead of `yarn npm info` for version checks
- Updated docs to remove Yarn's `create` command usage in `docs/_snippets/create-command-custom-version.md`
- Changed initialization instructions in `docs/get-started/install.mdx` to use `yarn dlx` instead of `yarn create`
- Standardized documentation across package managers to maintain consistency in version handling



<!-- /greptile_comment -->