### PR TITLE
Revert "CLI: Fix `sb` CLI by explicitly exporting `bin/index.cjs` from `storybook` package"

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -274,7 +274,6 @@
     "./internal/manager/globals-runtime": {
       "import": "./dist/manager/globals-runtime.js"
     },
-    "./bin/index.cjs": "./bin/index.cjs",
     "./package.json": "./package.json",
     "./internal/package.json": "./package.json"
   },

--- a/code/core/scripts/helpers/generatePackageJsonFile.ts
+++ b/code/core/scripts/helpers/generatePackageJsonFile.ts
@@ -68,9 +68,6 @@ export async function generatePackageJsonFile(entries: ReturnType<typeof getEntr
     return acc;
   }, {});
 
-  // Add CLI entry so `sb` can require it.
-  pkgJson.exports['./bin/index.cjs'] = './bin/index.cjs';
-
   // Add the package.json file to the exports, so we can use it to `require.resolve` the package's root easily
   pkgJson.exports['./package.json'] = './package.json';
   pkgJson.exports['./internal/package.json'] = './package.json';


### PR DESCRIPTION
Reverts storybookjs/storybook#31922

<!-- greptile_comment -->

## Greptile Summary

Reverts changes that explicitly exported `bin/index.cjs` in package.json exports map, returning to standard Node.js package binary exposure through the `bin` field.

- Removes explicit `./bin/index.cjs` export from `code/core/package.json` exports map
- Reverts changes in `code/core/scripts/helpers/generatePackageJsonFile.ts` that added CLI entry point exports
- CLI binary remains accessible through standard `bin` field specification on line 422
- May reintroduce `ERR_PACKAGE_PATH_NOT_EXPORTED` error when using direct `require()` of `storybook/bin/index.cjs`



<!-- /greptile_comment -->