### PR TITLE
Controls: fix option label display when name matches Array built-in method

### DIFF
--- a/code/addons/docs/src/blocks/controls/options/Options.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Options.tsx
@@ -26,7 +26,7 @@ const normalizeOptions = (options: Options, labels?: Record<any, string>) => {
       // methods) as object keys. This can happen when an option's name matches a built-in array
       // method (e.g. 'reverse') and `labels` is inadvertently an array instead of a Record.
       // See: https://github.com/storybookjs/storybook/issues/30142
-      acc[typeof label === 'string' ? label : String(item)] = item;
+      acc[typeof label === 'string' && label !== '' ? label : String(item)] = item;
       return acc;
     }, {});
   }

--- a/code/addons/docs/src/blocks/controls/options/Options.tsx
+++ b/code/addons/docs/src/blocks/controls/options/Options.tsx
@@ -21,7 +21,12 @@ import { SelectControl } from './Select';
 const normalizeOptions = (options: Options, labels?: Record<any, string>) => {
   if (Array.isArray(options)) {
     return options.reduce((acc, item) => {
-      acc[labels?.[item] || String(item)] = item;
+      const label = labels?.[item];
+      // Ensure the label is a string to avoid using non-string values (e.g., Array prototype
+      // methods) as object keys. This can happen when an option's name matches a built-in array
+      // method (e.g. 'reverse') and `labels` is inadvertently an array instead of a Record.
+      // See: https://github.com/storybookjs/storybook/issues/30142
+      acc[typeof label === 'string' ? label : String(item)] = item;
       return acc;
     }, {});
   }

--- a/code/addons/docs/src/blocks/controls/options/RadioOptions.stories.tsx
+++ b/code/addons/docs/src/blocks/controls/options/RadioOptions.stories.tsx
@@ -127,3 +127,16 @@ export const ArrayWithBuiltinNames: Story = {
     argType: { options: optionsWithArrayMethodNames },
   },
 };
+
+// Reproduces the exact bug from issue #30142: when `labels` is inadvertently an array
+// (instead of a Record), `labels?.['reverse']` resolves to `Array.prototype.reverse` — a
+// truthy native function — causing the label to render as "function reverse() { [native code] }".
+export const ArrayWithBuiltinNamesAndArrayLabels: Story = {
+  name: 'Array with built-in names and labels accidentally passed as array (bug #30142)',
+  args: {
+    value: optionsWithArrayMethodNames[0],
+    argType: { options: optionsWithArrayMethodNames },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    labels: optionsWithArrayMethodNames as any,
+  },
+};

--- a/code/addons/docs/src/blocks/controls/options/RadioOptions.stories.tsx
+++ b/code/addons/docs/src/blocks/controls/options/RadioOptions.stories.tsx
@@ -115,3 +115,15 @@ export const ArrayReadonly: Story = {
     },
   },
 };
+
+// Regression test for https://github.com/storybookjs/storybook/issues/30142
+// Options whose names match Array prototype methods (e.g. 'reverse') must be
+// displayed as plain text, not as the stringified native function.
+const optionsWithArrayMethodNames = ['normal', 'reverse', 'filter', 'map'];
+export const ArrayWithBuiltinNames: Story = {
+  name: 'Array with option names matching built-in Array methods',
+  args: {
+    value: optionsWithArrayMethodNames[0],
+    argType: { options: optionsWithArrayMethodNames },
+  },
+};


### PR DESCRIPTION
## What changed

Fixes #30142

## Problem

When a story's control options array contains a string that matches an Array prototype method name (e.g. `'reverse'`, `'filter'`, `'map'`), the option can be displayed as `function reverse() { [native code] }` instead of the correct option text.

### Root cause

The `normalizeOptions` function converts an array of options to a label→value mapping:

```js
const normalizeOptions = (options, labels) => {
  if (Array.isArray(options)) {
    return options.reduce((acc, item) => {
      acc[labels?.[item] || String(item)] = item; // ← bug here
      return acc;
    }, {});
  }
  return options;
};
```

When `labels` is inadvertently an array (rather than a `Record<any, string>`) — for instance, when an integration (like an older version of `@storybook/addon-svelte-csf`) passes the options array as `labels` — then:

```js
labels?.['reverse']  // → Array.prototype.reverse (a native function, which is truthy!)
```

Because the function is truthy, it bypasses the `|| String(item)` fallback and gets used as the object key. When a function is used as an object key it is coerced to its string representation:

```
acc[Array.prototype.reverse] = 'reverse'
// key becomes: 'function reverse() { [native code] }'
```

`Object.keys(options)` then returns that stringified function, which is rendered as the option label in the UI.

## Fix

Added a `typeof` check to ensure only **string** label values are used as keys, falling back to `String(item)` for any non-string values:

```js
const label = labels?.[item];
acc[typeof label === 'string' ? label : String(item)] = item;
```

## Added

- Regression story `ArrayWithBuiltinNames` in `RadioOptions.stories.tsx` to document and visually verify the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of option labels so non-string or empty label values no longer become object keys, preventing incorrect rendering or runtime issues.

* **Tests**
  * Added two regression stories covering options whose names overlap built-in array method names and cases where labels are provided as arrays, ensuring these scenarios render as plain text and do not produce unexpected function output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->