### PR TITLE
fix(vue3): clear stale args/globals when nextArgs is empty in updateArgs

### DIFF
--- a/code/renderers/vue3/src/render.test.ts
+++ b/code/renderers/vue3/src/render.test.ts
@@ -91,6 +91,12 @@ describe('Render Story', () => {
     expect(reactiveArgs).toEqual({ objectArg: { argFoo: 'bar' } });
   });
 
+  it('clears all args when nextArgs is empty -> updateArgs()', () => {
+    const reactiveArgs = reactive({ argFoo: 'foo', argBar: 'bar' });
+    updateArgs(reactiveArgs, {} as any);
+    expect(reactiveArgs).toEqual({});
+  });
+
   it('update reactive Globals', async () => {
     const reactiveGlobals = reactive<Globals>({ theme: 'light', locale: 'en' });
 

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -153,9 +153,6 @@ export function updateArgs<
     [name: string]: unknown;
   },
 >(reactiveArgs: T, nextArgs: T) {
-  if (Object.keys(nextArgs).length === 0) {
-    return;
-  }
   const currentArgs = isReactive(reactiveArgs) ? reactiveArgs : reactive(reactiveArgs);
   // delete all args in currentArgs that are not in nextArgs
   Object.keys(currentArgs).forEach((key) => {


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where stale args/globals persisted in Vue decorators after resetting args or clearing toolbar globals.

When `updateArgs()` was called with an empty `nextArgs` object, the early return on line 156 skipped the deletion loop entirely. This left every existing key in `reactiveArgs`/`reactiveGlobals` alive, so resetting args or clearing toolbar globals back to `{}` had no effect on the Vue reactive objects.

### Fix

Remove the early return so the deletion loop always runs. When `nextArgs` is `{}`, all keys in `currentArgs` are deleted, resulting in a properly empty reactive object.

### Test

Added a regression test: `updateArgs(reactive({ argFoo: 'foo', argBar: 'bar' }), {})` now results in an empty object.

Fixes #34319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Vue3 renderer to properly clear component arguments when updating with empty values. Previously, the renderer would skip processing updates if an empty object was provided. Now it correctly removes arguments not included in new values.

## Tests
* Added test coverage to verify argument clearing works correctly during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->