### PR TITLE
Angular: Support stats-json

### DIFF
--- a/code/frameworks/angular/build-schema.json
+++ b/code/frameworks/angular/build-schema.json
@@ -67,18 +67,35 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": ["-e", "json"],
+      "default": [
+        "-e",
+        "json"
+      ],
       "items": {
         "type": "string"
       }
     },
     "webpackStatsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
     "statsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
+      "description": "Write stats JSON to disk",
+      "default": false
+    },
+    "stats-json": {
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write stats JSON to disk",
       "default": false
     },
@@ -116,7 +133,10 @@
       }
     },
     "sourceMap": {
-      "type": ["boolean", "object"],
+      "type": [
+        "boolean",
+        "object"
+      ],
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
@@ -159,7 +179,11 @@
             }
           },
           "additionalProperties": false,
-          "required": ["glob", "input", "output"]
+          "required": [
+            "glob",
+            "input",
+            "output"
+          ]
         },
         {
           "type": "string"
@@ -187,7 +211,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["input"]
+          "required": [
+            "input"
+          ]
         },
         {
           "type": "string",

--- a/code/frameworks/angular/src/builders/build-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/build-storybook/index.ts
@@ -136,7 +136,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (
         },
         tsConfig,
         webpackStatsJson,
-        statsJson,
+        statsJson: statsJson ?? (options['stats-json'] as string | boolean),
         debugWebpack,
         previewUrl,
       };

--- a/code/frameworks/angular/src/builders/start-storybook/index.ts
+++ b/code/frameworks/angular/src/builders/start-storybook/index.ts
@@ -161,7 +161,7 @@ const commandBuilder: BuilderHandlerFn<StorybookBuilderOptions> = (options, cont
         open,
         debugWebpack,
         webpackStatsJson,
-        statsJson,
+        statsJson: statsJson ?? (options['stats-json'] as string | boolean),
         loglevel,
         previewUrl,
       };

--- a/code/frameworks/angular/start-schema.json
+++ b/code/frameworks/angular/start-schema.json
@@ -93,7 +93,10 @@
     "compodocArgs": {
       "type": "array",
       "description": "Compodoc options : https://compodoc.app/guides/options.html. Options `-p` with tsconfig path and `-d` with workspace root is always given.",
-      "default": ["-e", "json"],
+      "default": [
+        "-e",
+        "json"
+      ],
       "items": {
         "type": "string"
       }
@@ -132,12 +135,26 @@
       "description": "URL path to be appended when visiting Storybook for the first time"
     },
     "webpackStatsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write Webpack Stats JSON to disk",
       "default": false
     },
     "statsJson": {
-      "type": ["boolean", "string"],
+      "type": [
+        "boolean",
+        "string"
+      ],
+      "description": "Write stats JSON to disk",
+      "default": false
+    },
+    "stats-json": {
+      "type": [
+        "boolean",
+        "string"
+      ],
       "description": "Write stats JSON to disk",
       "default": false
     },
@@ -151,7 +168,10 @@
       "pattern": "(silly|verbose|info|warn|silent)"
     },
     "sourceMap": {
-      "type": ["boolean", "object"],
+      "type": [
+        "boolean",
+        "object"
+      ],
       "description": "Configure sourcemaps. See: https://angular.io/guide/workspace-config#source-map-configuration",
       "default": false
     },
@@ -194,7 +214,11 @@
             }
           },
           "additionalProperties": false,
-          "required": ["glob", "input", "output"]
+          "required": [
+            "glob",
+            "input",
+            "output"
+          ]
         },
         {
           "type": "string"
@@ -222,7 +246,9 @@
             }
           },
           "additionalProperties": false,
-          "required": ["input"]
+          "required": [
+            "input"
+          ]
         },
         {
           "type": "string",


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/29193

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- greptile_comment -->

## Greptile Summary

Added support for the `--stats-json` flag in Angular's Storybook configuration to fix Chromatic build compatibility issues.

- Added `stats-json` field in `code/frameworks/angular/build-schema.json` and `start-schema.json` while maintaining backward compatibility
- Updated builders in `code/frameworks/angular/src/builders/build-storybook/index.ts` to handle both camelCase and kebab-case parameter formats
- Modified `code/frameworks/angular/src/builders/start-storybook/index.ts` to support both `statsJson` and `stats-json` parameters
- Ensured compatibility with existing `webpackStatsJson` field while supporting new hyphenated format



<!-- /greptile_comment -->