### PR TITLE
Docs: Update package homepages

### DIFF
--- a/code/addons/a11y/package.json
+++ b/code/addons/a11y/package.json
@@ -19,7 +19,7 @@
     "svelte",
     "web-components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/a11y",
+  "homepage": "https://storybook.js.org/docs/writing-tests/accessibility-testing?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/docs/package.json
+++ b/code/addons/docs/package.json
@@ -22,7 +22,7 @@
     "svelte",
     "web-components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/docs",
+  "homepage": "https://storybook.js.org/docs/writing-docs?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/jest/package.json
+++ b/code/addons/jest/package.json
@@ -14,7 +14,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/jest",
+  "homepage": "https://storybook.js.org/addons/@storybook/addon-jest?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/links/package.json
+++ b/code/addons/links/package.json
@@ -11,7 +11,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/links",
+  "homepage": "https://storybook.js.org/addons/@storybook/addon-links?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/onboarding/package.json
+++ b/code/addons/onboarding/package.json
@@ -15,7 +15,7 @@
     "svelte",
     "web-components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/onboarding",
+  "homepage": "https://storybook.js.org/docs?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/pseudo-states/package.json
+++ b/code/addons/pseudo-states/package.json
@@ -17,7 +17,7 @@
     "svelte",
     "web-components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/pseudo-states",
+  "homepage": "https://storybook.js.org/addons/storybook-addon-pseudo-states?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/themes/package.json
+++ b/code/addons/themes/package.json
@@ -18,7 +18,7 @@
     "svelte",
     "web-components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/themes",
+  "homepage": "https://storybook.js.org/docs/essentials/themes?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/addons/vitest/package.json
+++ b/code/addons/vitest/package.json
@@ -16,7 +16,7 @@
     "svelte",
     "web-components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/vitest",
+  "homepage": "https://storybook.js.org/docs/writing-tests/integrations/vitest-addon?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/builders/builder-vite/package.json
+++ b/code/builders/builder-vite/package.json
@@ -11,7 +11,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/builders/builder-vite/#readme",
+  "homepage": "https://storybook.js.org/docs/builders/vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/builders/builder-webpack5/package.json
+++ b/code/builders/builder-webpack5/package.json
@@ -11,7 +11,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/builders/builder-webpack5",
+  "homepage": "https://storybook.js.org/docs/builders/webpack?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -19,7 +19,7 @@
     "sveltekit",
     "web-components"
   ],
-  "homepage": "https://storybook.js.org",
+  "homepage": "https://storybook.js.org?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/angular/package.json
+++ b/code/frameworks/angular/package.json
@@ -9,7 +9,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/angular",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/angular?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -11,7 +11,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/nextjs-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/nextjs?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -10,7 +10,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/nextjs",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/nextjs?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/preact-vite/package.json
+++ b/code/frameworks/preact-vite/package.json
@@ -10,7 +10,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/preact-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/preact-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/react-native-web-vite/package.json
+++ b/code/frameworks/react-native-web-vite/package.json
@@ -12,7 +12,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/react-native-web-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/react-native-web-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/react-vite/package.json
+++ b/code/frameworks/react-vite/package.json
@@ -10,7 +10,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/react-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/react-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/react-webpack5/package.json
+++ b/code/frameworks/react-webpack5/package.json
@@ -10,7 +10,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/react-webpack5",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/react-webpack5?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/svelte-vite/package.json
+++ b/code/frameworks/svelte-vite/package.json
@@ -10,7 +10,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/svelte-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/svelte-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/sveltekit/package.json
+++ b/code/frameworks/sveltekit/package.json
@@ -12,7 +12,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/sveltekit",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/sveltekit?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/vue3-vite/package.json
+++ b/code/frameworks/vue3-vite/package.json
@@ -10,7 +10,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/vue3-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/vue3-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/frameworks/web-components-vite/package.json
+++ b/code/frameworks/web-components-vite/package.json
@@ -12,7 +12,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/frameworks/web-components-vite",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/web-components-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/lib/cli-sb/package.json
+++ b/code/lib/cli-sb/package.json
@@ -10,7 +10,7 @@
     "upgrade",
     "init"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/lib/cli-sb",
+  "homepage": "https://storybook.js.org/docs/api/cli-options?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/lib/cli-storybook/package.json
+++ b/code/lib/cli-storybook/package.json
@@ -10,7 +10,7 @@
     "upgrade",
     "init"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/lib/cli-storybook",
+  "homepage": "https://storybook.js.org/docs/api/cli-options?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/renderers/preact/package.json
+++ b/code/renderers/preact/package.json
@@ -9,7 +9,7 @@
     "components",
     "component"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/renderers/preact",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/preact-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "storybook"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/renderers/react",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/react-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/renderers/svelte/package.json
+++ b/code/renderers/svelte/package.json
@@ -8,7 +8,7 @@
     "svelte",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/renderers/svelte",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/svelte-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/renderers/vue3/package.json
+++ b/code/renderers/vue3/package.json
@@ -9,7 +9,7 @@
     "components",
     "component"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/renderers/vue3",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/vue3-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },

--- a/code/renderers/web-components/package.json
+++ b/code/renderers/web-components/package.json
@@ -11,7 +11,7 @@
     "component",
     "components"
   ],
-  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/renderers/web-components",
+  "homepage": "https://storybook.js.org/docs/get-started/frameworks/web-components-vite?ref=npm",
   "bugs": {
     "url": "https://github.com/storybookjs/storybook/issues"
   },


### PR DESCRIPTION
Closes N/A

## What I did

Update all of the package.json homepages to their storybook.js.org links, which contain curated documentation on package.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->
