### PR TITLE
Experiment: Inspect and highlight story components

### DIFF
--- a/code/addons/story-inspector/README.md
+++ b/code/addons/story-inspector/README.md
@@ -1,0 +1,56 @@
+# Storybook Story Inspector
+
+A Storybook addon that helps you visualize which components in your stories have corresponding story files and which don't.
+
+## Features
+
+- 🔍 **Visual Component Inspection**: Highlights components in your stories with color-coded indicators
+- ✅ **Story Status Indication**: Green highlights for components that have stories, orange for those that don't
+- 🚀 **Quick Navigation**: Click highlighted components with stories to navigate directly to them
+- ➕ **Story Creation**: Click highlighted components without stories to automatically create a story file
+- 🎯 **Smart Detection**: Uses file path metadata to accurately match components to their story files
+
+## How it works
+
+1. **File Transformation**: A Vite plugin automatically injects component file path metadata into your JSX elements during build
+2. **Component Detection**: The addon scans the rendered story for components with this metadata
+3. **Story Matching**: Components are matched against the story index to determine if they have stories
+4. **Visual Feedback**: Components are highlighted with different colors based on their story status
+5. **Interactive Actions**: Click highlights to navigate to stories or create new ones
+
+## Usage
+
+1. Install the addon (it's included as an internal Storybook addon)
+2. Click the eye icon in the Storybook toolbar to enable story inspection
+3. Components will be highlighted:
+   - **Green**: Component has stories - click to navigate
+   - **Orange**: Component has no stories - click to create one
+
+## Highlighting Colors
+
+- 🟢 **Green**: Components that have corresponding story files
+- 🟠 **Orange**: Components that don't have story files yet
+
+## Creating Stories
+
+When you click on an orange-highlighted component (one without stories), the addon will:
+
+1. Automatically create a new story file for that component
+2. Generate basic story structure with sensible defaults
+3. Navigate you to the newly created story
+4. Show a success notification
+
+## Technical Details
+
+This addon consists of:
+
+- **Vite Plugin**: Injects component file paths as data attributes
+- **Manager Extension**: Provides toolbar controls and highlighting logic
+- **Story Matching**: Compares component paths against the story index
+- **Story Creation**: Integrates with Storybook's story creation APIs
+
+## Limitations
+
+- Currently optimized for Vite-based Storybook setups
+- Works best with React components (JSX/TSX)
+- Requires components to be in separate files for accurate detection

--- a/code/addons/story-inspector/USAGE.md
+++ b/code/addons/story-inspector/USAGE.md
@@ -1,0 +1,138 @@
+# Using the Story Inspector Addon
+
+The Story Inspector addon helps you visualize which components in your Storybook stories have corresponding story files and which don't. This is particularly useful for large codebases where you want to ensure story coverage for your components.
+
+## Installation and Setup
+
+### For Internal Use (Development)
+
+The addon is built as an internal Storybook addon. To use it in your Storybook:
+
+1. **Add to your `.storybook/main.ts`:**
+
+```typescript
+module.exports = {
+  // ... other config
+  addons: [
+    // ... other addons
+    '@storybook/addon-story-inspector',
+  ],
+};
+```
+
+2. **Ensure Vite is used as your builder** (required for the component path injection):
+
+```typescript
+module.exports = {
+  framework: {
+    name: '@storybook/react-vite', // or another vite-based framework
+    options: {},
+  },
+  // ... other config
+};
+```
+
+## How to Use
+
+### 1. Enable the Inspector
+
+- Look for the eye icon 👁️ in the Storybook toolbar
+- Click it to toggle the Story Inspector on/off
+- The icon will show a badge with the number of detected components when active
+
+### 2. View Component Highlights
+
+When enabled, components in your stories will be highlighted with colored outlines:
+
+- **🟢 Green**: Components that have existing story files
+- **🟠 Orange**: Components that don't have story files yet
+
+### 3. Interact with Highlighted Components
+
+Click on any highlighted component to see a context menu with options:
+
+**For components WITH stories (green):**
+
+- "Go to story" - Navigate directly to the component's story
+
+**For components WITHOUT stories (orange):**
+
+- "Create story" - Automatically create a new story file for the component
+
+### 4. Creating Stories Automatically
+
+When you click "Create story" on an orange-highlighted component:
+
+1. The addon automatically creates a new story file
+2. Generates basic story structure with sensible defaults
+3. Navigates you to the newly created story
+4. Shows a success notification
+
+## What Gets Detected
+
+The Story Inspector detects:
+
+- React components (JSX/TSX files)
+- Vue components (`.vue` files)
+- Svelte components (`.svelte` files)
+
+It excludes:
+
+- Story files (`.stories.*`)
+- Test files (`.test.*`, `.spec.*`)
+- Node modules
+- HTML elements (lowercase tags)
+
+## Technical Details
+
+### How It Works
+
+1. **Build-time injection**: A Vite plugin injects `data-sb-component-path` attributes into component elements
+2. **Runtime detection**: The addon scans rendered stories for these attributes
+3. **Story matching**: Component paths are matched against the story index to determine story existence
+4. **Visual feedback**: Components are highlighted using the same system as the a11y addon
+
+### File Path Matching
+
+The addon matches components to stories by comparing:
+
+- Component file path (from the injected metadata)
+- `rawComponentPath` field in story index entries
+
+Paths are normalized to handle cross-platform differences (Windows vs Unix paths).
+
+## Limitations
+
+- **Vite-only**: Currently works only with Vite-based Storybook setups
+- **Component detection**: Only detects components that render as distinct elements
+- **Path accuracy**: Relies on accurate file path metadata injection
+
+## Troubleshooting
+
+### Components not being detected
+
+- Ensure you're using a Vite-based framework
+- Check that components are being rendered in the story
+- Verify component names start with uppercase letters (React convention)
+
+### Story creation failing
+
+- Ensure the component file exists and is accessible
+- Check that you have write permissions in the project directory
+- Verify the component exports are structured correctly
+
+### Performance
+
+- The inspector scans the DOM when enabled, which may impact performance with many components
+- Consider disabling when not needed for story development
+
+## Development Notes
+
+The addon consists of:
+
+- **Vite Plugin**: Injects component metadata during build
+- **Manager UI**: Provides toolbar controls and highlighting
+- **Story Creation**: Integrates with Storybook's story creation APIs
+- **Highlighting System**: Uses the same highlighting infrastructure as other addons
+
+For more details, see the implementation in `code/addons/story-inspector/src/`.

--- a/code/addons/story-inspector/build-config.ts
+++ b/code/addons/story-inspector/build-config.ts
@@ -1,0 +1,30 @@
+import type { BuildEntries } from '../../../scripts/build/utils/entry-utils';
+
+const config: BuildEntries = {
+  entries: {
+    browser: [
+      {
+        exportEntries: ['.'],
+        entryPoint: './src/index.ts',
+      },
+      {
+        exportEntries: ['./manager'],
+        entryPoint: './src/manager.tsx',
+        dts: false,
+      },
+      {
+        exportEntries: ['./preview'],
+        entryPoint: './src/preview.ts',
+      },
+    ],
+    node: [
+      {
+        exportEntries: ['./preset'],
+        entryPoint: './src/preset.ts',
+        dts: false,
+      },
+    ],
+  },
+};
+
+export default config;

--- a/code/addons/story-inspector/manager.js
+++ b/code/addons/story-inspector/manager.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/manager');

--- a/code/addons/story-inspector/package.json
+++ b/code/addons/story-inspector/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@storybook/addon-story-inspector",
+  "version": "10.0.0-beta.6",
+  "description": "Storybook Story Inspector addon: Visualize components and navigate to their stories",
+  "keywords": [
+    "storybook",
+    "storybook-addon",
+    "inspector",
+    "component",
+    "components",
+    "stories",
+    "highlight",
+    "debug",
+    "development"
+  ],
+  "homepage": "https://github.com/storybookjs/storybook/tree/next/code/addons/story-inspector",
+  "bugs": {
+    "url": "https://github.com/storybookjs/storybook/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storybookjs/storybook.git",
+    "directory": "code/addons/story-inspector"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/storybook"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./manager": "./dist/manager.js",
+    "./package.json": "./package.json",
+    "./preset": "./dist/preset.js",
+    "./preview": {
+      "types": "./dist/preview.d.ts",
+      "default": "./dist/preview.js"
+    }
+  },
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts",
+    "!src/**/*"
+  ],
+  "scripts": {
+    "check": "jiti ../../../scripts/check/check-package.ts",
+    "prep": "jiti ../../../scripts/build/build-package.ts"
+  },
+  "dependencies": {
+    "magic-string": "^0.30.5",
+    "ts-dedent": "^2.0.0"
+  },
+  "devDependencies": {
+    "@storybook/icons": "^1.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.8.3"
+  },
+  "peerDependencies": {
+    "storybook": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "storybook": {
+    "displayName": "Story Inspector",
+    "icon": "🔍"
+  }
+}

--- a/code/addons/story-inspector/preset.js
+++ b/code/addons/story-inspector/preset.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/preset');

--- a/code/addons/story-inspector/preview.js
+++ b/code/addons/story-inspector/preview.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/preview');

--- a/code/addons/story-inspector/project.json
+++ b/code/addons/story-inspector/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "story-inspector",
+  "$schema": "../../../nx.json",
+  "projectType": "library",
+  "targets": {
+    "prep": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "yarn prep",
+            "forwardAllArgs": false
+          }
+        ],
+        "parallel": false
+      }
+    },
+    "check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "yarn check",
+            "forwardAllArgs": false
+          }
+        ],
+        "parallel": false
+      }
+    }
+  }
+}

--- a/code/addons/story-inspector/src/components/StoryInspectorTool.tsx
+++ b/code/addons/story-inspector/src/components/StoryInspectorTool.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { IconButton } from 'storybook/internal/components';
+
+import { EyeCloseIcon, EyeIcon } from '@storybook/icons';
+
+import { useStoryInspector } from '../hooks/useStoryInspector';
+
+export const StoryInspectorTool = () => {
+  const { isEnabled, toggleInspector, components } = useStoryInspector();
+
+  const { withStories, withoutStories } = components;
+  const totalComponents = withStories.length + withoutStories.length;
+
+  const title = isEnabled
+    ? `Story Inspector: ON (${totalComponents} components found: ${withStories.length} with stories, ${withoutStories.length} without)`
+    : 'Story Inspector: OFF - Click to scan for components';
+
+  return (
+    <IconButton key="story-inspector" active={isEnabled} title={title} onClick={toggleInspector}>
+      {isEnabled ? <EyeIcon /> : <EyeCloseIcon />}
+      {totalComponents > 0 && isEnabled && (
+        <span
+          style={{
+            position: 'absolute',
+            top: '-8px',
+            right: '-8px',
+            background: withoutStories.length > 0 ? '#f59e0b' : '#22c55e',
+            color: 'white',
+            borderRadius: '50%',
+            padding: '2px 6px',
+            fontSize: '10px',
+            fontWeight: 'bold',
+            minWidth: '16px',
+            textAlign: 'center',
+          }}
+        >
+          {totalComponents}
+        </span>
+      )}
+    </IconButton>
+  );
+};

--- a/code/addons/story-inspector/src/constants/index.ts
+++ b/code/addons/story-inspector/src/constants/index.ts
@@ -1,0 +1,16 @@
+export const ADDON_ID = 'storybook/story-inspector' as const;
+export const TOOL_ID = `${ADDON_ID}/tool` as const;
+export const PARAM_KEY = 'storyInspector' as const;
+
+// Data attribute for component file paths
+export const COMPONENT_PATH_ATTRIBUTE = 'data-sb-component-path' as const;
+
+// Highlight IDs
+export const HIGHLIGHT_ID_WITH_STORIES = `${ADDON_ID}/with-stories` as const;
+export const HIGHLIGHT_ID_WITHOUT_STORIES = `${ADDON_ID}/without-stories` as const;
+
+// Events
+export const EVENTS = {
+  TOGGLE_INSPECTOR: `${ADDON_ID}/toggle-inspector`,
+  CREATE_STORY_FOR_COMPONENT: `${ADDON_ID}/create-story-for-component`,
+} as const;

--- a/code/addons/story-inspector/src/hooks/useStoryInspector.ts
+++ b/code/addons/story-inspector/src/hooks/useStoryInspector.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import type { StoryIndex } from 'storybook/internal/types';
+
+import { HIGHLIGHT, REMOVE_HIGHLIGHT } from 'storybook/highlight';
+import type { HighlightMenuItem } from 'storybook/highlight';
+import { useChannel, useStorybookState } from 'storybook/manager-api';
+
+import {
+  ADDON_ID,
+  EVENTS,
+  HIGHLIGHT_ID_WITHOUT_STORIES,
+  HIGHLIGHT_ID_WITH_STORIES,
+} from '../constants';
+import {
+  type ComponentInfo,
+  checkComponentsAgainstIndex,
+  findComponentsInDOM,
+  generateSelectorsForComponents,
+  groupComponentsByStoryStatus,
+} from '../utils/story-matcher';
+
+export function useStoryInspector() {
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [components, setComponents] = useState<ComponentInfo[]>([]);
+  const emit = useChannel({});
+  const { index } = useStorybookState();
+
+  const toggleInspector = useCallback(() => {
+    setIsEnabled((prev) => !prev);
+    emit(EVENTS.TOGGLE_INSPECTOR, !isEnabled);
+  }, [isEnabled, emit]);
+
+  const createStoryForComponent = useCallback(
+    (componentPath: string) => {
+      emit(EVENTS.CREATE_STORY_FOR_COMPONENT, { componentPath });
+    },
+    [emit]
+  );
+
+  const scanComponents = useCallback(() => {
+    if (!index) {
+      return;
+    }
+
+    const foundComponents = findComponentsInDOM();
+    const componentsWithStoryStatus = checkComponentsAgainstIndex(foundComponents, index as any);
+    setComponents(componentsWithStoryStatus);
+  }, [index]);
+
+  const updateHighlights = useCallback(() => {
+    // Remove existing highlights
+    emit(REMOVE_HIGHLIGHT, HIGHLIGHT_ID_WITH_STORIES);
+    emit(REMOVE_HIGHLIGHT, HIGHLIGHT_ID_WITHOUT_STORIES);
+
+    if (!isEnabled || components.length === 0) {
+      return;
+    }
+
+    const { withStories, withoutStories } = groupComponentsByStoryStatus(components);
+
+    // Highlight components with stories
+    if (withStories.length > 0) {
+      const selectorsWithStories = generateSelectorsForComponents(withStories);
+
+      emit(HIGHLIGHT, {
+        id: HIGHLIGHT_ID_WITH_STORIES,
+        priority: 1,
+        selectors: selectorsWithStories,
+        styles: {
+          outline: '2px solid #22c55e',
+          backgroundColor: 'rgba(34, 197, 94, 0.1)',
+        },
+        hoverStyles: {
+          outline: '2px solid #16a34a',
+          backgroundColor: 'rgba(34, 197, 94, 0.2)',
+        },
+        menu: withStories.map<HighlightMenuItem[]>((component) => [
+          {
+            id: `${component.storyId}:info`,
+            title: `Component: ${component.componentPath
+              .split('/')
+              .pop()
+              ?.replace(/\.(tsx?|jsx?)$/, '')}`,
+            description: `Story exists: ${component.storyEntry?.title || 'Unknown'}`,
+            selectors: [generateSelectorsForComponents([component])[0]],
+          },
+          {
+            id: `${component.storyId}:navigate`,
+            iconLeft: 'shareAlt',
+            title: 'Go to story',
+            clickEvent: 'storybook/navigate-to-story',
+            eventData: { storyId: component.storyId },
+            selectors: [generateSelectorsForComponents([component])[0]],
+          },
+        ]),
+      });
+    }
+
+    // Highlight components without stories
+    if (withoutStories.length > 0) {
+      const selectorsWithoutStories = generateSelectorsForComponents(withoutStories);
+
+      emit(HIGHLIGHT, {
+        id: HIGHLIGHT_ID_WITHOUT_STORIES,
+        priority: 1,
+        selectors: selectorsWithoutStories,
+        styles: {
+          outline: '2px solid #f59e0b',
+          backgroundColor: 'rgba(245, 158, 11, 0.1)',
+        },
+        hoverStyles: {
+          outline: '2px solid #d97706',
+          backgroundColor: 'rgba(245, 158, 11, 0.2)',
+        },
+        menu: withoutStories.map<HighlightMenuItem[]>((component) => [
+          {
+            id: `${component.componentPath}:info`,
+            title: `Component: ${component.componentPath
+              .split('/')
+              .pop()
+              ?.replace(/\.(tsx?|jsx?)$/, '')}`,
+            description: 'No story exists yet',
+            selectors: [generateSelectorsForComponents([component])[0]],
+          },
+          {
+            id: `${component.componentPath}:create`,
+            iconLeft: 'plus',
+            title: 'Create story',
+            clickEvent: EVENTS.CREATE_STORY_FOR_COMPONENT,
+            eventData: { componentPath: component.componentPath },
+            selectors: [generateSelectorsForComponents([component])[0]],
+          },
+        ]),
+      });
+    }
+  }, [isEnabled, components, emit]);
+
+  // Scan components when inspector is enabled or index changes
+  useEffect(() => {
+    if (isEnabled) {
+      scanComponents();
+    }
+  }, [isEnabled, scanComponents]);
+
+  // Update highlights when components or enabled state changes
+  useEffect(() => {
+    updateHighlights();
+  }, [updateHighlights]);
+
+  // Clean up highlights when component unmounts
+  useEffect(() => {
+    return () => {
+      emit(REMOVE_HIGHLIGHT, HIGHLIGHT_ID_WITH_STORIES);
+      emit(REMOVE_HIGHLIGHT, HIGHLIGHT_ID_WITHOUT_STORIES);
+    };
+  }, [emit]);
+
+  return {
+    isEnabled,
+    toggleInspector,
+    createStoryForComponent,
+    components: groupComponentsByStoryStatus(components),
+  };
+}

--- a/code/addons/story-inspector/src/index.ts
+++ b/code/addons/story-inspector/src/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/code/addons/story-inspector/src/manager.tsx
+++ b/code/addons/story-inspector/src/manager.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+
+import { addons, types } from 'storybook/manager-api';
+
+import { StoryInspectorTool } from './components/StoryInspectorTool';
+import { ADDON_ID, EVENTS, PARAM_KEY, TOOL_ID } from './constants';
+
+// Register the addon
+addons.register(ADDON_ID, (api) => {
+  // Add the toolbar tool
+  addons.add(TOOL_ID, {
+    title: 'Story Inspector',
+    type: types.TOOL,
+    match: ({ viewMode, tabId }) => !!(viewMode && viewMode.match(/^(story|docs)$/)) && !tabId,
+    render: () => <StoryInspectorTool />,
+    paramKey: PARAM_KEY,
+  });
+
+  // Handle navigation to stories
+  api.on('storybook/navigate-to-story', ({ storyId }: { storyId: string }) => {
+    api.selectStory(storyId);
+  });
+
+  // Handle create story requests
+  api.on(
+    EVENTS.CREATE_STORY_FOR_COMPONENT,
+    async ({ componentPath }: { componentPath: string }) => {
+      // Extract component information for the create story modal
+      const componentName =
+        componentPath
+          .split('/')
+          .pop()
+          ?.replace(/\.(tsx?|jsx?)$/, '') || 'Component';
+      const isDefaultExport = true; // Assume default export for now
+
+      try {
+        // Use the same logic as CreateNewStoryFileModal
+        const { experimental_requestResponse, addons: storybookAddons } = await import(
+          'storybook/manager-api'
+        );
+        const {
+          CREATE_NEW_STORYFILE_REQUEST,
+          CREATE_NEW_STORYFILE_RESPONSE,
+          ARGTYPES_INFO_REQUEST,
+          ARGTYPES_INFO_RESPONSE,
+          SAVE_STORY_REQUEST,
+          SAVE_STORY_RESPONSE,
+        } = await import('storybook/internal/core-events');
+
+        const channel = storybookAddons.getChannel();
+
+        // Create new story file
+        const createNewStoryResult = await experimental_requestResponse(
+          channel,
+          CREATE_NEW_STORYFILE_REQUEST,
+          CREATE_NEW_STORYFILE_RESPONSE,
+          {
+            componentExportName: componentName,
+            componentFilePath: componentPath,
+            componentIsDefaultExport: isDefaultExport,
+            componentExportCount: 1,
+          }
+        );
+
+        const storyId = createNewStoryResult.storyId;
+
+        // Try to select the new story
+        await new Promise((resolve) => {
+          const attemptSelect = (attempts = 0) => {
+            if (attempts > 10) {
+              resolve(undefined);
+              return;
+            }
+
+            try {
+              api.selectStory(storyId);
+              resolve(undefined);
+            } catch {
+              setTimeout(() => attemptSelect(attempts + 1), 100);
+            }
+          };
+          attemptSelect();
+        });
+
+        // Get argTypes and save with defaults
+        try {
+          const argTypesInfoResult = await experimental_requestResponse(
+            channel,
+            ARGTYPES_INFO_REQUEST,
+            ARGTYPES_INFO_RESPONSE,
+            { storyId }
+          );
+
+          const argTypes = argTypesInfoResult.argTypes;
+
+          // Extract required args with default values
+          const requiredArgs: Record<string, any> = {};
+          Object.entries(argTypes || {}).forEach(([key, argType]: [string, any]) => {
+            if (argType.type?.required || argType.control?.required) {
+              // Provide sensible defaults based on type
+              if (argType.type?.name === 'string') {
+                requiredArgs[key] = 'Sample text';
+              } else if (argType.type?.name === 'number') {
+                requiredArgs[key] = 42;
+              } else if (argType.type?.name === 'boolean') {
+                requiredArgs[key] = true;
+              } else {
+                requiredArgs[key] = null;
+              }
+            }
+          });
+
+          await experimental_requestResponse(channel, SAVE_STORY_REQUEST, SAVE_STORY_RESPONSE, {
+            args: JSON.stringify(requiredArgs, (_, value) => {
+              if (typeof value === 'function') {
+                return '__sb_empty_function_arg__';
+              }
+              return value;
+            }),
+            importPath: createNewStoryResult.storyFilePath,
+            csfId: storyId,
+          });
+        } catch (e) {
+          // Ignore argTypes errors
+        }
+
+        // Show success notification
+        api.addNotification({
+          id: 'story-inspector-create-success',
+          content: {
+            headline: 'Story created successfully',
+            subHeadline: `Created story for ${componentName}`,
+          },
+          duration: 5000,
+          icon: <span>✅</span>,
+        });
+      } catch (error: any) {
+        // Handle errors
+        let errorMessage = 'Failed to create story';
+
+        if (error?.payload?.type === 'STORY_FILE_EXISTS') {
+          errorMessage = 'Story already exists';
+          // Try to navigate to existing story
+          try {
+            // @ts-expect-error (non strict)
+            await api.selectStory(error.payload.kind);
+          } catch {}
+        }
+
+        api.addNotification({
+          id: 'story-inspector-create-error',
+          content: {
+            headline: errorMessage,
+            subHeadline: error.message || `Error creating story for ${componentName}`,
+          },
+          duration: 8000,
+          icon: <span>❌</span>,
+        });
+      }
+    }
+  );
+});

--- a/code/addons/story-inspector/src/preset.ts
+++ b/code/addons/story-inspector/src/preset.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from 'storybook/internal/types';
+
+import { componentPathInjectorPlugin } from './utils/vite-plugin';
+
+export const viteFinal = async (config: any, options: any): Promise<any> => {
+  const plugins = config.plugins || [];
+
+  // Add our component path injector plugin
+  plugins.push(componentPathInjectorPlugin(options));
+
+  return {
+    ...config,
+    plugins,
+  };
+};

--- a/code/addons/story-inspector/src/preview.ts
+++ b/code/addons/story-inspector/src/preview.ts
@@ -1,0 +1,26 @@
+import type { Decorator, StoryContext } from 'storybook/preview-api';
+
+import { PARAM_KEY } from './constants';
+
+/** Global decorator that helps with story inspector functionality */
+export const decorators: Decorator[] = [
+  (storyFn, context) => {
+    // The decorator doesn't need to do much - the main work is done by:
+    // 1. The Vite plugin (injecting component paths)
+    // 2. The manager-side highlighting logic
+
+    // We could add functionality here if needed, such as:
+    // - Scanning for components after story render
+    // - Adding event listeners for inspector interactions
+
+    return storyFn();
+  },
+];
+
+/** Global parameters for the story inspector */
+export const parameters = {
+  [PARAM_KEY]: {
+    // Default to disabled - users can enable via toolbar
+    enabled: false,
+  },
+};

--- a/code/addons/story-inspector/src/utils/__tests__/story-matcher.test.ts
+++ b/code/addons/story-inspector/src/utils/__tests__/story-matcher.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type ComponentInfo,
+  checkComponentsAgainstIndex,
+  generateSelectorsForComponents,
+  groupComponentsByStoryStatus,
+} from '../story-matcher';
+
+// Mock DOM
+global.document = {
+  querySelectorAll: vi.fn(),
+} as any;
+
+describe('story-matcher', () => {
+  describe('checkComponentsAgainstIndex', () => {
+    it('should match components against story index', () => {
+      const components: ComponentInfo[] = [
+        {
+          element: {} as Element,
+          componentPath: '/src/components/Button.tsx',
+          hasStory: false,
+        },
+        {
+          element: {} as Element,
+          componentPath: '/src/components/Input.tsx',
+          hasStory: false,
+        },
+      ];
+
+      const storyIndex = {
+        entries: {
+          'button--default': {
+            id: 'button--default',
+            title: 'Button',
+            name: 'Default',
+            rawComponentPath: '/src/components/Button.tsx',
+          },
+        },
+      };
+
+      const result = checkComponentsAgainstIndex(components, storyIndex as any);
+
+      expect(result[0].hasStory).toBe(true);
+      expect(result[0].storyId).toBe('button--default');
+      expect(result[1].hasStory).toBe(false);
+    });
+
+    it('should normalize paths for comparison', () => {
+      const components: ComponentInfo[] = [
+        {
+          element: {} as Element,
+          componentPath: '/src\\components\\Button.tsx', // Windows path
+          hasStory: false,
+        },
+      ];
+
+      const storyIndex = {
+        entries: {
+          'button--default': {
+            id: 'button--default',
+            title: 'Button',
+            name: 'Default',
+            rawComponentPath: '/src/components/Button.tsx', // Unix path
+          },
+        },
+      };
+
+      const result = checkComponentsAgainstIndex(components, storyIndex as any);
+
+      expect(result[0].hasStory).toBe(true);
+    });
+  });
+
+  describe('groupComponentsByStoryStatus', () => {
+    it('should group components by story status', () => {
+      const components: ComponentInfo[] = [
+        {
+          element: {} as Element,
+          componentPath: '/src/components/Button.tsx',
+          hasStory: true,
+          storyId: 'button--default',
+        },
+        {
+          element: {} as Element,
+          componentPath: '/src/components/Input.tsx',
+          hasStory: false,
+        },
+      ];
+
+      const result = groupComponentsByStoryStatus(components);
+
+      expect(result.withStories).toHaveLength(1);
+      expect(result.withoutStories).toHaveLength(1);
+      expect(result.withStories[0].componentPath).toBe('/src/components/Button.tsx');
+      expect(result.withoutStories[0].componentPath).toBe('/src/components/Input.tsx');
+    });
+  });
+
+  describe('generateSelectorsForComponents', () => {
+    it('should generate CSS selectors for components', () => {
+      const components: ComponentInfo[] = [
+        {
+          element: {
+            tagName: 'BUTTON',
+            getAttribute: () => '/src/components/Button.tsx',
+          } as any,
+          componentPath: '/src/components/Button.tsx',
+          hasStory: false,
+        },
+      ];
+
+      const result = generateSelectorsForComponents(components);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe('button[data-sb-component-path="/src/components/Button.tsx"]');
+    });
+  });
+});

--- a/code/addons/story-inspector/src/utils/__tests__/vite-plugin.test.ts
+++ b/code/addons/story-inspector/src/utils/__tests__/vite-plugin.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { componentPathInjectorPlugin } from '../vite-plugin';
+
+describe('componentPathInjectorPlugin', () => {
+  it('should create a plugin with correct name', () => {
+    const plugin = componentPathInjectorPlugin();
+
+    expect(plugin.name).toBe('storybook:story-inspector-component-path-injector');
+    expect(plugin.enforce).toBe('pre');
+  });
+
+  it('should inject component path into JSX elements', async () => {
+    const plugin = componentPathInjectorPlugin();
+    const code = `
+import React from 'react';
+
+const Button = () => <button>Click me</button>;
+
+export const MyStory = () => (
+  <div>
+    <Button />
+    <span>Hello</span>
+  </div>
+);
+`;
+
+    const result = await plugin.transform(code, '/src/components/Button.tsx');
+
+    expect(result?.code).toContain('data-sb-component-path="/src/components/Button.tsx"');
+    expect(result?.code).toContain('<Button data-sb-component-path="/src/components/Button.tsx"');
+    // Should not affect lowercase HTML elements
+    expect(result?.code).not.toContain('<span data-sb-component-path');
+    expect(result?.code).not.toContain('<div data-sb-component-path');
+  });
+
+  it('should not process non-component files', async () => {
+    const plugin = componentPathInjectorPlugin();
+    const code = 'const config = { test: true };';
+
+    const result = await plugin.transform(code, '/src/config.js');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should not process story files', async () => {
+    const plugin = componentPathInjectorPlugin();
+    const code = `
+export const MyStory = () => <Button />;
+`;
+
+    const result = await plugin.transform(code, '/src/Button.stories.tsx');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should not process test files', async () => {
+    const plugin = componentPathInjectorPlugin();
+    const code = `
+test('should work', () => {
+  expect(<Button />).toBeDefined();
+});
+`;
+
+    const result = await plugin.transform(code, '/src/Button.test.tsx');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should handle self-closing JSX elements', async () => {
+    const plugin = componentPathInjectorPlugin();
+    const code = `
+export const MyStory = () => (
+  <div>
+    <Button onClick={() => {}} />
+    <Icon name="star" />
+  </div>
+);
+`;
+
+    const result = await plugin.transform(code, '/src/components/Story.tsx');
+
+    expect(result?.code).toContain(
+      '<Button data-sb-component-path="/src/components/Story.tsx" onClick={() => {}} />'
+    );
+    expect(result?.code).toContain(
+      '<Icon data-sb-component-path="/src/components/Story.tsx" name="star" />'
+    );
+  });
+
+  it('should not double-inject attributes', async () => {
+    const plugin = componentPathInjectorPlugin();
+    const code = `
+export const MyStory = () => (
+  <Button data-sb-component-path="/already/set" />
+);
+`;
+
+    const result = await plugin.transform(code, '/src/components/Story.tsx');
+
+    // Should not modify already processed elements
+    expect(result?.code || code).toContain('data-sb-component-path="/already/set"');
+    expect(result?.code || code).not.toContain(
+      'data-sb-component-path="/src/components/Story.tsx"'
+    );
+  });
+});

--- a/code/addons/story-inspector/src/utils/story-matcher.ts
+++ b/code/addons/story-inspector/src/utils/story-matcher.ts
@@ -1,0 +1,77 @@
+import type { IndexEntry, StoryIndex } from 'storybook/internal/types';
+
+import { COMPONENT_PATH_ATTRIBUTE } from '../constants';
+
+export interface ComponentInfo {
+  element: Element;
+  componentPath: string;
+  hasStory: boolean;
+  storyEntry?: IndexEntry;
+  storyId?: string;
+}
+
+/** Find all components in the DOM that have component path metadata */
+export function findComponentsInDOM(): ComponentInfo[] {
+  const elements = document.querySelectorAll(`[${COMPONENT_PATH_ATTRIBUTE}]`);
+  const components: ComponentInfo[] = [];
+
+  elements.forEach((element) => {
+    const componentPath = element.getAttribute(COMPONENT_PATH_ATTRIBUTE);
+    if (componentPath) {
+      components.push({
+        element,
+        componentPath,
+        hasStory: false, // Will be determined by checkComponentsAgainstIndex
+      });
+    }
+  });
+
+  return components;
+}
+
+/** Check components against the story index to determine which have stories */
+export function checkComponentsAgainstIndex(
+  components: ComponentInfo[],
+  storyIndex: StoryIndex
+): ComponentInfo[] {
+  const entries = storyIndex.entries || {};
+
+  return components.map((component) => {
+    // Find matching story entries by comparing rawComponentPath
+    const matchingEntry = Object.values(entries).find((entry) => {
+      // Normalize paths for comparison
+      const entryPath = entry.rawComponentPath?.replace(/\\/g, '/');
+      const componentPath = component.componentPath.replace(/\\/g, '/');
+      return entryPath === componentPath;
+    });
+
+    if (matchingEntry) {
+      return {
+        ...component,
+        hasStory: true,
+        storyEntry: matchingEntry,
+        storyId: matchingEntry.id,
+      };
+    }
+
+    return component;
+  });
+}
+
+/** Group components by their story status */
+export function groupComponentsByStoryStatus(components: ComponentInfo[]) {
+  const withStories = components.filter((c) => c.hasStory);
+  const withoutStories = components.filter((c) => !c.hasStory);
+
+  return { withStories, withoutStories };
+}
+
+/** Generate CSS selectors for highlighting components */
+export function generateSelectorsForComponents(components: ComponentInfo[]): string[] {
+  return components.map((component) => {
+    // Generate a unique selector for the element
+    const tagName = component.element.tagName.toLowerCase();
+    const componentPath = component.componentPath;
+    return `${tagName}[${COMPONENT_PATH_ATTRIBUTE}="${componentPath}"]`;
+  });
+}

--- a/code/addons/story-inspector/src/utils/vite-plugin.ts
+++ b/code/addons/story-inspector/src/utils/vite-plugin.ts
@@ -1,0 +1,111 @@
+import MagicString from 'magic-string';
+
+import { COMPONENT_PATH_ATTRIBUTE } from '../constants';
+
+/**
+ * This Vite plugin injects component file path metadata into JSX/TSX elements so they can be
+ * identified by the story inspector
+ */
+export function componentPathInjectorPlugin(options?: any): any {
+  // Simple filter function instead of using vite's createFilter
+  const filter = (id: string) => {
+    // Include React/Vue/Svelte component files
+    const includeExtensions = ['.jsx', '.tsx', '.js', '.ts', '.vue', '.svelte'];
+    const hasIncludedExt = includeExtensions.some((ext) => id.endsWith(ext));
+
+    // Exclude certain patterns
+    const excludePatterns = ['node_modules', '.stories.', '.spec.', '.test.'];
+    const isExcluded = excludePatterns.some((pattern) => id.includes(pattern));
+
+    return hasIncludedExt && !isExcluded;
+  };
+
+  return {
+    name: 'storybook:story-inspector-component-path-injector',
+    enforce: 'pre', // Run before other transforms
+
+    async transform(code: string, id: string) {
+      if (!filter(id)) {
+        return undefined;
+      }
+
+      // Skip if this doesn't look like a component file
+      if (!isComponentFile(code)) {
+        return undefined;
+      }
+
+      const s = new MagicString(code);
+
+      // Find JSX elements and add the component path attribute
+      const transformedCode = injectComponentPath(s, code, id);
+
+      if (transformedCode === code) {
+        return undefined; // No changes made
+      }
+
+      return {
+        code: s.toString(),
+        map: s.generateMap({ hires: true, source: id }),
+      };
+    },
+  };
+}
+
+/** Check if the file likely contains React components */
+function isComponentFile(code: string): boolean {
+  // Look for JSX elements or React imports
+  return (
+    code.includes('jsx') ||
+    code.includes('React') ||
+    code.includes('</') ||
+    /export\s+(default\s+)?function\s+[A-Z]/.test(code) ||
+    /export\s+(default\s+)?const\s+[A-Z]/.test(code) ||
+    /export\s+{\s*[A-Z]/.test(code)
+  );
+}
+
+/** Inject component path attribute into JSX elements */
+function injectComponentPath(s: MagicString, code: string, filePath: string): string {
+  // This is a simplified approach - in a real implementation we'd use a proper AST parser
+  // For now, we'll use regex to find JSX opening tags and add our attribute
+
+  // Normalize file path
+  const normalizedPath = filePath.replace(/\\/g, '/');
+
+  // Find JSX opening tags that don't already have our attribute
+  const jsxElementRegex = /<([A-Z][a-zA-Z0-9]*(?:\.[A-Z][a-zA-Z0-9]*)*)\s*([^>]*?)(\s*\/?>)/g;
+
+  let match;
+  const replacements: Array<{ start: number; end: number; replacement: string }> = [];
+
+  while ((match = jsxElementRegex.exec(code)) !== null) {
+    const [fullMatch, componentName, attributes, closing] = match;
+    const { index } = match;
+
+    // Skip if already has our attribute
+    if (attributes.includes(COMPONENT_PATH_ATTRIBUTE)) {
+      continue;
+    }
+
+    // Skip HTML elements (lowercase first letter)
+    if (componentName[0].toLowerCase() === componentName[0]) {
+      continue;
+    }
+
+    // Build replacement
+    const trimmedAttributes = attributes.trim();
+    const attributesToAdd = trimmedAttributes
+      ? ` ${trimmedAttributes} ${COMPONENT_PATH_ATTRIBUTE}="${normalizedPath}"`
+      : ` ${COMPONENT_PATH_ATTRIBUTE}="${normalizedPath}"`;
+
+    const replacement = `<${componentName}${attributesToAdd}${closing}`;
+    replacements.push({ start: index, end: index + fullMatch.length, replacement });
+  }
+
+  // Apply replacements in reverse order to maintain indices
+  replacements.reverse().forEach(({ start, end, replacement }) => {
+    s.overwrite(start, end, replacement);
+  });
+
+  return s.toString();
+}

--- a/code/addons/story-inspector/tsconfig.json
+++ b/code/addons/story-inspector/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strict": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.*", "src/**/test.*", "src/**/*.stories.*"]
+}

--- a/code/addons/story-inspector/vitest.config.ts
+++ b/code/addons/story-inspector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/scripts/build/entry-configs.ts
+++ b/scripts/build/entry-configs.ts
@@ -11,6 +11,8 @@ import onboardingConfig from '../../../code/addons/onboarding/build-config';
 // @ts-ignore
 import pseudoStatesConfig from '../../../code/addons/pseudo-states/build-config';
 // @ts-ignore
+import storyInspectorConfig from '../../../code/addons/story-inspector/build-config';
+// @ts-ignore
 import themesConfig from '../../../code/addons/themes/build-config';
 // @ts-ignore
 import vitestConfig from '../../../code/addons/vitest/build-config';
@@ -93,6 +95,7 @@ export const buildEntries = {
   '@storybook/addon-links': linksConfig,
   '@storybook/addon-onboarding': onboardingConfig,
   'storybook-addon-pseudo-states': pseudoStatesConfig,
+  '@storybook/addon-story-inspector': storyInspectorConfig,
   '@storybook/addon-themes': themesConfig,
   '@storybook/addon-vitest': vitestConfig,
   '@storybook/addon-jest': jestConfig,


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces a new internal addon, `@storybook/addon-story-inspector`, designed to enhance the developer experience by visualizing story coverage for components.

Key features include:

*   **Vite Plugin**: Injects `data-sb-component-path` attributes into JSX/TSX elements at build time, linking rendered components to their source files.
*   **Toolbar Integration**: A new "eye" icon in the toolbar allows toggling the inspector on/off. It displays a badge with the count of detected components.
*   **Component Highlighting**:
    *   **Green**: Components with existing stories are highlighted. Clicking them allows direct navigation to their corresponding story.
    *   **Orange**: Components without stories are highlighted. Clicking them provides an option to automatically create a new story file, pre-filled with sensible defaults, and then navigates to the new story.
*   **Story Matching**: Components are matched against the Storybook index using their file paths, handling path normalization for cross-platform compatibility.
*   **Story Creation**: Integrates with Storybook's internal story creation logic, similar to `CreateNewStoryFileModal`, to generate new story files.

This addon is currently focused on Vite-based Storybook setups.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

1.  Run a sandbox for a Vite-based template, e.g., `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2.  Add `@storybook/addon-story-inspector` to your `.storybook/main.ts` file:
    ```typescript
    // .storybook/main.ts
    module.exports = {
      addons: ['@storybook/addon-story-inspector'],
    };
    ```
3.  Open Storybook in your browser.
4.  Navigate to a story that renders various components (some with stories, some without).
5.  Click the new "eye" icon (👁️) in the Storybook toolbar to enable the inspector.
6.  Observe components being highlighted:
    *   **Green outlines**: Indicate components that have existing stories.
    *   **Orange outlines**: Indicate components that do not yet have stories.
7.  Click on a **green-highlighted** component. A context menu should appear with "Go to story". Click it and verify that Storybook navigates to the component's story.
8.  Click on an **orange-highlighted** component. A context menu should appear with "Create story". Click it and verify:
    *   A new story file is created for the component.
    *   Storybook navigates to the newly created story.
    *   A success notification appears.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

---
<a href="https://cursor.com/background-agent?bcId=bc-c6fe9ad4-eb98-4ec7-856c-3113d7be5938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6fe9ad4-eb98-4ec7-856c-3113d7be5938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

