### PR TITLE
Revert "Core: Fix FIPS compliance"

### DIFF
--- a/code/core/src/common/utils/file-cache.ts
+++ b/code/core/src/common/utils/file-cache.ts
@@ -35,7 +35,7 @@ export class FileSystemCache {
 
   constructor(options: FileSystemCacheOptions = {}) {
     this.prefix = (options.ns || options.prefix || '') + '-';
-    this.hash_alg = options.hash_alg || 'sha256';
+    this.hash_alg = options.hash_alg || 'md5';
     this.cache_dir =
       options.basePath || join(tmpdir(), randomBytes(15).toString('base64').replace(/\//g, '-'));
     this.ttl = options.ttl || 0;


### PR DESCRIPTION
Reverts storybookjs/storybook#31806

<!-- greptile_comment -->

## Greptile Summary

Reverts the FIPS compliance fix that switched hashing from MD5 to SHA256 in FileSystemCache.

- Reverts change in `code/core/src/common/utils/file-cache.ts` back to using MD5 instead of SHA256
- Could impact organizations requiring FIPS compliance as MD5 is not FIPS-compliant
- May affect build performance and caching behavior due to hash algorithm change



<!-- /greptile_comment -->