### PR TITLE
Core: Fix copy to clipboard functionality in preview

### DIFF
--- a/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
+++ b/code/core/src/components/components/syntaxhighlighter/syntaxhighlighter.tsx
@@ -225,18 +225,14 @@ export const SyntaxHighlighter = ({
 
   const [copied, setCopied] = useState(false);
 
-  const onClick = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault();
-      copyToClipboard(highlightableCode)
-        .then(() => {
-          setCopied(true);
-          globalWindow.setTimeout(() => setCopied(false), 1500);
-        })
-        .catch(logger.error);
-    },
-    [highlightableCode]
-  );
+  const onClick = useCallback(() => {
+    copyToClipboard(highlightableCode)
+      .then(() => {
+        setCopied(true);
+        globalWindow.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(logger.error);
+  }, [highlightableCode]);
   const renderer = wrapRenderer(rest.renderer, showLineNumbers);
 
   return (

--- a/code/core/src/components/components/typography/link/link.test.tsx
+++ b/code/core/src/components/components/typography/link/link.test.tsx
@@ -20,7 +20,7 @@ function ThemedLink(props: LinkProps & AnchorHTMLAttributes<HTMLAnchorElement>) 
 }
 
 async function click(target: Element, button: string, modifier?: string) {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ writeToClipboard: true });
   if (modifier) {
     // Trailing > means to leave it pressed
     await user.keyboard(`{${modifier}>}`);

--- a/code/core/src/test/preview.ts
+++ b/code/core/src/test/preview.ts
@@ -94,7 +94,7 @@ const enhanceContext: LoaderFunction = async (context) => {
   // which will throw an error in react native for example.
   if (globalThis.window?.navigator?.clipboard) {
     context.userEvent = instrument(
-      { userEvent: uninstrumentedUserEvent.setup() },
+      { userEvent: uninstrumentedUserEvent.setup({ writeToClipboard: true }) },
       { intercept: true }
     ).userEvent;
 


### PR DESCRIPTION
Closes #31626

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

- Pass `{ writeToClipboard: true }` to `userEvent.setup` in order to allow clipboard usage despite mocking the clipboard.
- Removed `event.preventDefault()` from the Docs syntax highlighter's event handler so that `@testing-library/user-event` won't block the clipboard write from going through.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-31666-sha-2d5d3891`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-31666-sha-2d5d3891 sandbox` or in an existing project with `npx storybook@0.0.0-pr-31666-sha-2d5d3891 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-31666-sha-2d5d3891`](https://npmjs.com/package/storybook/v/0.0.0-pr-31666-sha-2d5d3891) |
| **Triggered by** | @ghengeveld |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`user-event-write-to-clipboard`](https://github.com/storybookjs/storybook/tree/user-event-write-to-clipboard) |
| **Commit** | [`2d5d3891`](https://github.com/storybookjs/storybook/commit/2d5d389178eecb53669db359b3c71c5a8aa2c8bf) |
| **Datetime** | Thu Jun  5 10:12:31 UTC 2025 (`1749118351`) |
| **Workflow run** | [15464408849](https://github.com/storybookjs/storybook/actions/runs/15464408849) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=31666`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Enables clipboard functionality in Storybook v9 by adding `writeToClipboard: true` to `userEvent.setup()` configuration, fixing issue #31626 where users were unable to paste clipboard content.

- Modified `code/core/src/test/preview.ts` to enable clipboard functionality in userEvent setup
- Updated `code/core/src/components/components/typography/link/link.test.tsx` to support clipboard operations in link tests
- Restores clipboard paste functionality that was working in Storybook v8.6.14



<!-- /greptile_comment -->