### PR TITLE
CSF: Add .test function

### DIFF
--- a/code/core/src/csf/csf-factories.test.ts
+++ b/code/core/src/csf/csf-factories.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { definePreview, definePreviewAddon } from './csf-factories';
 
@@ -16,7 +16,9 @@ const addon2 = definePreviewAddon<Addon2Types>({});
 
 const preview = definePreview({ addons: [addon, addon2] });
 
-const meta = preview.meta({});
+const meta = preview.meta({
+  render: () => 'hello',
+});
 
 test('addon parameters are inferred', () => {
   const MyStory = meta.story({
@@ -39,5 +41,36 @@ test('addon parameters are inferred', () => {
         value: 1,
       },
     },
+  });
+});
+
+describe('test function', () => {
+  test('without overrides', async () => {
+    const MyStory = meta.story({ args: { label: 'foo' } });
+    const testFn = vi.fn();
+    const testName = 'should run test';
+
+    // register test
+    MyStory.test(testName, testFn);
+    const storyTest = MyStory.input.__tests![testName];
+    expect(storyTest.input.args).toEqual({ label: 'foo' });
+
+    // execute test
+    await storyTest.input.__testFunction?.();
+    expect(testFn).toHaveBeenCalled();
+  });
+  test('with overrides', async () => {
+    const MyStory = meta.story({ args: { label: 'foo' } });
+    const testFn = vi.fn();
+    const testName = 'should run test';
+
+    // register test
+    MyStory.test(testName, { args: { label: 'bar' } }, testFn);
+    const storyTest = MyStory.input.__tests![testName];
+    expect(storyTest.input.args).toEqual({ label: 'bar' });
+
+    // execute test
+    await storyTest.input.__testFunction?.();
+    expect(testFn).toHaveBeenCalled();
   });
 });

--- a/code/core/src/csf/story.ts
+++ b/code/core/src/csf/story.ts
@@ -533,6 +533,10 @@ export type StoryAnnotations<
 
   /** @deprecated */
   story?: Omit<StoryAnnotations<TRenderer, TArgs>, 'story'>;
+
+  /** @private */
+  __tests?: Record<string, StoryAnnotations<TRenderer, TRenderer['args']>>;
+  __testFunction?: (context: StoryContext<TRenderer>) => Promise<void>;
 } & ({} extends TRequiredArgs ? { args?: TRequiredArgs } : { args: TRequiredArgs });
 
 export type LegacyAnnotatedStoryFn<TRenderer extends Renderer = Renderer, TArgs = Args> = StoryFn<


### PR DESCRIPTION
Closes #32262

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new `.test()` function to CSF (Component Story Format) factories, implementing the functionality requested in issue #32262. The change allows developers to define tests directly on story instances that can inherit the story's context (args, parameters, etc.) while optionally overriding specific properties.

The implementation spans three key files:

1. **Type definitions** (`story.ts`): Adds two private properties to `StoryAnnotations` interface - `__tests` to store test definitions and `__testFunction` to store test execution logic
2. **Factory implementation** (`csf-factories.ts`): Implements the actual `.test()` method with two overloads - one without overrides and one with overrides that allow customizing test context
3. **Test coverage** (`csf-factories.test.ts`): Comprehensive test suite validating both registration and execution of tests

The feature integrates seamlessly with Storybook's existing CSF system by extending stories with test annotations stored in a `__tests` collection. When a test is registered, it creates an extended story that merges the parent story's configuration with any test-specific overrides. This allows for flexible testing scenarios where tests can run with different contexts than their parent story while maintaining type safety and following established CSF patterns.

## Confidence score: 3/5

- This PR introduces complex logic changes to core CSF functionality that could have wide-reaching effects
- The change from throwing an error to returning `composeConfigs()` in the composed getter may have unintended side effects on existing functionality
- Args merging logic using `this.composed.args` could potentially create circular dependency issues that need careful monitoring
- Pay close attention to `code/core/src/csf/csf-factories.ts` for potential runtime issues with the composed getter and args merging changes

<!-- /greptile_comment -->