### PR TITLE
Addon Vitest: Reset `currentRun` data when starting new test

### DIFF
--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -103,6 +103,7 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
     testProviderStore.setState('test-provider-state:running');
     store.setState((s) => ({
       ...s,
+      currentRun: storeOptions.initialState.currentRun,
       fatalError: undefined,
     }));
     runTestRunner({

--- a/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
@@ -216,8 +216,8 @@ test.describe("component testing", () => {
 
     await runTestsButton.click();
     await expect(watchModeButton).toBeDisabled();
-
-    await expect(testingModuleDescription).toContainText("Testing");
+    await expect(testingModuleDescription).toContainText("Starting...");
+    await expect(testingModuleDescription).toContainText("Testing...");
 
     // Wait for test results to appear
     await expect(testingModuleDescription).toHaveText(/Ran \d+ tests/, {

--- a/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/e2e-tests/component-testing.spec.ts
@@ -205,10 +205,6 @@ test.describe("component testing", () => {
       "Run component tests"
     );
 
-    const testingModuleDescription = await page.locator(
-      "#testing-module-description"
-    );
-
     const runTestsButton = await page.getByLabel("Start test run");
     const watchModeButton = await page.getByLabel("Enable watch mode");
     await expect(runTestsButton).toBeEnabled();
@@ -216,13 +212,18 @@ test.describe("component testing", () => {
 
     await runTestsButton.click();
     await expect(watchModeButton).toBeDisabled();
-    await expect(testingModuleDescription).toContainText("Starting...");
-    await expect(testingModuleDescription).toContainText("Testing...");
+    await expect(page.locator("#testing-module-description")).toHaveText(
+      /Starting/
+    );
+    await expect(page.locator("#testing-module-description")).toHaveText(
+      /Testing/
+    );
 
     // Wait for test results to appear
-    await expect(testingModuleDescription).toHaveText(/Ran \d+ tests/, {
-      timeout: 30000,
-    });
+    await expect(page.locator("#testing-module-description")).toHaveText(
+      /Ran \d+ tests/,
+      { timeout: 30000 }
+    );
 
     await expect(runTestsButton).toBeEnabled();
     await expect(watchModeButton).toBeEnabled();

--- a/test-storybooks/portable-stories-kitchen-sink/react/playwright-e2e.config.ts
+++ b/test-storybooks/portable-stories-kitchen-sink/react/playwright-e2e.config.ts
@@ -56,7 +56,5 @@ export default defineConfig({
     command: "yarn storybook",
     url: "http://127.0.0.1:6006",
     reuseExistingServer: true,
-    stdout: "pipe",
-    stderr: "pipe",
   },
 });


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Prevent the testing module from briefly showing "Ran x tests" (from the previous run) when starting a new test run. This should resolve flake such as [this](https://app.circleci.com/pipelines/github/storybookjs/storybook/100122/workflows/8890b731-2719-456c-8716-109cfcb3bc1d/jobs/845241/tests) one.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
