### PR TITLE
WIP Vitest test runner experiment 

### DIFF
--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -54,6 +54,11 @@
       "import": "./dist/vitest-plugin/test-utils.mjs",
       "require": "./dist/vitest-plugin/test-utils.js"
     },
+    "./internal/playwright-utils": {
+      "types": "./dist/vitest-plugin/playwright-utils.d.ts",
+      "import": "./dist/vitest-plugin/playwright-utils.mjs",
+      "require": "./dist/vitest-plugin/playwright-utils.js"
+    },
     "./internal/coverage-reporter": {
       "types": "./dist/node/coverage-reporter.d.ts",
       "import": "./dist/node/coverage-reporter.mjs",
@@ -145,6 +150,7 @@
     "exportEntries": [
       "./src/index.ts",
       "./src/vitest-plugin/test-utils.ts",
+      "./src/vitest-plugin/playwright-utils.ts",
       "./src/vitest-plugin/setup-file.ts"
     ],
     "managerEntries": [

--- a/code/addons/vitest/src/constants.ts
+++ b/code/addons/vitest/src/constants.ts
@@ -19,9 +19,11 @@ export const DOCUMENTATION_FATAL_ERROR_LINK = `${DOCUMENTATION_LINK}#what-happen
 export const COVERAGE_DIRECTORY = 'coverage';
 
 export const SUPPORTED_FRAMEWORKS = [
+  '@storybook/angular',
   '@storybook/nextjs',
   '@storybook/nextjs-vite',
   '@storybook/react-vite',
+  '@storybook/react-webpack5',
   '@storybook/svelte-vite',
   '@storybook/vue3-vite',
   '@storybook/html-vite',

--- a/code/addons/vitest/src/manager.tsx
+++ b/code/addons/vitest/src/manager.tsx
@@ -17,81 +17,81 @@ import { A11Y_PANEL_ID, ADDON_ID, COMPONENT_TESTING_PANEL_ID, TEST_PROVIDER_ID }
 import { useTestProvider } from './use-test-provider-state';
 
 addons.register(ADDON_ID, (api) => {
-  const storybookBuilder = (globalThis as any).STORYBOOK_BUILDER || '';
-  if (storybookBuilder.includes('vite')) {
-    const openPanel = (panelId: string) => {
-      api.setSelectedPanel(panelId);
-      api.togglePanel(true);
-    };
-    componentTestStatusStore.onSelect(() => {
-      openPanel(COMPONENT_TESTING_PANEL_ID);
-    });
-    a11yStatusStore.onSelect(() => {
-      openPanel(A11Y_PANEL_ID);
-    });
-    testProviderStore.onRunAll(() => {
-      store.send({
-        type: 'TRIGGER_RUN',
-        payload: {
-          triggeredBy: 'run-all',
-        },
-      });
-    });
-    store.untilReady().then(() => {
-      store.setState((state) => ({
-        ...state,
-        indexUrl: new URL('index.json', window.location.href).toString(),
-      }));
-    });
-
-    addons.add(TEST_PROVIDER_ID, {
-      type: Addon_TypesEnum.experimental_TEST_PROVIDER,
-      render: () => {
-        const [isModalOpen, setModalOpen] = useState(false);
-        const {
-          storeState,
-          setStoreState,
-          testProviderState,
-          componentTestStatusValueToStoryIds,
-          a11yStatusValueToStoryIds,
-          isSettingsUpdated,
-        } = useTestProvider(api);
-        return (
-          <GlobalErrorContext.Provider value={{ isModalOpen, setModalOpen }}>
-            <TestProviderRender
-              api={api}
-              storeState={storeState}
-              setStoreState={setStoreState}
-              isSettingsUpdated={isSettingsUpdated}
-              testProviderState={testProviderState}
-              componentTestStatusValueToStoryIds={componentTestStatusValueToStoryIds}
-              a11yStatusValueToStoryIds={a11yStatusValueToStoryIds}
-            />
-            <GlobalErrorModal
-              storeState={storeState}
-              onRerun={() => {
-                setModalOpen(false);
-                store.send({
-                  type: 'TRIGGER_RUN',
-                  payload: {
-                    triggeredBy: 'global',
-                  },
-                });
-              }}
-            />
-          </GlobalErrorContext.Provider>
-        );
-      },
-
-      sidebarContextMenu: ({ context }) => {
-        if (context.type === 'docs') {
-          return null;
-        }
-        if (context.type === 'story' && !context.tags.includes('test')) {
-          return null;
-        }
-        return <SidebarContextMenu context={context} api={api} />;
+  // const storybookBuilder = (globalThis as any).STORYBOOK_BUILDER || '';
+  // if (storybookBuilder.includes('vite')) {
+  const openPanel = (panelId: string) => {
+    api.setSelectedPanel(panelId);
+    api.togglePanel(true);
+  };
+  componentTestStatusStore.onSelect(() => {
+    openPanel(COMPONENT_TESTING_PANEL_ID);
+  });
+  a11yStatusStore.onSelect(() => {
+    openPanel(A11Y_PANEL_ID);
+  });
+  testProviderStore.onRunAll(() => {
+    store.send({
+      type: 'TRIGGER_RUN',
+      payload: {
+        triggeredBy: 'run-all',
       },
     });
-  }
+  });
+  store.untilReady().then(() => {
+    store.setState((state) => ({
+      ...state,
+      indexUrl: new URL('index.json', window.location.href).toString(),
+    }));
+  });
+
+  addons.add(TEST_PROVIDER_ID, {
+    type: Addon_TypesEnum.experimental_TEST_PROVIDER,
+    render: () => {
+      const [isModalOpen, setModalOpen] = useState(false);
+      const {
+        storeState,
+        setStoreState,
+        testProviderState,
+        componentTestStatusValueToStoryIds,
+        a11yStatusValueToStoryIds,
+        isSettingsUpdated,
+      } = useTestProvider(api);
+      return (
+        <GlobalErrorContext.Provider value={{ isModalOpen, setModalOpen }}>
+          <TestProviderRender
+            api={api}
+            storeState={storeState}
+            setStoreState={setStoreState}
+            isSettingsUpdated={isSettingsUpdated}
+            testProviderState={testProviderState}
+            componentTestStatusValueToStoryIds={componentTestStatusValueToStoryIds}
+            a11yStatusValueToStoryIds={a11yStatusValueToStoryIds}
+          />
+          <GlobalErrorModal
+            storeState={storeState}
+            onRerun={() => {
+              setModalOpen(false);
+              store.send({
+                type: 'TRIGGER_RUN',
+                payload: {
+                  triggeredBy: 'global',
+                },
+              });
+            }}
+          />
+        </GlobalErrorContext.Provider>
+      );
+    },
+
+    sidebarContextMenu: ({ context }) => {
+      if (context.type === 'docs') {
+        return null;
+      }
+      if (context.type === 'story' && !context.tags.includes('test')) {
+        return null;
+      }
+      return <SidebarContextMenu context={context} api={api} />;
+    },
+  });
+  // }
 });

--- a/code/addons/vitest/src/postinstall.ts
+++ b/code/addons/vitest/src/postinstall.ts
@@ -141,18 +141,18 @@ export default async function postInstall(options: PostinstallOptions) {
   const prerequisiteCheck = async () => {
     const reasons = [];
 
-    if (hasCustomWebpackConfig) {
-      reasons.push('• The addon can not be used with a custom Webpack configuration.');
-    }
+    // if (hasCustomWebpackConfig) {
+    //   reasons.push('• The addon can not be used with a custom Webpack configuration.');
+    // }
 
-    if (
-      info.frameworkPackageName !== '@storybook/nextjs' &&
-      info.builderPackageName !== '@storybook/builder-vite'
-    ) {
-      reasons.push(
-        '• The addon can only be used with a Vite-based Storybook framework or Next.js.'
-      );
-    }
+    // if (
+    //   info.frameworkPackageName !== '@storybook/nextjs' &&
+    //   info.builderPackageName !== '@storybook/builder-vite'
+    // ) {
+    //   reasons.push(
+    //     '• The addon can only be used with a Vite-based Storybook framework or Next.js.'
+    //   );
+    // }
 
     if (!isRendererSupported) {
       reasons.push(dedent`

--- a/code/addons/vitest/src/preset.ts
+++ b/code/addons/vitest/src/preset.ts
@@ -56,20 +56,21 @@ export const experimental_serverChannel = async (channel: Channel, options: Opti
     options
   );
 
-  const builderName = typeof core?.builder === 'string' ? core.builder : core?.builder?.name;
-  const framework = await getFrameworkName(options);
+  // Commenting this out for experimentation purposes
+  // const builderName = typeof core?.builder === 'string' ? core.builder : core?.builder?.name;
+  // const framework = await getFrameworkName(options);
 
   // Only boot the test runner if the builder is vite, else just provide interactions functionality
-  if (!builderName?.includes('vite')) {
-    if (framework.includes('nextjs')) {
-      log(dedent`
-        You're using ${framework}, which is a Webpack-based builder. In order to use Storybook Test, with your project, you need to use '@storybook/nextjs-vite', a high performance Vite-based equivalent.
+  // if (!builderName?.includes('vite')) {
+  //   if (framework.includes('nextjs')) {
+  //     log(dedent`
+  //       You're using ${framework}, which is a Webpack-based builder. In order to use Storybook Test, with your project, you need to use '@storybook/nextjs-vite', a high performance Vite-based equivalent.
 
-        Information on how to upgrade here: ${picocolors.yellow('https://storybook.js.org/docs/get-started/frameworks/nextjs#with-vite')}\n
-      `);
-    }
-    return channel;
-  }
+  //       Information on how to upgrade here: ${picocolors.yellow('https://storybook.js.org/docs/get-started/frameworks/nextjs#with-vite')}\n
+  //     `);
+  //   }
+  //   return channel;
+  // }
 
   const fsCache = createFileSystemCache({
     basePath: resolvePathInStorybookCache(ADDON_ID.replace('/', '-')),

--- a/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
@@ -11,6 +11,15 @@ declare global {
   const logToPage: (message: string) => Promise<void>;
 }
 
+export const convertToFilePath = (url: string): string => {
+  // Remove the file:// protocol
+  const path = url.replace(/^file:\/\//, '');
+  // Handle Windows paths
+  const normalizedPath = path.replace(/^\/+([a-zA-Z]:)/, '$1');
+  // Convert %20 to spaces
+  return normalizedPath.replace(/%20/g, ' ');
+};
+
 export async function prepareScript(page: Page) {
   await page.goto('http://localhost:6006/iframe.html', { waitUntil: 'load' }).catch((err) => {
     if (err.message?.includes('ERR_CONNECTION_REFUSED')) {
@@ -594,8 +603,8 @@ export async function setupPageScript(page: Page) {
 }
 
 export async function testStory(storyId: string, page: Page): Promise<void> {
-  await page.evaluate(async () => {
+  await page.evaluate(async (storyId: string) => {
     // @ts-expect-error Need to fix with augmentation
     return await globalThis.__test(storyId);
-  });
+  }, storyId);
 }

--- a/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
@@ -635,4 +635,15 @@ export async function testStory(
     );
     await playwrightFn({ page, context: storyContext });
   }
+
+  // @ts-expect-error Need to fix with augmentation
+  const coverage = await page.evaluate(() => globalThis.__coverage__);
+  if (coverage) {
+    // @ts-expect-error Need to fix with augmentation
+    await globalThis.__vitest_worker__.rpc.onAfterSuiteRun({
+      coverage,
+      testFiles: [],
+      transformMode: 'web',
+    });
+  }
 }

--- a/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
@@ -1,0 +1,601 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { StoryContext } from 'storybook/internal/csf';
+
+import { type Page } from '@playwright/test';
+
+// Type definitions for globals
+declare global {
+  // this is defined in setup-page.ts and can be used for logging from the browser to node, helpful for debugging
+  const logToPage: (message: string) => Promise<void>;
+}
+
+export async function prepareScript(page: Page) {
+  await page.goto('http://localhost:6006/iframe.html', { waitUntil: 'load' }).catch((err) => {
+    if (err.message?.includes('ERR_CONNECTION_REFUSED')) {
+      const errorMessage = `Could not access the Storybook instance at http://localhost:6006. Are you sure it's running?\n\n${err.message}`;
+      throw new Error(errorMessage);
+    }
+
+    throw err;
+  });
+
+  await page.exposeBinding('logToPage', (_, message) => console.log(message));
+}
+
+export async function setupPageScript(page: Page) {
+  await page.evaluate(async () => {
+    type ConsoleMethod =
+      | 'log'
+      | 'info'
+      | 'warn'
+      | 'error'
+      | 'trace'
+      | 'debug'
+      | 'group'
+      | 'groupCollapsed'
+      | 'table'
+      | 'dir';
+    type LogLevel = 'none' | 'info' | 'warn' | 'error' | 'verbose';
+
+    // All of these variables will be replaced once this file is processed.
+    const TEST_RUNNER_STORYBOOK_URL: string = 'http://localhost:6006';
+    const TEST_RUNNER_VERSION: string = '1.0.0';
+    const TEST_RUNNER_FAIL_ON_CONSOLE: string = 'true';
+    const TEST_RUNNER_RENDERED_EVENT: string = 'storyFinished';
+    const TEST_RUNNER_VIEW_MODE: string = 'story';
+    const TEST_RUNNER_LOG_LEVEL = 'verbose' as LogLevel;
+    const TEST_RUNNER_DEBUG_PRINT_LIMIT = 1000;
+
+    // Type definitions for function parameters and return types
+    type Colorizer = (message: string) => string;
+
+    const bold: Colorizer = (message: string) => `\u001b[1m${message}\u001b[22m`;
+    const magenta: Colorizer = (message: string) => `\u001b[35m${message}\u001b[39m`;
+    const blue: Colorizer = (message: string) => `\u001b[34m${message}\u001b[39m`;
+    const red: Colorizer = (message: string) => `\u001b[31m${message}\u001b[39m`;
+    const yellow: Colorizer = (message: string) => `\u001b[33m${message}\u001b[39m`;
+    const grey: Colorizer = (message: string) => `\u001b[90m${message}\u001b[39m`;
+
+    // Constants
+    const LIMIT_REPLACE_NODE = '[...]';
+    const CIRCULAR_REPLACE_NODE = '[Circular]';
+
+    // Arrays for tracking replacements
+    const arr: any[] = [];
+    const replacerStack: any[] = [];
+
+    // Default options for stringification
+    function defaultOptions(): { depthLimit: number; edgesLimit: number } {
+      return {
+        depthLimit: Number.MAX_SAFE_INTEGER,
+        edgesLimit: Number.MAX_SAFE_INTEGER,
+      };
+    }
+
+    // Stringify function
+    function stringify(
+      obj: any,
+      replacer: ((key: string, value: any) => any) | null,
+      spacer: string | number | null,
+      options?: { depthLimit: number; edgesLimit: number }
+    ): string {
+      if (typeof options === 'undefined') {
+        options = defaultOptions();
+      }
+
+      decirc(obj, '', 0, [], undefined, 0, options);
+      let res: string;
+      try {
+        if (replacerStack.length === 0) {
+          // @ts-expect-error TODO: check why TS complains about this
+          res = JSON.stringify(obj, replacer, spacer);
+        } else {
+          // @ts-expect-error TODO: check why TS complains about this
+          res = JSON.stringify(obj, replaceGetterValues(replacer), spacer);
+        }
+      } catch (_) {
+        return JSON.stringify(
+          '[unable to serialize, circular reference is too complex to analyze]'
+        );
+      } finally {
+        while (arr.length !== 0) {
+          const part = arr.pop();
+          if (part && part.length === 4) {
+            Object.defineProperty(part[0], part[1], part[3]);
+          } else if (part) {
+            part[0][part[1]] = part[2];
+          }
+        }
+      }
+      return res;
+    }
+
+    // Handle circular references and limits
+    function decirc(
+      val: any,
+      k: string,
+      edgeIndex: number,
+      stack: any[],
+      parent: any | undefined,
+      depth: number,
+      options: { depthLimit: number; edgesLimit: number }
+    ): void {
+      depth += 1;
+      let i: number;
+      if (typeof val === 'object' && val !== null) {
+        for (i = 0; i < stack.length; i++) {
+          if (stack[i] === val) {
+            setReplace(CIRCULAR_REPLACE_NODE, val, k, parent);
+            return;
+          }
+        }
+
+        if (depth > options.depthLimit || edgeIndex + 1 > options.edgesLimit) {
+          setReplace(LIMIT_REPLACE_NODE, val, k, parent);
+          return;
+        }
+
+        stack.push(val);
+        if (Array.isArray(val)) {
+          for (i = 0; i < val.length; i++) {
+            decirc(val[i], i.toString(), i, stack, val, depth, options);
+          }
+        } else {
+          const keys = Object.keys(val);
+          for (i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            decirc(val[key], key, i, stack, val, depth, options);
+          }
+        }
+        stack.pop();
+      }
+    }
+
+    // Set replacement values in objects
+    function setReplace(replace: any, val: any, k: string, parent: any | undefined): void {
+      if (!parent) {
+        return;
+      }
+      const propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k);
+      if (propertyDescriptor && propertyDescriptor.get !== undefined) {
+        if (propertyDescriptor.configurable) {
+          Object.defineProperty(parent, k, { value: replace });
+          arr.push([parent, k, val, propertyDescriptor]);
+        } else {
+          replacerStack.push([val, k, replace]);
+        }
+      } else {
+        parent[k] = replace;
+        arr.push([parent, k, val]);
+      }
+    }
+
+    // Replace getter values
+    function replaceGetterValues(
+      replacer?: (this: any, key: string, value: any) => any
+    ): (this: any, key: string, value: any) => any {
+      const effectiveReplacer = replacer ?? ((_k: string, v: any) => v);
+      return function (this: any, key: string, val: any): any {
+        if (replacerStack.length > 0) {
+          for (let i = 0; i < replacerStack.length; i++) {
+            const part = replacerStack[i];
+            if (part[1] === key && part[0] === val) {
+              val = part[2];
+              replacerStack.splice(i, 1);
+              break;
+            }
+          }
+        }
+        return effectiveReplacer.call(this, key, val);
+      };
+    }
+
+    // Compose message function
+    function composeMessage(args: any): string {
+      if (args instanceof Error) {
+        return `${args.name}: ${args.message}\n${args.stack}`;
+      }
+
+      if (typeof args === 'undefined') {
+        return 'undefined';
+      }
+
+      if (typeof args === 'string') {
+        return args;
+      }
+      return stringify(args, null, null, { depthLimit: 5, edgesLimit: 100 });
+    }
+
+    // Truncate long strings
+    function truncate(input: string, limit: number): string {
+      if (input.length > limit) {
+        return input.substring(0, limit) + '…';
+      }
+      return input;
+    }
+
+    // Add extra information to the user agent
+    function addToUserAgent(extra: string): void {
+      // eslint-disable-next-line compat/compat
+      const originalUserAgent = globalThis.navigator.userAgent;
+      if (!originalUserAgent.includes(extra)) {
+        Object.defineProperty(globalThis.navigator, 'userAgent', {
+          get: function () {
+            return [originalUserAgent, extra].join(' ');
+          },
+          configurable: true,
+        });
+      }
+    }
+
+    function getStory(): StoryContext {
+      // @ts-expect-error TODO: fix later
+      const currentRender = globalThis.__STORYBOOK_PREVIEW__.currentRender;
+      if (currentRender && 'story' in currentRender) {
+        return currentRender.story as unknown as StoryContext;
+      }
+
+      return {} as StoryContext;
+    }
+
+    // Custom error class
+    class StorybookTestRunnerError extends Error {
+      constructor(params: {
+        storyId: string;
+        errorMessage: string;
+        logs?: string[];
+        isMessageFormatted?: boolean;
+      }) {
+        const { storyId, errorMessage, logs = [], isMessageFormatted = false } = params;
+        const message = isMessageFormatted
+          ? errorMessage
+          : StorybookTestRunnerError.buildErrorMessage({
+              storyId,
+              errorMessage,
+              logs,
+            });
+        super(message);
+
+        this.name = 'StorybookTestRunnerError';
+      }
+
+      public static buildErrorMessage(params: {
+        storyId: string;
+        errorMessage: string;
+        logs?: string[];
+        panel?: string;
+        errorMessagePrefix?: string;
+      }): string {
+        const { storyId, errorMessage, logs = [], panel, errorMessagePrefix = '' } = params;
+        const storyUrl = `${TEST_RUNNER_STORYBOOK_URL}?path=/story/${storyId}`;
+        const finalStoryUrl = panel ? `${storyUrl}&addonPanel=${panel}` : storyUrl;
+        const separator = '\n\n--------------------------------------------------';
+        // The original error message will also be collected in the logs, so we filter it to avoid duplication
+        const finalLogs = logs.filter((err: string) => !err.includes(errorMessage));
+        const extraLogs =
+          finalLogs.length > 0 ? separator + '\n\nBrowser logs:\n\n' + finalLogs.join('\n\n') : '';
+
+        const linkPrefix = blue(
+          `\nClick to debug the error directly in Storybook:\n${finalStoryUrl}\n\n`
+        );
+
+        const message = `${errorMessagePrefix}${linkPrefix}Message:\n ${truncate(
+          errorMessage,
+          TEST_RUNNER_DEBUG_PRINT_LIMIT
+        )}\n${extraLogs}`;
+
+        return message;
+      }
+    }
+
+    // Wait for Storybook to load
+    async function __waitForStorybook(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject();
+        }, 10000);
+
+        if (document.querySelector('#root') || document.querySelector('#storybook-root')) {
+          clearTimeout(timeout);
+          return resolve();
+        }
+
+        const observer = new MutationObserver(() => {
+          if (document.querySelector('#root') || document.querySelector('#storybook-root')) {
+            clearTimeout(timeout);
+            resolve();
+            observer.disconnect();
+          }
+        });
+
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+        });
+      });
+    }
+
+    function isServerComponentError(error: unknown) {
+      return (
+        typeof error === 'string' &&
+        (error.includes('Only Server Components can be async at the moment.') ||
+          error.includes('A component was suspended by an uncached promise.') ||
+          error.includes('async/await is not yet supported in Client Components'))
+      );
+    }
+
+    function expectToHaveNoViolations(results: any): { long: string; short: string } | null {
+      const violations = filterViolations(
+        results.violations,
+        // `impactLevels` is not a valid toolOption but one we add to the config
+        // when calling `run`. axe just happens to pass this along. Might be a safer
+        // way to do this since it's not documented API.
+        results.toolOptions?.impactLevels ?? []
+      );
+
+      function reporter(violations: any) {
+        if (violations.length === 0) {
+          return null;
+        }
+
+        const lineBreak = '\n\n';
+        const horizontalLine = '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
+
+        return violations
+          .map((violation: any) => {
+            const errorBody = violation.nodes
+              .map((node: any) => {
+                const selector = node.target.join(', ');
+                const expectedText =
+                  red(`Expected the HTML found at $('${selector}') to have no violations:`) +
+                  lineBreak;
+                return (
+                  expectedText +
+                  grey(node.html) +
+                  lineBreak +
+                  red(`Received:`) +
+                  lineBreak +
+                  red(`"${violation.help} (${violation.id})"`) +
+                  lineBreak +
+                  yellow(node.failureSummary) +
+                  lineBreak +
+                  (violation.helpUrl
+                    ? red(`You can find more information on this issue here:`) +
+                      `\n${blue(violation.helpUrl)}`
+                    : '')
+                );
+              })
+              .join(lineBreak);
+            return errorBody;
+          })
+          .join(lineBreak + horizontalLine + lineBreak);
+      }
+
+      const formatedViolations = reporter(violations);
+
+      return {
+        long: formatedViolations,
+        short: `Found ${violations.length} a11y violations, run the test with 'a11y: { test: 'error' }' parameter to see the full report or debug it directly in Storybook.`,
+      };
+    }
+
+    function filterViolations(violations: any, impactLevels: Array<any>) {
+      if (impactLevels && impactLevels.length > 0) {
+        return violations.filter((v: any) => impactLevels.includes(v.impact));
+      }
+      return violations;
+    }
+
+    async function __test(storyId: string): Promise<any> {
+      try {
+        await __waitForStorybook();
+      } catch (err) {
+        const message = `Timed out waiting for Storybook to load after 10 seconds. Are you sure the Storybook is running correctly in that URL? Is the Storybook private (e.g. under authentication layers)?\n\n\nHTML: ${document.body.innerHTML}`;
+        throw new StorybookTestRunnerError({ storyId, errorMessage: message });
+      }
+
+      const channel = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
+      if (!channel) {
+        throw new StorybookTestRunnerError({
+          storyId,
+          errorMessage:
+            'The test runner could not access the Storybook channel. Are you sure the Storybook is running correctly in that URL?',
+        });
+      }
+
+      addToUserAgent(`(StorybookTestRunner@${TEST_RUNNER_VERSION})`);
+
+      // Collect logs to show upon test error
+      const logs: string[] = [];
+      let hasErrors = false;
+
+      const logLevelMapping: { [key in ConsoleMethod]: LogLevel[] } = {
+        log: ['info', 'verbose'],
+        warn: ['info', 'warn', 'verbose'],
+        error: ['info', 'warn', 'error', 'verbose'],
+        info: ['verbose'],
+        trace: ['verbose'],
+        debug: ['verbose'],
+        group: ['verbose'],
+        groupCollapsed: ['verbose'],
+        table: ['verbose'],
+        dir: ['verbose'],
+      };
+
+      const spyOnConsole = (method: ConsoleMethod, name: string): void => {
+        const originalFn = console[method].bind(console);
+        console[method] = function (...args: any[]) {
+          const isConsoleError = method === 'error';
+          // Storybook nextjs/react supress error logs from server components and so should the test-runner
+          if (isConsoleError && isServerComponentError(args[0])) {
+            return;
+          }
+
+          const shouldCollectError = TEST_RUNNER_FAIL_ON_CONSOLE === 'true' && method === 'error';
+          if (shouldCollectError) {
+            hasErrors = true;
+          }
+
+          let message = args.map(composeMessage).join(', ');
+          if (method === 'trace') {
+            const stackTrace = new Error().stack;
+            message += `\n${stackTrace}\n`;
+          }
+
+          if (logLevelMapping[method].includes(TEST_RUNNER_LOG_LEVEL) || shouldCollectError) {
+            const prefix = `${bold(name)}: `;
+            logs.push(prefix + message);
+          }
+
+          originalFn(...args);
+        };
+      };
+
+      // Console methods + color function for their prefix
+      const spiedMethods: { [key: string]: Colorizer } = {
+        // info
+        log: blue,
+        info: blue,
+        // warn
+        warn: yellow,
+        // error
+        error: red,
+        // verbose
+        dir: magenta,
+        trace: magenta,
+        group: magenta,
+        groupCollapsed: magenta,
+        table: magenta,
+        debug: magenta,
+      };
+
+      Object.entries(spiedMethods).forEach(([method, color]) => {
+        spyOnConsole(method as ConsoleMethod, color(method));
+      });
+
+      const cleanup = (_listeners: Record<string, (...args: any[]) => void>) => {
+        Object.entries(_listeners).forEach(([eventName, listener]) => {
+          channel.off(eventName, listener);
+        });
+      };
+
+      return new Promise((resolve, reject) => {
+        const rejectWithFormattedError = (storyId: string, message: string, panel?: string) => {
+          const errorMessage = StorybookTestRunnerError.buildErrorMessage({
+            storyId,
+            errorMessage: message,
+            logs,
+            panel,
+          });
+
+          reject(
+            new StorybookTestRunnerError({
+              storyId,
+              errorMessage,
+              logs,
+              isMessageFormatted: true,
+            })
+          );
+        };
+
+        const INTERACTIONS_PANEL = 'storybook/interactions/panel';
+        const A11Y_PANEL = 'storybook/a11y/panel';
+
+        const listeners = {
+          [TEST_RUNNER_RENDERED_EVENT]: (data: any) => {
+            cleanup(listeners);
+
+            if (hasErrors) {
+              rejectWithFormattedError(storyId, 'Browser console errors');
+              return;
+            } else if (data?.reporters) {
+              const story = getStory();
+              const a11yGlobals = story.globals?.a11y;
+              const a11yParameter = story.parameters?.a11y;
+              const a11yTestParameter = a11yParameter?.test;
+              const a11yReport = data.reporters.find((reporter: any) => reporter.type === 'a11y');
+
+              const shouldRunA11yTest =
+                a11yParameter?.disable !== true &&
+                a11yParameter?.test !== 'off' &&
+                a11yGlobals?.manual !== true &&
+                a11yReport?.result?.violations?.length > 0;
+
+              if (shouldRunA11yTest) {
+                const violations = expectToHaveNoViolations(a11yReport.result);
+                if (violations && a11yTestParameter === 'error') {
+                  rejectWithFormattedError(storyId, violations.long, A11Y_PANEL);
+                  return;
+                } else if (violations && a11yTestParameter === 'todo') {
+                  const warningMessage = StorybookTestRunnerError.buildErrorMessage({
+                    storyId,
+                    errorMessagePrefix: `--------------------------\n${story.title} > ${story.name}`,
+                    errorMessage: yellow(violations.short),
+                    logs,
+                    panel: A11Y_PANEL,
+                  });
+                  logToPage(warningMessage);
+                }
+              }
+            }
+
+            resolve(document.getElementById('root'));
+          },
+
+          storyUnchanged: () => {
+            cleanup(listeners);
+            resolve(document.getElementById('root'));
+          },
+
+          storyErrored: ({ description }: { description: string }) => {
+            cleanup(listeners);
+            rejectWithFormattedError(storyId, description, INTERACTIONS_PANEL);
+          },
+
+          storyThrewException: (error: Error) => {
+            cleanup(listeners);
+            rejectWithFormattedError(storyId, error.message, INTERACTIONS_PANEL);
+          },
+
+          playFunctionThrewException: (error: Error) => {
+            cleanup(listeners);
+
+            rejectWithFormattedError(storyId, error.message, INTERACTIONS_PANEL);
+          },
+
+          unhandledErrorsWhilePlaying: ([error]: Error[]) => {
+            cleanup(listeners);
+            rejectWithFormattedError(storyId, error.message, INTERACTIONS_PANEL);
+          },
+
+          storyMissing: (id: string) => {
+            cleanup(listeners);
+            if (id === storyId) {
+              rejectWithFormattedError(storyId, 'The story was missing when trying to access it.');
+            }
+          },
+        };
+
+        Object.entries(listeners).forEach(([eventName, listener]) => {
+          channel.on(eventName, listener);
+        });
+
+        channel.emit('setCurrentStory', {
+          storyId,
+          viewMode: TEST_RUNNER_VIEW_MODE,
+        });
+      });
+    }
+    // @ts-expect-error Need to fix with augmentation
+    globalThis.__test = __test;
+  });
+}
+
+export async function testStory(storyId: string, page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    // @ts-expect-error Need to fix with augmentation
+    return await globalThis.__test(storyId);
+  });
+}

--- a/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
@@ -604,16 +604,14 @@ export async function setupPageScript(page: Page) {
   });
 }
 
-export function testStory(storyId: string, page: Page) {
-  return async (context: TestContext) => {
-    const _task = context.task as RunnerTask & {
-      meta: TaskMeta & { storyId: string; reports: Report[] };
-    };
-    _task.meta.storyId = storyId;
-
-    await page.evaluate(async (storyId: string) => {
-      // @ts-expect-error Need to fix with augmentation
-      return await globalThis.__test(storyId);
-    }, storyId);
+export async function testStory(storyId: string, page: Page, context: TestContext) {
+  const _task = context.task as RunnerTask & {
+    meta: TaskMeta & { storyId: string; reports: Report[] };
   };
+  _task.meta.storyId = storyId;
+
+  await page.evaluate(async (storyId: string) => {
+    // @ts-expect-error Need to fix with augmentation
+    return await globalThis.__test(storyId);
+  }, storyId);
 }

--- a/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
+++ b/code/addons/vitest/src/vitest-plugin/playwright-utils.ts
@@ -1,6 +1,8 @@
 /* eslint-disable local-rules/no-uncategorized-errors */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { type RunnerTask, type TaskMeta, type TestContext } from 'vitest';
+
 import type { StoryContext } from 'storybook/internal/csf';
 
 import { type Page } from '@playwright/test';
@@ -602,9 +604,16 @@ export async function setupPageScript(page: Page) {
   });
 }
 
-export async function testStory(storyId: string, page: Page): Promise<void> {
-  await page.evaluate(async (storyId: string) => {
-    // @ts-expect-error Need to fix with augmentation
-    return await globalThis.__test(storyId);
-  }, storyId);
+export function testStory(storyId: string, page: Page) {
+  return async (context: TestContext) => {
+    const _task = context.task as RunnerTask & {
+      meta: TaskMeta & { storyId: string; reports: Report[] };
+    };
+    _task.meta.storyId = storyId;
+
+    await page.evaluate(async (storyId: string) => {
+      // @ts-expect-error Need to fix with augmentation
+      return await globalThis.__test(storyId);
+    }, storyId);
+  };
 }

--- a/code/addons/vitest/src/vitest-plugin/types.ts
+++ b/code/addons/vitest/src/vitest-plugin/types.ts
@@ -1,5 +1,11 @@
 export type UserOptions = {
   /**
+   * Whether to use Playwright to run the tests.
+   *
+   * @default false
+   */
+  usePlaywright?: boolean;
+  /**
    * The directory where the Storybook configuration is located, relative to the vitest
    * configuration file. If not provided, the plugin will use '.storybook' in the current working
    * directory.

--- a/code/addons/vitest/src/vitest-plugin/viewports.ts
+++ b/code/addons/vitest/src/vitest-plugin/viewports.ts
@@ -53,7 +53,11 @@ const parseDimension = (value: string, dimension: 'width' | 'height') => {
   }
 };
 
-export const setViewport = async (parameters: Parameters = {}, globals: Globals = {}) => {
+export const setViewport = async (
+  parameters: Parameters = {},
+  globals: Globals = {},
+  pwPage?: any
+) => {
   let defaultViewport;
   const viewportsParam: ViewportsParam = parameters.viewport ?? {};
   const viewportsGlobal: ViewportsGlobal = globals.viewport ?? {};
@@ -66,9 +70,13 @@ export const setViewport = async (parameters: Parameters = {}, globals: Globals 
     defaultViewport = viewportsParam.defaultViewport;
   }
 
-  const { page } = await import('@vitest/browser/context').catch(() => ({
-    page: null,
-  }));
+  let page = pwPage;
+  if (!page) {
+    const res = await import('@vitest/browser/context').catch(() => ({
+      page: null,
+    }));
+    page = res.page;
+  }
 
   if (!page || !globalThis.__vitest_browser__) {
     return;

--- a/code/core/src/csf-tools/index.ts
+++ b/code/core/src/csf-tools/index.ts
@@ -4,3 +4,4 @@ export * from './getStorySortParameter';
 export * from './enrichCsf';
 export { babelParse } from 'storybook/internal/babel';
 export { vitestTransform } from './vitest-plugin/transformer';
+export { vitestPlaywrightTransform } from './vitest-plugin/transformer-playwright';

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
@@ -1,0 +1,429 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getStoryTitle } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
+
+import { type RawSourceMap, SourceMapConsumer } from 'source-map';
+
+import { vitestPlaywrightTransform as originalTransform } from './transformer-playwright';
+
+vi.mock('storybook/internal/common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('storybook/internal/common')>();
+  return {
+    ...actual,
+    getStoryTitle: vi.fn(() => 'automatic/calculated/title'),
+  };
+});
+
+expect.addSnapshotSerializer({
+  serialize: (val: any) => (typeof val === 'string' ? val : val.toString()),
+  test: (val) => true,
+});
+
+const transform = async ({
+  code = '',
+  fileName = 'src/components/Button.stories.js',
+  tagsFilter = {
+    include: ['test'],
+    exclude: [] as string[],
+    skip: [] as string[],
+  },
+  configDir = '.storybook',
+  stories = [],
+  previewLevelTags = [],
+}) => {
+  const transformed = await originalTransform({
+    code,
+    fileName,
+    configDir,
+    stories,
+    tagsFilter,
+    previewLevelTags,
+  });
+  if (typeof transformed === 'string') {
+    return { code: transformed, map: null };
+  }
+
+  return transformed;
+};
+
+describe('transformer-playwright', () => {
+  describe('no-op', () => {
+    it('should return original code if the file is not a story file', async () => {
+      const code = `console.log('Not a story file');`;
+      const fileName = 'src/components/Button.js';
+
+      const result = await transform({ code, fileName });
+
+      expect(result.code).toMatchInlineSnapshot(`console.log('Not a story file');`);
+    });
+  });
+
+  describe('CSF v1/v2/v3', () => {
+    describe('default exports (meta)', () => {
+      it('should add title to inline default export if not present', async () => {
+        const code = `
+          export default {
+            component: Button,
+          };
+          export const Story = {};
+        `;
+
+        const result = await transform({ code });
+
+        expect(getStoryTitle).toHaveBeenCalled();
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          const _meta = {
+            component: Button,
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Story = {};
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: false
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Story", _testStory("automatic-calculated-title--story", page));
+          }
+        `);
+      });
+
+      it('should overwrite title to inline default export if already present', async () => {
+        const code = `
+          export default {
+            title: 'Button',
+            component: Button,
+          };
+          export const Story = {};
+        `;
+
+        const result = await transform({ code });
+
+        expect(getStoryTitle).toHaveBeenCalled();
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          const _meta = {
+            title: "automatic/calculated/title",
+            component: Button
+          };
+          export default _meta;
+          export const Story = {};
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: false
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Story", _testStory("automatic-calculated-title--story", page));
+          }
+        `);
+      });
+
+      it('should add title to const declared default export if not present', async () => {
+        const code = `
+          const meta = {
+            component: Button,
+          };
+          export default meta;
+  
+          export const Story = {};
+        `;
+
+        const result = await transform({ code });
+
+        expect(getStoryTitle).toHaveBeenCalled();
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          const meta = {
+            component: Button,
+            title: "automatic/calculated/title"
+          };
+          export default meta;
+          export const Story = {};
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: false
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Story", _testStory("automatic-calculated-title--story", page));
+          }
+        `);
+      });
+
+      it('should overwrite title to const declared default export if already present', async () => {
+        const code = `
+          const meta = {
+            title: 'Button',
+            component: Button,
+          };  
+          export default meta;
+  
+          export const Story = {};
+        `;
+
+        const result = await transform({ code });
+
+        expect(getStoryTitle).toHaveBeenCalled();
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          const meta = {
+            title: "automatic/calculated/title",
+            component: Button
+          };
+          export default meta;
+          export const Story = {};
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: false
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Story", _testStory("automatic-calculated-title--story", page));
+          }
+        `);
+      });
+    });
+
+    describe('named exports (stories)', () => {
+      it('should add test statement to inline exported stories', async () => {
+        const code = `
+          export default {
+            component: Button,
+          }
+          export const Primary = {
+            args: {
+              label: 'Primary Button',
+            },
+          };
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          const _meta = {
+            component: Button,
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Primary = {
+            args: {
+              label: 'Primary Button'
+            }
+          };
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: false
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Primary", _testStory("automatic-calculated-title--primary", page));
+          }
+        `);
+      });
+
+      it('should add test statement to const declared exported stories', async () => {
+        const code = `
+          export default {
+            component: Button,
+          }
+          const Primary = {
+            args: {
+              label: 'Primary Button',
+            },
+          };
+          export { Primary };
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          const _meta = {
+            component: Button,
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          const Primary = {
+            args: {
+              label: 'Primary Button'
+            }
+          };
+          export { Primary };
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: false
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Primary", _testStory("automatic-calculated-title--primary", page));
+          }
+        `);
+      });
+    });
+
+    describe('tags', () => {
+      it('should skip stories with excluded tags', async () => {
+        const code = `
+          export default {
+            component: Button,
+            tags: ['skip-test'],
+          }
+          export const Primary = {
+            args: {
+              label: 'Primary Button',
+            },
+          };
+        `;
+
+        const result = await transform({
+          code,
+          tagsFilter: {
+            include: ['test'],
+            exclude: ['skip-test'],
+            skip: [],
+          },
+        });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, describe as _describe } from "vitest";
+          const _meta = {
+            component: Button,
+            tags: ['skip-test'],
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Primary = {
+            args: {
+              label: 'Primary Button'
+            }
+          };
+          _describe.skip("No valid tests found");
+        `);
+      });
+
+      it('should skip stories without included tags', async () => {
+        const code = `
+          export default {
+            component: Button,
+          }
+          export const Primary = {
+            args: {
+              label: 'Primary Button',
+            },
+          };
+        `;
+
+        const result = await transform({
+          code,
+          tagsFilter: {
+            include: ['e2e'],
+            exclude: [],
+            skip: [],
+          },
+        });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, describe as _describe } from "vitest";
+          const _meta = {
+            component: Button,
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Primary = {
+            args: {
+              label: 'Primary Button'
+            }
+          };
+          _describe.skip("No valid tests found");
+        `);
+      });
+    });
+  });
+});

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
@@ -99,7 +99,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
+            _test("Story", _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -143,7 +143,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
+            _test("Story", _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -188,7 +188,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
+            _test("Story", _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -234,7 +234,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
+            _test("Story", _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -285,7 +285,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", async () => _testStory("automatic-calculated-title--primary", page));
+            _test("Primary", _testStory("automatic-calculated-title--primary", page));
           }
         `);
       });
@@ -336,7 +336,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", async () => _testStory("automatic-calculated-title--primary", page));
+            _test("Primary", _testStory("automatic-calculated-title--primary", page));
           }
         `);
       });

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
@@ -76,8 +76,7 @@ describe('transformer-playwright', () => {
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
           import { chromium } from "playwright";
-          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
-          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
           const _meta = {
             component: Button,
             title: "automatic/calculated/title"
@@ -100,7 +99,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -121,8 +120,7 @@ describe('transformer-playwright', () => {
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
           import { chromium } from "playwright";
-          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
-          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
           const _meta = {
             title: "automatic/calculated/title",
             component: Button
@@ -145,7 +143,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -167,8 +165,7 @@ describe('transformer-playwright', () => {
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
           import { chromium } from "playwright";
-          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
-          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
           const meta = {
             component: Button,
             title: "automatic/calculated/title"
@@ -191,7 +188,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -214,8 +211,7 @@ describe('transformer-playwright', () => {
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
           import { chromium } from "playwright";
-          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
-          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
           const meta = {
             title: "automatic/calculated/title",
             component: Button
@@ -238,7 +234,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async () => _testStory("automatic-calculated-title--story", page));
           }
         `);
       });
@@ -262,8 +258,7 @@ describe('transformer-playwright', () => {
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
           import { chromium } from "playwright";
-          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
-          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
           const _meta = {
             component: Button,
             title: "automatic/calculated/title"
@@ -290,7 +285,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", _testStory("automatic-calculated-title--primary", page));
+            _test("Primary", async () => _testStory("automatic-calculated-title--primary", page));
           }
         `);
       });
@@ -313,8 +308,7 @@ describe('transformer-playwright', () => {
         expect(result.code).toMatchInlineSnapshot(`
           import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
           import { chromium } from "playwright";
-          import { convertToFilePath } from "@storybook/addon-vitest/internal/test-utils";
-          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript } from "@storybook/addon-vitest/internal/playwright-utils";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
           const _meta = {
             component: Button,
             title: "automatic/calculated/title"
@@ -342,7 +336,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", _testStory("automatic-calculated-title--primary", page));
+            _test("Primary", async () => _testStory("automatic-calculated-title--primary", page));
           }
         `);
       });

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
@@ -89,7 +89,7 @@ describe('transformer-playwright', () => {
             let page;
             _beforeAll(async () => {
               const options = {
-                headless: false
+                headless: true
               };
               browser = await chromium.launch(options);
               page = await browser.newPage();
@@ -99,7 +99,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context, null));
           }
         `);
       });
@@ -133,7 +133,7 @@ describe('transformer-playwright', () => {
             let page;
             _beforeAll(async () => {
               const options = {
-                headless: false
+                headless: true
               };
               browser = await chromium.launch(options);
               page = await browser.newPage();
@@ -143,7 +143,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context, null));
           }
         `);
       });
@@ -178,7 +178,7 @@ describe('transformer-playwright', () => {
             let page;
             _beforeAll(async () => {
               const options = {
-                headless: false
+                headless: true
               };
               browser = await chromium.launch(options);
               page = await browser.newPage();
@@ -188,7 +188,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context, null));
           }
         `);
       });
@@ -224,7 +224,7 @@ describe('transformer-playwright', () => {
             let page;
             _beforeAll(async () => {
               const options = {
-                headless: false
+                headless: true
               };
               browser = await chromium.launch(options);
               page = await browser.newPage();
@@ -234,7 +234,62 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context, null));
+          }
+        `);
+      });
+
+      it('should pass playwright function to testStory if defined', async () => {
+        const code = `
+          export default {
+            component: Button,
+          };
+          export const Story = {
+            playwright: async ({ page }) => {
+              await page.goto('https://www.google.com');
+            },
+          };
+        `;
+
+        const result = await transform({ code });
+
+        expect(result.code).toMatchInlineSnapshot(`
+          import { test as _test, beforeAll as _beforeAll, afterAll as _afterAll, expect as _expect } from "vitest";
+          import { chromium } from "playwright";
+          import { testStory as _testStory, prepareScript as _prepareScript, setupPageScript as _setupPageScript, convertToFilePath } from "@storybook/addon-vitest/internal/playwright-utils";
+          const _meta = {
+            component: Button,
+            title: "automatic/calculated/title"
+          };
+          export default _meta;
+          export const Story = {
+            playwright: async ({
+              page
+            }) => {
+              await page.goto('https://www.google.com');
+            }
+          };
+          const _isRunningFromThisFile = convertToFilePath(import.meta.url).includes(globalThis.__vitest_worker__.filepath ?? _expect.getState().testPath);
+          if (_isRunningFromThisFile) {
+            let browser;
+            let page;
+            _beforeAll(async () => {
+              const options = {
+                headless: true
+              };
+              browser = await chromium.launch(options);
+              page = await browser.newPage();
+              await _prepareScript(page);
+              await _setupPageScript(page);
+            });
+            _afterAll(async () => {
+              await browser.close();
+            });
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context, async ({
+              page
+            }) => {
+              await page.goto('https://www.google.com');
+            }));
           }
         `);
       });
@@ -275,7 +330,7 @@ describe('transformer-playwright', () => {
             let page;
             _beforeAll(async () => {
               const options = {
-                headless: false
+                headless: true
               };
               browser = await chromium.launch(options);
               page = await browser.newPage();
@@ -285,7 +340,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", async context => _testStory("automatic-calculated-title--primary", page, context));
+            _test("Primary", async context => _testStory("automatic-calculated-title--primary", page, context, null));
           }
         `);
       });
@@ -326,7 +381,7 @@ describe('transformer-playwright', () => {
             let page;
             _beforeAll(async () => {
               const options = {
-                headless: false
+                headless: true
               };
               browser = await chromium.launch(options);
               page = await browser.newPage();
@@ -336,7 +391,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", async context => _testStory("automatic-calculated-title--primary", page, context));
+            _test("Primary", async context => _testStory("automatic-calculated-title--primary", page, context, null));
           }
         `);
       });

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.test.ts
@@ -99,7 +99,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
           }
         `);
       });
@@ -143,7 +143,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
           }
         `);
       });
@@ -188,7 +188,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
           }
         `);
       });
@@ -234,7 +234,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Story", _testStory("automatic-calculated-title--story", page));
+            _test("Story", async context => _testStory("automatic-calculated-title--story", page, context));
           }
         `);
       });
@@ -285,7 +285,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", _testStory("automatic-calculated-title--primary", page));
+            _test("Primary", async context => _testStory("automatic-calculated-title--primary", page, context));
           }
         `);
       });
@@ -336,7 +336,7 @@ describe('transformer-playwright', () => {
             _afterAll(async () => {
               await browser.close();
             });
-            _test("Primary", _testStory("automatic-calculated-title--primary", page));
+            _test("Primary", async context => _testStory("automatic-calculated-title--primary", page, context));
           }
         `);
       });

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
@@ -199,11 +199,7 @@ export async function vitestPlaywrightTransform({
       const testStoryCall = t.expressionStatement(
         t.callExpression(vitestTestId, [
           t.stringLiteral(testTitle),
-          t.arrowFunctionExpression(
-            [],
-            t.callExpression(testStoryId, [t.stringLiteral(storyId), t.identifier('page')]),
-            true // async
-          ),
+          t.callExpression(testStoryId, [t.stringLiteral(storyId), t.identifier('page')]),
         ])
       );
 

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
@@ -1,0 +1,358 @@
+/* eslint-disable local-rules/no-uncategorized-errors */
+import { types as t } from 'storybook/internal/babel';
+import { getStoryTitle } from 'storybook/internal/common';
+import { combineTags, storyNameFromExport, toId } from 'storybook/internal/csf';
+import { logger } from 'storybook/internal/node-logger';
+import type { StoriesEntry, Tag } from 'storybook/internal/types';
+
+import { dedent } from 'ts-dedent';
+
+import { formatCsf, loadCsf } from '../CsfFile';
+
+type TagsFilter = {
+  include: string[];
+  exclude: string[];
+  skip: string[];
+};
+
+const isValidTest = (storyTags: string[], tagsFilter: TagsFilter) => {
+  if (tagsFilter.include.length && !tagsFilter.include.some((tag) => storyTags?.includes(tag))) {
+    return false;
+  }
+  if (tagsFilter.exclude.some((tag) => storyTags?.includes(tag))) {
+    return false;
+  }
+  // Skipped tests are intentionally included here
+  return true;
+};
+
+export async function vitestPlaywrightTransform({
+  code,
+  fileName,
+  configDir,
+  stories,
+  tagsFilter,
+  previewLevelTags = [],
+}: {
+  code: string;
+  fileName: string;
+  configDir: string;
+  tagsFilter: TagsFilter;
+  stories: StoriesEntry[];
+  previewLevelTags: Tag[];
+}): Promise<ReturnType<typeof formatCsf>> {
+  const isStoryFile = /\.stor(y|ies)\./.test(fileName);
+  if (!isStoryFile) {
+    return code;
+  }
+
+  const parsed = loadCsf(code, {
+    fileName,
+    transformInlineMeta: true,
+    makeTitle: (title) => {
+      const result =
+        getStoryTitle({
+          storyFilePath: fileName,
+          configDir,
+          stories,
+          userTitle: title,
+        }) || 'unknown';
+
+      if (result === 'unknown') {
+        logger.warn(
+          dedent`
+            [Storybook]: Could not calculate story title for "${fileName}".
+            Please make sure that this file matches the globs included in the "stories" field in your Storybook configuration at "${configDir}".
+          `
+        );
+      }
+      return result;
+    },
+  }).parse();
+
+  const ast = parsed._ast;
+
+  const metaNode = parsed._metaNode as t.ObjectExpression;
+
+  const metaTitleProperty = metaNode.properties.find(
+    (prop) => t.isObjectProperty(prop) && t.isIdentifier(prop.key) && prop.key.name === 'title'
+  );
+
+  const metaTitle = t.stringLiteral(parsed._meta?.title || 'unknown');
+  if (!metaTitleProperty) {
+    metaNode.properties.push(t.objectProperty(t.identifier('title'), metaTitle));
+  } else if (t.isObjectProperty(metaTitleProperty)) {
+    // If the title is present in meta, overwrite it because autotitle can still affect existing titles
+    metaTitleProperty.value = metaTitle;
+  }
+
+  if (!metaNode || !parsed._meta) {
+    throw new Error(
+      'The Storybook vitest plugin could not detect the meta (default export) object in the story file. \n\nPlease make sure you have a default export with the meta object. If you are using a different export format that is not supported, please file an issue with details about your use case.'
+    );
+  }
+
+  // Filter out stories based on the passed tags filter
+  const validStories: (typeof parsed)['_storyStatements'] = {};
+  Object.keys(parsed._stories).map((key) => {
+    const finalTags = combineTags(
+      'test',
+      'dev',
+      ...previewLevelTags,
+      ...(parsed.meta?.tags || []),
+      ...(parsed._stories[key].tags || [])
+    );
+
+    if (isValidTest(finalTags, tagsFilter)) {
+      validStories[key] = parsed._storyStatements[key];
+    }
+  });
+
+  const vitestTestId = parsed._file.path.scope.generateUidIdentifier('test');
+  const vitestBeforeAllId = parsed._file.path.scope.generateUidIdentifier('beforeAll');
+  const vitestAfterAllId = parsed._file.path.scope.generateUidIdentifier('afterAll');
+  const vitestDescribeId = parsed._file.path.scope.generateUidIdentifier('describe');
+
+  // if no valid stories are found, we just add describe.skip() to the file to avoid empty test files
+  if (Object.keys(validStories).length === 0) {
+    const describeSkipBlock = t.expressionStatement(
+      t.callExpression(t.memberExpression(vitestDescribeId, t.identifier('skip')), [
+        t.stringLiteral('No valid tests found'),
+      ])
+    );
+
+    ast.program.body.push(describeSkipBlock);
+    const imports = [
+      t.importDeclaration(
+        [
+          t.importSpecifier(vitestTestId, t.identifier('test')),
+          t.importSpecifier(vitestDescribeId, t.identifier('describe')),
+        ],
+        t.stringLiteral('vitest')
+      ),
+    ];
+
+    ast.program.body.unshift(...imports);
+  } else {
+    const vitestExpectId = parsed._file.path.scope.generateUidIdentifier('expect');
+    const testStoryId = parsed._file.path.scope.generateUidIdentifier('testStory');
+    const prepareScriptId = parsed._file.path.scope.generateUidIdentifier('prepareScript');
+    const setupPageScriptId = parsed._file.path.scope.generateUidIdentifier('setupPageScript');
+
+    function getTestGuardDeclaration() {
+      const isRunningFromThisFileId =
+        parsed._file.path.scope.generateUidIdentifier('isRunningFromThisFile');
+
+      // expect.getState().testPath
+      const testPathProperty = t.memberExpression(
+        t.callExpression(t.memberExpression(vitestExpectId, t.identifier('getState')), []),
+        t.identifier('testPath')
+      );
+
+      // There is a bug in Vitest where expect.getState().testPath is undefined when called outside of a test function so we add this fallback in the meantime
+      // https://github.com/vitest-dev/vitest/issues/6367
+      // globalThis.__vitest_worker__.filepath
+      const filePathProperty = t.memberExpression(
+        t.memberExpression(t.identifier('globalThis'), t.identifier('__vitest_worker__')),
+        t.identifier('filepath')
+      );
+
+      // Combine testPath and filepath using the ?? operator
+      const nullishCoalescingExpression = t.logicalExpression(
+        '??',
+        // TODO: switch order of testPathProperty and filePathProperty when the bug is fixed
+        // https://github.com/vitest-dev/vitest/issues/6367 (or probably just use testPathProperty)
+        filePathProperty,
+        testPathProperty
+      );
+
+      // Create the final expression: convertToFilePath(import.meta.url).includes(...)
+      const includesCall = t.callExpression(
+        t.memberExpression(
+          t.callExpression(t.identifier('convertToFilePath'), [
+            t.memberExpression(
+              t.memberExpression(t.identifier('import'), t.identifier('meta')),
+              t.identifier('url')
+            ),
+          ]),
+          t.identifier('includes')
+        ),
+        [nullishCoalescingExpression]
+      );
+
+      const isRunningFromThisFileDeclaration = t.variableDeclaration('const', [
+        t.variableDeclarator(isRunningFromThisFileId, includesCall),
+      ]);
+      return { isRunningFromThisFileDeclaration, isRunningFromThisFileId };
+    }
+
+    const getTestStatementForStory = ({
+      testTitle,
+      storyId,
+      node,
+    }: {
+      testTitle: string;
+      storyId: string;
+      node: t.Node;
+    }): t.ExpressionStatement => {
+      // Create the _test expression directly using the exportName identifier
+      const testStoryCall = t.expressionStatement(
+        t.callExpression(vitestTestId, [
+          t.stringLiteral(testTitle),
+          t.callExpression(testStoryId, [t.stringLiteral(storyId), t.identifier('page')]),
+        ])
+      );
+
+      // Preserve sourcemaps location
+      testStoryCall.loc = node.loc;
+
+      return testStoryCall;
+    };
+
+    const { isRunningFromThisFileDeclaration, isRunningFromThisFileId } = getTestGuardDeclaration();
+
+    const storyTestStatements = Object.entries(validStories)
+      .map(([exportName, node]) => {
+        if (node === null) {
+          logger.warn(
+            dedent`
+            [Storybook]: Could not transform "${exportName}" story into test at "${fileName}".
+            Please make sure to define stories in the same file and not re-export stories coming from other files".
+          `
+          );
+          return;
+        }
+
+        const storyName = storyNameFromExport(exportName);
+        const testTitle = parsed._stories[exportName].name ?? storyName;
+        const storyId = toId(parsed._meta?.title || '', storyName);
+
+        return getTestStatementForStory({ testTitle, storyId, node });
+      })
+      .filter((st) => !!st) as t.ExpressionStatement[];
+
+    // Create browser and page variables
+    const browserDeclaration = t.variableDeclaration('let', [
+      t.variableDeclarator(t.identifier('browser')),
+    ]);
+
+    const pageDeclaration = t.variableDeclaration('let', [
+      t.variableDeclarator(t.identifier('page')),
+    ]);
+
+    // Create beforeAll hook
+    const beforeAllBlock = t.expressionStatement(
+      t.callExpression(vitestBeforeAllId, [
+        t.arrowFunctionExpression(
+          [],
+          t.blockStatement([
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                t.identifier('options'),
+                t.objectExpression([
+                  t.objectProperty(t.identifier('headless'), t.booleanLiteral(false)),
+                ])
+              ),
+            ]),
+            t.expressionStatement(
+              t.assignmentExpression(
+                '=',
+                t.identifier('browser'),
+                t.awaitExpression(
+                  t.callExpression(
+                    t.memberExpression(t.identifier('chromium'), t.identifier('launch')),
+                    [t.identifier('options')]
+                  )
+                )
+              )
+            ),
+            t.expressionStatement(
+              t.assignmentExpression(
+                '=',
+                t.identifier('page'),
+                t.awaitExpression(
+                  t.callExpression(
+                    t.memberExpression(t.identifier('browser'), t.identifier('newPage')),
+                    []
+                  )
+                )
+              )
+            ),
+            t.expressionStatement(
+              t.awaitExpression(t.callExpression(prepareScriptId, [t.identifier('page')]))
+            ),
+            t.expressionStatement(
+              t.awaitExpression(t.callExpression(setupPageScriptId, [t.identifier('page')]))
+            ),
+          ]),
+          true
+        ),
+      ])
+    );
+
+    // Create afterAll hook
+    const afterAllBlock = t.expressionStatement(
+      t.callExpression(vitestAfterAllId, [
+        t.arrowFunctionExpression(
+          [],
+          t.blockStatement([
+            t.expressionStatement(
+              t.awaitExpression(
+                t.callExpression(
+                  t.memberExpression(t.identifier('browser'), t.identifier('close')),
+                  []
+                )
+              )
+            ),
+          ]),
+          true
+        ),
+      ])
+    );
+
+    const testBlock = t.ifStatement(
+      isRunningFromThisFileId,
+      t.blockStatement([
+        browserDeclaration,
+        pageDeclaration,
+        beforeAllBlock,
+        afterAllBlock,
+        ...storyTestStatements,
+      ])
+    );
+
+    ast.program.body.push(isRunningFromThisFileDeclaration, testBlock);
+
+    const imports = [
+      t.importDeclaration(
+        [
+          t.importSpecifier(vitestTestId, t.identifier('test')),
+          t.importSpecifier(vitestBeforeAllId, t.identifier('beforeAll')),
+          t.importSpecifier(vitestAfterAllId, t.identifier('afterAll')),
+          t.importSpecifier(vitestExpectId, t.identifier('expect')),
+        ],
+        t.stringLiteral('vitest')
+      ),
+      t.importDeclaration(
+        [t.importSpecifier(t.identifier('chromium'), t.identifier('chromium'))],
+        t.stringLiteral('playwright')
+      ),
+      t.importDeclaration(
+        [t.importSpecifier(t.identifier('convertToFilePath'), t.identifier('convertToFilePath'))],
+        t.stringLiteral('@storybook/addon-vitest/internal/test-utils')
+      ),
+      t.importDeclaration(
+        [
+          t.importSpecifier(testStoryId, t.identifier('testStory')),
+          t.importSpecifier(prepareScriptId, t.identifier('prepareScript')),
+          t.importSpecifier(setupPageScriptId, t.identifier('setupPageScript')),
+        ],
+        t.stringLiteral('@storybook/addon-vitest/internal/playwright-utils')
+      ),
+    ];
+
+    ast.program.body.unshift(...imports);
+  }
+
+  return formatCsf(parsed, { sourceMaps: true, sourceFileName: fileName }, code);
+}

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
@@ -199,7 +199,11 @@ export async function vitestPlaywrightTransform({
       const testStoryCall = t.expressionStatement(
         t.callExpression(vitestTestId, [
           t.stringLiteral(testTitle),
-          t.callExpression(testStoryId, [t.stringLiteral(storyId), t.identifier('page')]),
+          t.arrowFunctionExpression(
+            [],
+            t.callExpression(testStoryId, [t.stringLiteral(storyId), t.identifier('page')]),
+            true // async
+          ),
         ])
       );
 
@@ -338,14 +342,11 @@ export async function vitestPlaywrightTransform({
         t.stringLiteral('playwright')
       ),
       t.importDeclaration(
-        [t.importSpecifier(t.identifier('convertToFilePath'), t.identifier('convertToFilePath'))],
-        t.stringLiteral('@storybook/addon-vitest/internal/test-utils')
-      ),
-      t.importDeclaration(
         [
           t.importSpecifier(testStoryId, t.identifier('testStory')),
           t.importSpecifier(prepareScriptId, t.identifier('prepareScript')),
           t.importSpecifier(setupPageScriptId, t.identifier('setupPageScript')),
+          t.importSpecifier(t.identifier('convertToFilePath'), t.identifier('convertToFilePath')),
         ],
         t.stringLiteral('@storybook/addon-vitest/internal/playwright-utils')
       ),

--- a/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
+++ b/code/core/src/csf-tools/vitest-plugin/transformer-playwright.ts
@@ -199,7 +199,15 @@ export async function vitestPlaywrightTransform({
       const testStoryCall = t.expressionStatement(
         t.callExpression(vitestTestId, [
           t.stringLiteral(testTitle),
-          t.callExpression(testStoryId, [t.stringLiteral(storyId), t.identifier('page')]),
+          t.arrowFunctionExpression(
+            [t.identifier('context')],
+            t.callExpression(testStoryId, [
+              t.stringLiteral(storyId),
+              t.identifier('page'),
+              t.identifier('context'),
+            ]),
+            true // async
+          ),
         ])
       );
 


### PR DESCRIPTION
Closes #

## What I did

This PR introduces a new mode for the vitest addon which allows it to test stories based on a live server's Storybook's index.json file.
It works by essentially using Vitest as a runner, Playwright as environment (managed manually) and by injecting the [same logic as the test-runner](https://github.com/storybookjs/test-runner/blob/next/src/setup-page-script.ts) to use the Storybook channel to visit stories and get reports back.

## Checklist for Contributors

### Testing

You can go to webpack based Storybooks and use the `0.0.0-pr-32047-sha-6cc3189c` canary to try it out.
You must configure Vite, Vitest and the addon-vitest plugin (without browser mode), e.g.

```ts
// vite.config.ts
/// <reference types="vitest/config" />
import { defineConfig } from 'vite'
import { storybookTest } from '@storybook/addon-vitest/vitest-plugin'

export default defineConfig({
  test: {
    testTimeout: 300000,
    coverage: {
      provider: 'istanbul',
      include: ['src/**/*.ts', 'src/**/*.tsx'],
      reporter: ['text', 'html'],
    },
    projects: [
      {
        extends: './vite.config.ts',
        plugins: [
          storybookTest({
            usePlaywright: true,
          }),
        ],
        test: {
          name: 'storybook',
        },
      },
    ],
  },
})
```

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32047-sha-6cc3189c`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32047-sha-6cc3189c sandbox` or in an existing project with `npx storybook@0.0.0-pr-32047-sha-6cc3189c upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32047-sha-6cc3189c`](https://npmjs.com/package/storybook/v/0.0.0-pr-32047-sha-6cc3189c) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/experiment-with-vitest-playwright-runner`](https://github.com/storybookjs/storybook/tree/yann/experiment-with-vitest-playwright-runner) |
| **Commit** | [`6cc3189c`](https://github.com/storybookjs/storybook/commit/6cc3189c31aa58464e0b95800bbeb4e6ccb90466) |
| **Datetime** | Thu Jul 17 16:19:46 UTC 2025 (`1752769186`) |
| **Workflow run** | [16350450264](https://github.com/storybookjs/storybook/actions/runs/16350450264) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32047`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
