### PR TITLE
Revert "Cleanup: Remove duplicated entrypoints in core"

### DIFF
--- a/code/addons/docs/src/blocks/components/TableOfContents.stories.tsx
+++ b/code/addons/docs/src/blocks/components/TableOfContents.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import { styled } from 'storybook/internal/theming';
+
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { expect, within } from 'storybook/test';
-import { styled } from 'storybook/theming';
 
 import { Heading } from '../blocks/Heading';
 import { TableOfContents } from './TableOfContents';

--- a/code/addons/pseudo-states/src/manager/PseudoStateTool.tsx
+++ b/code/addons/pseudo-states/src/manager/PseudoStateTool.tsx
@@ -1,11 +1,11 @@
 import React, { type ComponentProps, useCallback } from 'react';
 
 import { Form, IconButton, TooltipLinkList, WithTooltip } from 'storybook/internal/components';
+import { color, styled } from 'storybook/internal/theming';
 
 import { ButtonIcon, RefreshIcon } from '@storybook/icons';
 
 import { useGlobals } from 'storybook/manager-api';
-import { color, styled } from 'storybook/theming';
 
 import { PARAM_KEY, PSEUDO_STATES } from '../constants';
 

--- a/code/addons/pseudo-states/src/stories/CSSAtRules.stories.tsx
+++ b/code/addons/pseudo-states/src/stories/CSSAtRules.stories.tsx
@@ -1,10 +1,9 @@
 import React, { type ComponentProps } from 'react';
 
 import { FORCE_REMOUNT } from 'storybook/internal/core-events';
+import { useChannel, useStoryContext } from 'storybook/internal/preview-api';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
-
-import { useChannel, useStoryContext } from 'storybook/preview-api';
 
 import { Button } from './CSSAtRules';
 import './grid.css';

--- a/code/addons/vitest/src/components/SidebarContextMenu.tsx
+++ b/code/addons/vitest/src/components/SidebarContextMenu.tsx
@@ -1,9 +1,8 @@
 import type { FC } from 'react';
 import React from 'react';
 
+import { type API } from 'storybook/internal/manager-api';
 import type { API_HashEntry } from 'storybook/internal/types';
-
-import { type API } from 'storybook/manager-api';
 
 import { useTestProvider } from '../use-test-provider-state';
 import { TestProviderRender } from './TestProviderRender';

--- a/code/builders/builder-vite/src/constants.ts
+++ b/code/builders/builder-vite/src/constants.ts
@@ -105,6 +105,7 @@ export const INCLUDE_CANDIDATES = [
   'storybook/actions/decorator',
   'storybook/internal/core-events',
   'storybook/internal/csf',
+  'storybook/internal/preview-api',
   'storybook/internal/preview/runtime',
   'storybook/preview-api',
   'storybook/viewport',

--- a/code/core/build-config.ts
+++ b/code/core/build-config.ts
@@ -97,7 +97,7 @@ const config: BuildEntries = {
         entryPoint: './src/instrumenter/index.ts',
       },
       {
-        exportEntries: ['./test'],
+        exportEntries: ['./test', './internal/test'],
         entryPoint: './src/test/index.ts',
       },
       {
@@ -105,19 +105,19 @@ const config: BuildEntries = {
         entryPoint: './src/preview-api/index.ts',
       },
       {
-        exportEntries: ['./highlight'],
+        exportEntries: ['./highlight', './internal/highlight'],
         entryPoint: './src/highlight/index.ts',
       },
       {
-        exportEntries: ['./actions'],
+        exportEntries: ['./actions', './internal/actions'],
         entryPoint: './src/actions/index.ts',
       },
       {
-        exportEntries: ['./actions/decorator'],
+        exportEntries: ['./actions/decorator', './internal/actions/decorator'],
         entryPoint: './src/actions/decorator.ts',
       },
       {
-        exportEntries: ['./viewport'],
+        exportEntries: ['./viewport', './internal/viewport'],
         entryPoint: './src/viewport/index.ts',
       },
       {
@@ -145,11 +145,11 @@ const config: BuildEntries = {
         dts: false,
       },
       {
-        exportEntries: ['./theming'],
+        exportEntries: ['./theming', './internal/theming'],
         entryPoint: './src/theming/index.ts',
       },
       {
-        exportEntries: ['./theming/create'],
+        exportEntries: ['./theming/create', './internal/theming/create'],
         entryPoint: './src/theming/create.ts',
       },
       {
@@ -157,7 +157,7 @@ const config: BuildEntries = {
         entryPoint: './src/components/index.ts',
       },
       {
-        exportEntries: ['./manager-api'],
+        exportEntries: ['./manager-api', './internal/manager-api'],
         entryPoint: './src/manager-api/index.ts',
       },
       {

--- a/code/core/package.json
+++ b/code/core/package.json
@@ -58,6 +58,14 @@
       "types": "./dist/highlight/index.d.ts",
       "default": "./dist/highlight/index.js"
     },
+    "./internal/actions": {
+      "types": "./dist/actions/index.d.ts",
+      "default": "./dist/actions/index.js"
+    },
+    "./internal/actions/decorator": {
+      "types": "./dist/actions/decorator.d.ts",
+      "default": "./dist/actions/decorator.js"
+    },
     "./internal/babel": {
       "types": "./dist/babel/index.d.ts",
       "default": "./dist/babel/index.js"
@@ -105,9 +113,17 @@
       "types": "./dist/docs-tools/index.d.ts",
       "default": "./dist/docs-tools/index.js"
     },
+    "./internal/highlight": {
+      "types": "./dist/highlight/index.d.ts",
+      "default": "./dist/highlight/index.js"
+    },
     "./internal/instrumenter": {
       "types": "./dist/instrumenter/index.d.ts",
       "default": "./dist/instrumenter/index.js"
+    },
+    "./internal/manager-api": {
+      "types": "./dist/manager-api/index.d.ts",
+      "default": "./dist/manager-api/index.js"
     },
     "./internal/manager-errors": {
       "types": "./dist/manager-errors.d.ts",
@@ -147,9 +163,25 @@
       "types": "./dist/telemetry/index.d.ts",
       "default": "./dist/telemetry/index.js"
     },
+    "./internal/test": {
+      "types": "./dist/test/index.d.ts",
+      "default": "./dist/test/index.js"
+    },
+    "./internal/theming": {
+      "types": "./dist/theming/index.d.ts",
+      "default": "./dist/theming/index.js"
+    },
+    "./internal/theming/create": {
+      "types": "./dist/theming/create.d.ts",
+      "default": "./dist/theming/create.js"
+    },
     "./internal/types": {
       "types": "./dist/types/index.d.ts",
       "default": "./dist/types/index.js"
+    },
+    "./internal/viewport": {
+      "types": "./dist/viewport/index.d.ts",
+      "default": "./dist/viewport/index.js"
     },
     "./manager-api": {
       "types": "./dist/manager-api/index.d.ts",

--- a/code/core/src/components/components/Button/Button.stories.tsx
+++ b/code/core/src/components/components/Button/Button.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { FaceHappyIcon } from '@storybook/icons';
+import { styled } from 'storybook/internal/theming';
 
-import { styled } from 'storybook/theming';
+import { FaceHappyIcon } from '@storybook/icons';
 
 import preview from '../../../../../.storybook/preview';
 import { Button } from './Button';

--- a/code/core/src/components/components/Form/Checkbox.tsx
+++ b/code/core/src/components/components/Form/Checkbox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { color, styled } from 'storybook/theming';
+import { color, styled } from 'storybook/internal/theming';
 
 const Input = styled.input({
   appearance: 'none',

--- a/code/core/src/components/components/Form/Radio.tsx
+++ b/code/core/src/components/components/Form/Radio.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { color, styled } from 'storybook/theming';
+import { color, styled } from 'storybook/internal/theming';
 
 const Input = styled.input({
   appearance: 'none',

--- a/code/core/src/highlight/useHighlights.stories.tsx
+++ b/code/core/src/highlight/useHighlights.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { useChannel } from 'storybook/preview-api';
+import { useChannel } from 'storybook/internal/preview-api';
+
 import { fn, userEvent, within } from 'storybook/test';
 
 import preview from '../../../.storybook/preview';

--- a/code/core/src/manager/components/layout/Layout.stories.tsx
+++ b/code/core/src/manager/components/layout/Layout.stories.tsx
@@ -1,12 +1,12 @@
 import type { FC, PropsWithChildren } from 'react';
 import React, { useState } from 'react';
 
+import { ManagerContext } from 'storybook/internal/manager-api';
 import { LocationProvider } from 'storybook/internal/router';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { action } from 'storybook/actions';
-import { ManagerContext } from 'storybook/manager-api';
 import { fn } from 'storybook/test';
 import { styled } from 'storybook/theming';
 
@@ -63,15 +63,6 @@ const managerContext: any = {
   state: {},
   api: {
     foo: 'bar',
-    getCurrentStoryData: fn()
-      .mockName('api::getCurrentStoryData')
-      .mockImplementation(() => ({
-        id: '123',
-        name: 'Test Story',
-        renderLabel: fn()
-          .mockName('api::getCurrentStoryData::renderLabel')
-          .mockImplementation(() => 'Test Story'),
-      })),
     getNavSizeWithCustomisations: fn()
       .mockName('api::getNavSizeWithCustomisations')
       .mockImplementation((size: number) => size),

--- a/code/core/src/manager/globals/globals-module-info.ts
+++ b/code/core/src/manager/globals/globals-module-info.ts
@@ -22,16 +22,6 @@ import { globalPackages, globalsNameReferenceMap } from './globals';
  * The `runtime.ts` file is used inside the manager's browser code runtime.
  */
 
-const duplicatedKeys = [
-  'storybook/theming',
-  'storybook/theming/create',
-  'storybook/manager-api',
-  'storybook/test',
-  'storybook/actions',
-  'storybook/highlight',
-  'storybook/viewport',
-];
-
 export const globalsModuleInfoMap = globalPackages.reduce(
   (acc, key) => {
     acc[key] = {
@@ -40,15 +30,6 @@ export const globalsModuleInfoMap = globalPackages.reduce(
       namedExports: Exports[key],
       defaultExport: true,
     };
-
-    if (duplicatedKeys.includes(key)) {
-      acc[key.replace('storybook', 'storybook/internal') as typeof key] = {
-        type: 'esm',
-        varName: globalsNameReferenceMap[key],
-        namedExports: Exports[key],
-        defaultExport: true,
-      };
-    }
     return acc;
   },
   {} as Required<Record<keyof typeof globalsNameReferenceMap, Required<ModuleInfo>>>

--- a/code/core/src/preview/globals/globals.ts
+++ b/code/core/src/preview/globals/globals.ts
@@ -13,7 +13,7 @@ export const globalsNameReferenceMap = {
   'storybook/internal/preview-errors': '__STORYBOOK_MODULE_CORE_EVENTS_PREVIEW_ERRORS__',
   'storybook/internal/types': '__STORYBOOK_MODULE_TYPES__',
 
-  // @deprecated TODO: Remove in 9.1 or some point in the future, I guess
+  // @deprecated TODO: Remove in 9.1
   'storybook/internal/preview-api': '__STORYBOOK_MODULE_PREVIEW_API__',
 } as const;
 

--- a/code/core/src/preview/globals/runtime.ts
+++ b/code/core/src/preview/globals/runtime.ts
@@ -25,5 +25,6 @@ export const globalsNameValueMap: Required<Record<keyof typeof globalsNameRefere
   'storybook/internal/core-events': CORE_EVENTS,
   'storybook/internal/types': TYPES,
   'storybook/internal/preview-errors': CORE_EVENTS_PREVIEW_ERRORS,
+
   'storybook/internal/preview-api': PREVIEW_API,
 };

--- a/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
+++ b/code/lib/cli-storybook/src/automigrate/fixes/consolidated-imports.ts
@@ -147,18 +147,7 @@ export const consolidatedImports: Fix<ConsolidatedOptions> = {
 
     const importErrors = await transformImportFiles(
       [...storiesPaths, ...configFiles].filter(Boolean) as string[],
-      {
-        ...consolidatedPackages,
-        'storybook/internal/manager-api': 'storybook/manager-api',
-        'storybook/internal/preview-api': 'storybook/preview-api',
-        'storybook/internal/theming': 'storybook/theming',
-        'storybook/internal/theming/create': 'storybook/theming/create',
-        'storybook/internal/test': 'storybook/test',
-        'storybook/internal/actions': 'storybook/internal/actions',
-        'storybook/internal/actions/decorator': 'storybook/internal/actions/decorator',
-        'storybook/internal/highlight': 'storybook/internal/highlight',
-        'storybook/internal/viewport': 'storybook/internal/viewport',
-      },
+      consolidatedPackages,
       !!dryRun
     );
 

--- a/code/renderers/react/template/stories/decorators.stories.tsx
+++ b/code/renderers/react/template/stories/decorators.stories.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react';
 import React, { createContext, useContext, useState } from 'react';
 
-import type { Meta, StoryObj } from '@storybook/react';
+import { useParameter } from 'storybook/internal/preview-api';
 
-import { useParameter } from 'storybook/preview-api';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const Component: FC = () => <p>Story</p>;
 


### PR DESCRIPTION
Reverts storybookjs/storybook#32507

Seems there may have been some unintentional UI changes due to this, checking if reverting this PR fixes it, if not something else was the cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized use of internal APIs across stories and components for consistency.
  - Simplified globals handling and reduced duplication.
  - Minor cleanup in example stories, including removal of obsolete mocked data.
- Chores
  - Expanded internal export surface to improve package ergonomics.
  - Updated build and bundling configuration to recognize additional internal entries.
  - Streamlined migration tooling to rely on consolidated import mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->