### PR TITLE
CSF: Improve error handling in csf factories codemod

### DIFF
--- a/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
+++ b/code/lib/cli-storybook/src/codemod/helpers/story-to-csf-factory.ts
@@ -35,6 +35,11 @@ export async function storyToCsfFactory(
     return info.source;
   }
 
+  // Track detected stories and which ones we actually transform
+  const detectedStories = csf.stories;
+  const detectedStoryNames = detectedStories.map((story) => story.name);
+  const transformedStoryExports = new Set<string>();
+
   const metaVariableName = csf._metaVariableName ?? 'meta';
 
   /**
@@ -95,7 +100,7 @@ export async function storyToCsfFactory(
   // @TODO: Support unconventional formats:
   // `export function Story() { };` and `export { Story };
   // These are not part of csf._storyExports but rather csf._storyStatements and are tricky to support.
-  Object.entries(csf._storyExports).forEach(([, decl]) => {
+  Object.entries(csf._storyExports).forEach(([exportName, decl]) => {
     const id = decl.id;
     const declarator = decl as t.VariableDeclarator;
     let init = t.isVariableDeclarator(declarator) ? declarator.init : undefined;
@@ -118,12 +123,18 @@ export async function storyToCsfFactory(
           t.memberExpression(t.identifier(metaVariableName), t.identifier('story')),
           init.properties.length === 0 ? [] : [init]
         );
+        if (t.isIdentifier(id)) {
+          transformedStoryExports.add(exportName);
+        }
       } else if (t.isArrowFunctionExpression(init)) {
         // Transform CSF1 to meta.story({ render: <originalFn> })
         declarator.init = t.callExpression(
           t.memberExpression(t.identifier(metaVariableName), t.identifier('story')),
           [init]
         );
+        if (t.isIdentifier(id)) {
+          transformedStoryExports.add(exportName);
+        }
       }
     }
   });
@@ -152,6 +163,7 @@ export async function storyToCsfFactory(
       )._storyPaths?.[exportName];
       if (pathForExport && pathForExport.replaceWith) {
         pathForExport.replaceWith(replacement);
+        transformedStoryExports.add(exportName);
       }
     }
   });
@@ -226,6 +238,16 @@ export async function storyToCsfFactory(
       }
     },
   });
+
+  // If some stories were detected but not all could be transformed, we skip the codemod to avoid mixed csf syntax and therefore a broken indexer.
+  if (detectedStoryNames.length > 0 && transformedStoryExports.size !== detectedStoryNames.length) {
+    logger.warn(
+      `Skipping codemod for ${info.path}:\nDetected stories [${detectedStoryNames
+        .map((name) => `"${name}"`)
+        .join(', ')}] were not fully transformed because some use an unsupported format.`
+    );
+    return info.source;
+  }
 
   // modify meta
   if (csf._metaPath) {


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR makes the csf factories codemod bail out on stories that were only half transformed, to avoid having a mixed csf format in the file and therefore a broken storybook index.
It warns the user regarding which file was not transformed and which stories were in a non supported format

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 18:02:05 UTC

This PR improves error handling in the CSF (Component Story Format) factories codemod to prevent partially transformed story files that would break Storybook's indexer. The changes implement a comprehensive tracking system that monitors which stories are successfully transformed during the migration from CSF 2 to CSF 3 format.

The core improvement is in `story-to-csf-factory.ts`, where the codemod now:
1. Tracks all detected stories in a file using `csf.stories`
2. Records successfully transformed story exports in a `Set<string>`
3. Compares the count of detected stories versus transformed stories after processing
4. If the counts don't match (indicating some stories couldn't be transformed), it bails out entirely and returns the original source unchanged
5. Warns users with specific information about which file was skipped and which stories were detected

This addresses a critical issue where the codemod could leave files in a mixed state - some stories using the new `meta.story()` factory syntax while others remained in the old format. Such mixed formatting breaks Storybook's story indexer, which expects consistent CSF format throughout a file. The solution ensures files remain in a working state and provides clear feedback about which stories need manual intervention.

The implementation includes comprehensive test coverage that validates the bailout behavior, mocks the logger to verify warning messages, and tests scenarios with mixed transformable/non-transformable stories.

## Confidence score: 4/5

- This PR addresses a critical bug that could break Storybook functionality during migrations
- The tracking logic is well-implemented with clear validation and appropriate fallback behavior  
- Pay close attention to the transformation tracking logic in `story-to-csf-factory.ts` to ensure all transformation paths correctly update the `transformedStoryExports` Set

<!-- /greptile_comment -->