### PR TITLE
Revert "Addon Vitest: Remove Optimize deps candidates due to Vitest warnings"

### DIFF
--- a/code/addons/vitest/src/vitest-plugin/index.ts
+++ b/code/addons/vitest/src/vitest-plugin/index.ts
@@ -330,6 +330,7 @@ export const storybookTest = async (options?: UserOptions): Promise<Plugin[]> =>
         optimizeDeps: {
           include: [
             ...extraOptimizeDeps,
+            ...INCLUDE_CANDIDATES,
             '@storybook/addon-vitest/internal/setup-file',
             '@storybook/addon-vitest/internal/global-setup',
             '@storybook/addon-vitest/internal/test-utils',


### PR DESCRIPTION
Reverts storybookjs/storybook#31809

<!-- greptile_comment -->

## Greptile Summary

Reverts removal of dependency optimization candidates in Vitest addon, restoring the pre-bundling configuration for improved build performance.

- Restores `INCLUDE_CANDIDATES` in `code/addons/vitest/src/vitest-plugin/index.ts` for dependency optimization
- Re-enables pre-bundling of common dependencies for better build performance
- May reintroduce some Vitest warnings, but preserves optimization benefits



<!-- /greptile_comment -->