### PR TITLE
Search: show Docs icon for standalone docs pages in search results

### DIFF
--- a/code/core/src/manager/components/sidebar/Search.tsx
+++ b/code/core/src/manager/components/sidebar/Search.tsx
@@ -222,6 +222,13 @@ export const Search = React.memo<SearchProps>(function Search({
         ) {
           return false;
         }
+        // Skip docs-only components so their docs child can show the Docs icon instead
+        if (item.type === 'component' && 'children' in item && Array.isArray(item.children)) {
+          const index = dataset.hash[item.refId]?.index;
+          if (index && item.children.every((childId) => index[childId]?.type === 'docs')) {
+            return false;
+          }
+        }
         resultIds.add(item.id);
         return true;
       });
@@ -239,7 +246,7 @@ export const Search = React.memo<SearchProps>(function Search({
 
       return results;
     },
-    [allComponents, makeFuse]
+    [allComponents, dataset, makeFuse]
   );
 
   const onSelect = useCallback(

--- a/code/core/src/manager/components/sidebar/SearchResults.stories.tsx
+++ b/code/core/src/manager/components/sidebar/SearchResults.stories.tsx
@@ -96,3 +96,28 @@ export const Searching = () => <SearchResults {...searching} />;
 export const NoResults = () => <SearchResults {...noResults} />;
 
 export const LastViewed = () => <SearchResults {...lastViewed} />;
+
+// Docs story: simulate a docs-only standalone page (e.g. Configure.mdx without <Meta of=...>)
+// These were previously shown with the Component icon; they should show the Docs icon instead
+const docsOnlyItem = {
+  id: 'configure-your-project',
+  type: 'docs',
+  name: 'Configure your project',
+  title: 'Configure your project',
+  refId: 'internal',
+  path: [],
+  importPath: './src/stories/Configure.mdx',
+  parent: undefined,
+  depth: 0,
+  tags: [],
+  prepared: false,
+  renderLabel: undefined,
+  status: undefined,
+} as unknown as SearchItem;
+
+export const SearchingDocPage = () => (
+  <SearchResults
+    {...searching}
+    results={[{ item: docsOnlyItem, matches: [{ value: 'Configure your project', indices: [[0, 9]], key: 'name' as const, arrayIndex: 0 }], score: 0 }]}
+  />
+);


### PR DESCRIPTION
Closes #34288

## What I did

Standalone MDX docs pages (e.g. `Configure.mdx`, any page without `<Meta of={SomeComponent} />`) were showing the **Component** icon in search results instead of the **Docs** icon.

**Root cause:** `transformStoryIndexToStoriesHash` creates an intermediate `type: 'component'` parent entry for docs pages that stand alone (not attached to a component). When a user searched for such a page, Fuse.js matched both the parent component entry and the docs entry. The deduplication filter passed the component entry first (better score / processed first), then blocked the docs entry because its parent ID was already in `resultIds`.

**Fix:** In `getResults`, before adding a `component` entry to `resultIds`, check if all its children are `docs` entries. If so, skip the component entry entirely — the docs child then passes through the filter and is rendered with the correct Docs (document) icon.

**Also adds** a `SearchingDocPage` story in `SearchResults.stories.tsx` to provide visual regression coverage for this case.

## Checklist for Contributors

### Testing

- [x] stories

#### Manual testing

To reproduce before this fix: in a default Storybook sandbox (react-vite/default-ts), search for "Configure your". The result shows a Component icon. After the fix, it shows the Docs icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search results filtering to exclude components that contain exclusively documentation entries, preventing unwanted docs-only components from appearing in search results. Also updated filtering dependencies for consistency and accuracy.

* **Tests**
  * Added new Storybook test coverage for documentation-only search results, ensuring proper rendering and icon/label behavior for search items containing documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->