### PR TITLE
Docs: add paddingLeft to OcticonHeaders so anchor icon is not clipped in light theme

### DIFF
--- a/code/addons/docs/src/blocks/blocks/mdx.tsx
+++ b/code/addons/docs/src/blocks/blocks/mdx.tsx
@@ -144,6 +144,9 @@ const OcticonHeaders = SUPPORTED_MDX_HEADERS.reduce(
   (acc, headerType) => ({
     ...acc,
     [headerType]: styled(headerType)({
+      // Reserve space for the floating anchor icon (which has marginLeft: '-24px')
+      // so it is visible in both light and dark themes without being clipped.
+      paddingLeft: '24px',
       '& svg': {
         position: 'relative',
         top: '-0.1em',


### PR DESCRIPTION
Closes #31505

## What I did

When the docs addon renders headings with anchor icons (`OcticonAnchor`), the anchor is positioned using `float: left` with `marginLeft: '-24px'`. This negative-margin approach requires the **heading itself** to have at least 24px of left padding so the floating icon has room to appear without being clipped by the parent container.

In the **light theme** the heading had no left padding, so the icon was cut off. The **dark theme** happened to have extra left space from a parent container, which masked the bug.

The fix adds `paddingLeft: '24px'` to the `OcticonHeaders` styled components (the same approach used by GitHub's Markdown heading anchors).

**Before (light theme):** anchor icon cut off on the left side  
**After (light theme):** anchor icon fully visible, matching dark-theme behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header styling in documentation blocks to properly display anchor icons without clipping in both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->