### PR TITLE
Core: Avoid circular dependency while using definePreview

### DIFF
--- a/code/core/src/actions/preview.ts
+++ b/code/core/src/actions/preview.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import * as addArgs from './addArgs';
 import * as loaders from './loaders';
 

--- a/code/core/src/backgrounds/preview.ts
+++ b/code/core/src/backgrounds/preview.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import { PARAM_KEY } from './constants';
 import { withBackgroundAndGrid } from './decorator';
 import type { BackgroundsParameters, GlobalState } from './types';

--- a/code/core/src/component-testing/preview.ts
+++ b/code/core/src/component-testing/preview.ts
@@ -1,7 +1,7 @@
 import { instrument } from 'storybook/internal/instrumenter';
 import type { PlayFunction, StepLabel, StoryContext } from 'storybook/internal/types';
 
-import { definePreview } from 'storybook/preview-api';
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 
 const { step } = instrument(
   {

--- a/code/core/src/controls/preview.ts
+++ b/code/core/src/controls/preview.ts
@@ -1,4 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 
 export default definePreview({
   // Controls addon doesn't need any preview-side configuration

--- a/code/core/src/measure/index.ts
+++ b/code/core/src/measure/index.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import * as addonAnnotations from './preview';
 
 export type { MeasureParameters } from './types';

--- a/code/core/src/measure/preview.ts
+++ b/code/core/src/measure/preview.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import { PARAM_KEY } from './constants';
 import { withMeasure } from './withMeasure';
 

--- a/code/core/src/outline/index.ts
+++ b/code/core/src/outline/index.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import * as addonAnnotations from './preview';
 
 export type { OutlineParameters } from './types';

--- a/code/core/src/outline/preview.ts
+++ b/code/core/src/outline/preview.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import { PARAM_KEY } from './constants';
 import { withOutline } from './withOutline';
 

--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -1,7 +1,6 @@
 import type { LoaderFunction } from 'storybook/internal/csf';
 import { instrument } from 'storybook/internal/instrumenter';
 
-import { definePreview } from 'storybook/preview-api';
 import {
   clearAllMocks,
   fn,
@@ -11,6 +10,8 @@ import {
   uninstrumentedUserEvent,
   within,
 } from 'storybook/test';
+
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 
 const resetAllMocksLoader: LoaderFunction = ({ parameters }) => {
   if (parameters?.test?.mockReset === true) {

--- a/code/core/src/viewport/preview.ts
+++ b/code/core/src/viewport/preview.ts
@@ -1,5 +1,4 @@
-import { definePreview } from 'storybook/preview-api';
-
+import { definePreview } from '../preview-api/modules/addons/definePreview';
 import { PARAM_KEY } from './constants';
 import type { GlobalState } from './types';
 


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/31573

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

I have avoided circular dependencies when using `definePreview` in the `storybook` package by relatively depending on `definePreview`.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31587-sha-f39414cb`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31587-sha-f39414cb sandbox` or in an existing project with `npx storybook@0.0.0-pr-31587-sha-f39414cb upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31587-sha-f39414cb`](https://npmjs.com/package/storybook/v/0.0.0-pr-31587-sha-f39414cb) |
| **Triggered by** | @valentinpalkovic |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`valentin/avoid-circular-dependencies-for-define-preview-usage`](https://github.com/storybookjs/storybook/tree/valentin/avoid-circular-dependencies-for-define-preview-usage) |
| **Commit** | [`f39414cb`](https://github.com/storybookjs/storybook/commit/f39414cb36c3ba3ff3bdb24d3a8364a0fb71efdb) |
| **Datetime** | Wed May 28 04:57:21 UTC 2025 (`1748408241`) |
| **Workflow run** | [15291851253](https://github.com/storybookjs/storybook/actions/runs/15291851253) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31587`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

This PR modifies import paths for `definePreview` across multiple core files to resolve circular dependencies that were causing Metro bundler crashes in React Native projects when React compiler is enabled.

- Changed imports in 10 core files from `storybook/preview-api` to `../preview-api/modules/addons/definePreview`
- Resolves issue #31573 by eliminating cyclic dependency chain: `storybook/preview-api -> storybook/measure -> storybook/preview-api`
- Maintains existing functionality while using direct relative imports
- Fixes Metro bundler crashes specifically when React compiler is enabled in React Native projects



<!-- /greptile_comment -->