### PR TITLE
Addon Docs: Fix Symbol conversion issue in docs page and controls panel

### DIFF
--- a/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx
+++ b/code/addons/docs/src/blocks/controls/react-editable-json-tree/JsonNodes.tsx
@@ -335,7 +335,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
         style: minus,
-        'aria-label': `remove the array '${name}'`,
+        'aria-label': `remove the array '${String(name)}'`,
       });
 
     return (
@@ -379,7 +379,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
         onClick: this.handleAddMode,
         className: 'rejt-plus-menu',
         style: plus,
-        'aria-label': `add a new item to the '${name}' array`,
+        'aria-label': `add a new item to the '${String(name)}' array`,
       });
     const removeItemButton =
       minusMenuElement &&
@@ -387,7 +387,7 @@ export class JsonArray extends Component<JsonArrayProps, JsonArrayState> {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
         style: minus,
-        'aria-label': `remove the array '${name}'`,
+        'aria-label': `remove the array '${String(name)}'`,
       });
 
     const onlyValue = true;
@@ -670,8 +670,8 @@ export class JsonFunctionValue extends Component<JsonFunctionValueProps, JsonFun
           onClick: handleRemove,
           className: 'rejt-minus-menu',
           style: style.minus,
-          'aria-label': `remove the function '${name}'${
-            parentPropertyName ? ` from '${parentPropertyName}'` : ''
+          'aria-label': `remove the function '${String(name)}'${
+            String(parentPropertyName) ? ` from '${String(parentPropertyName)}'` : ''
           }`,
         });
       minusElement = resultOnlyResult ? null : minusMenuLayout;
@@ -1222,7 +1222,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
         style: minus,
-        'aria-label': `remove the object '${name}'`,
+        'aria-label': `remove the object '${String(name)}'`,
       });
 
     return (
@@ -1268,7 +1268,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
         onClick: this.handleAddMode,
         className: 'rejt-plus-menu',
         style: plus,
-        'aria-label': `add a new property to the object '${name}'`,
+        'aria-label': `add a new property to the object '${String(name)}'`,
       });
     const removeItemButton =
       minusMenuElement &&
@@ -1276,7 +1276,7 @@ export class JsonObject extends Component<JsonObjectProps, JsonObjectState> {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
         style: minus,
-        'aria-label': `remove the object '${name}'`,
+        'aria-label': `remove the object '${String(name)}'`,
       });
 
     const list = keyList.map((key) => (
@@ -1540,8 +1540,8 @@ export class JsonValue extends Component<JsonValueProps, JsonValueState> {
         onClick: handleRemove,
         className: 'rejt-minus-menu',
         style: style.minus,
-        'aria-label': `remove the property '${name}' with value '${originalValue}'${
-          parentPropertyName ? ` from '${parentPropertyName}'` : ''
+        'aria-label': `remove the property '${String(name)}' with value '${String(originalValue)}'${
+          String(parentPropertyName) ? ` from '${String(parentPropertyName)}'` : ''
         }`,
       });
 

--- a/code/e2e-tests/addon-controls.spec.ts
+++ b/code/e2e-tests/addon-controls.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import process from 'process';
 
-import { SbPage } from './util';
+import { SbPage, isReactSandbox } from './util';
 
 const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
 const templateName = process.env.STORYBOOK_TEMPLATE_NAME || '';
@@ -102,5 +102,16 @@ test.describe('addon-controls', () => {
     );
 
     await expect(page).toHaveURL(/.*multiSelect\[0]:double\+\+space.*/);
+  });
+
+  // We want to avoid the controls panel crashing when JSX elements are part of args table
+  test('should show JSX elements in controls panel', async ({ page }) => {
+    test.skip(!isReactSandbox(templateName), 'This is a React only feature');
+    await page.goto(`${storybookUrl}?path=/story/stories-renderers-react-jsx-docgen--default`);
+
+    const sbPage = new SbPage(page, expect);
+    await sbPage.waitUntilLoaded();
+    await sbPage.viewAddonPanel('Controls');
+    await expect(sbPage.panelContent().getByText('ReactReactNode')).toBeVisible();
   });
 });

--- a/code/e2e-tests/addon-controls.spec.ts
+++ b/code/e2e-tests/addon-controls.spec.ts
@@ -112,6 +112,6 @@ test.describe('addon-controls', () => {
     const sbPage = new SbPage(page, expect);
     await sbPage.waitUntilLoaded();
     await sbPage.viewAddonPanel('Controls');
-    await expect(sbPage.panelContent().getByText('ReactReactNode')).toBeVisible();
+    await expect(sbPage.panelContent().getByText('children').first()).toBeVisible();
   });
 });

--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from '@playwright/test';
 import process from 'process';
 import { dedent } from 'ts-dedent';
 
-import { SbPage } from './util';
+import { SbPage, isReactSandbox } from './util';
 
 const storybookUrl = process.env.STORYBOOK_URL || 'http://localhost:8001';
 const templateName = process.env.STORYBOOK_TEMPLATE_NAME || '';
@@ -279,5 +279,15 @@ test.describe('addon-docs', () => {
       'H 1 Content',
       'H 2 Content',
     ]);
+  });
+
+  // We want to avoid the docs page crashing when JSX elements are part of args table
+  test('should show JSX elements in docs page', async ({ page }) => {
+    test.skip(!isReactSandbox(templateName), 'This is a React only feature');
+
+    const sbPage = new SbPage(page, expect);
+    await sbPage.navigateToStory('/stories/renderers/react/jsx-docgen', 'docs');
+    const root = sbPage.previewRoot();
+    await expect(root.getByText('ReactReactNode')).toBeVisible();
   });
 });

--- a/code/e2e-tests/addon-docs.spec.ts
+++ b/code/e2e-tests/addon-docs.spec.ts
@@ -288,6 +288,6 @@ test.describe('addon-docs', () => {
     const sbPage = new SbPage(page, expect);
     await sbPage.navigateToStory('/stories/renderers/react/jsx-docgen', 'docs');
     const root = sbPage.previewRoot();
-    await expect(root.getByText('ReactReactNode')).toBeVisible();
+    await expect(root.getByText('children').first()).toBeVisible();
   });
 });

--- a/code/e2e-tests/util.ts
+++ b/code/e2e-tests/util.ts
@@ -205,6 +205,10 @@ export class SbPage {
 const templateName: keyof typeof allTemplates = process.env.STORYBOOK_TEMPLATE_NAME || ('' as any);
 
 const templates = allTemplates;
+
+export const isReactSandbox = (templateName: string) =>
+  templates[templateName as keyof typeof templates]?.expected.renderer === '@storybook/react';
+
 export const hasVitestIntegration =
   !templates[templateName]?.skipTasks?.includes('vitest-integration');
 

--- a/code/renderers/react/template/stories/jsx-docgen.stories.tsx
+++ b/code/renderers/react/template/stories/jsx-docgen.stories.tsx
@@ -1,0 +1,17 @@
+import React, { type FC } from 'react';
+
+const Component: FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <div>{children}</div>;
+};
+
+export default {
+  component: Component,
+  tags: ['autodocs'],
+};
+
+// This story is used to test whether JSX elements render correctly in autodocs and controls panel
+export const Default = {
+  args: {
+    children: <div>Test</div>,
+  },
+};


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/32183

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-32210-sha-378d79af`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-32210-sha-378d79af sandbox` or in an existing project with `npx storybook@0.0.0-pr-32210-sha-378d79af upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-32210-sha-378d79af`](https://npmjs.com/package/storybook/v/0.0.0-pr-32210-sha-378d79af) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/fix-jsx-issue`](https://github.com/storybookjs/storybook/tree/yann/fix-jsx-issue) |
| **Commit** | [`378d79af`](https://github.com/storybookjs/storybook/commit/378d79af360f65195d96fb2065e055cd026bbec2) |
| **Datetime** | Thu Aug  7 13:09:18 UTC 2025 (`1754572158`) |
| **Workflow run** | [16805413425](https://github.com/storybookjs/storybook/actions/runs/16805413425) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=32210`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical runtime error in Storybook's docs page and controls panel that occurs when React components receive Symbol values as props. The issue manifested as "Cannot convert a Symbol value to string" errors when these Symbol values were used in template literals for `aria-label` attributes in the JSON tree editor component.

The fix involves systematically wrapping all variable interpolations in `aria-label` attributes with explicit `String()` conversion calls. This change is applied across all JSON component types in the `JsonNodes.tsx` file, including `JsonArray`, `JsonFunctionValue`, `JsonObject`, and `JsonValue` components. Specifically, the modifications replace direct template literal interpolations like `${name}` with `${String(name)}`, `${parentPropertyName}` with `${String(parentPropertyName)}`, and `${originalValue}` with `${String(originalValue)}`.

This defensive programming approach ensures that all values - including Symbols, null, undefined, and other primitive types - are safely converted to strings before being used in accessibility labels. The change integrates seamlessly with the existing JSON tree editor functionality used in Storybook's controls panel and docs page, maintaining all existing behavior while preventing the Symbol conversion errors that would previously crash the interface.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it addresses a specific runtime error with a targeted fix
- Score reflects the focused nature of the changes and clear understanding of the JavaScript Symbol conversion issue
- No files require special attention as the changes are straightforward string conversion safety measures

<!-- /greptile_comment -->