### PR TITLE
Maintenance: Extract shared parseEvent() helper from channel transports

### DIFF
--- a/code/core/src/channels/parse-event.ts
+++ b/code/core/src/channels/parse-event.ts
@@ -1,0 +1,15 @@
+/// <reference path="../typings.d.ts" />
+import { global } from '@storybook/global';
+
+import { isJSON, parse } from 'telejson';
+
+/**
+ * Deserialize a raw channel message using telejson. Returns the parsed object when the message is
+ * a JSON string, otherwise returns it as-is. Uses `global.CHANNEL_OPTIONS` for parse options so
+ * all transports apply the same settings.
+ */
+export function parseEvent(data: unknown): any {
+  return typeof data === 'string' && isJSON(data)
+    ? parse(data, global.CHANNEL_OPTIONS || {})
+    : data;
+}

--- a/code/core/src/channels/postmessage/index.ts
+++ b/code/core/src/channels/postmessage/index.ts
@@ -4,7 +4,7 @@ import * as EVENTS from 'storybook/internal/core-events';
 
 import { global } from '@storybook/global';
 
-import { isJSON, parse, stringify } from 'telejson';
+import { stringify } from 'telejson';
 import invariant from 'tiny-invariant';
 
 import type {
@@ -14,6 +14,7 @@ import type {
   ChannelTransport,
   Config,
 } from '../types';
+import { parseEvent } from '../parse-event';
 import { getEventSourceUrl } from './getEventSourceUrl';
 
 const { document, location } = global;
@@ -195,7 +196,7 @@ export class PostMessageTransport implements ChannelTransport {
     try {
       const { data } = rawEvent;
       const { key, event, refId } =
-        typeof data === 'string' && isJSON(data) ? parse(data, global.CHANNEL_OPTIONS || {}) : data;
+        parseEvent(data);
 
       if (key === KEY) {
         const pageString =

--- a/code/core/src/channels/websocket/index.ts
+++ b/code/core/src/channels/websocket/index.ts
@@ -3,10 +3,11 @@ import * as EVENTS from 'storybook/internal/core-events';
 
 import { global } from '@storybook/global';
 
-import { isJSON, parse, stringify } from 'telejson';
+import { stringify } from 'telejson';
 import invariant from 'tiny-invariant';
 
 import type { ChannelHandler, ChannelTransport, Config } from '../types';
+import { parseEvent } from '../parse-event';
 
 const { WebSocket } = global;
 
@@ -49,7 +50,7 @@ export class WebsocketTransport implements ChannelTransport {
       this.flush();
     };
     this.socket.onmessage = ({ data }) => {
-      const event = typeof data === 'string' && isJSON(data) ? parse(data) : data;
+      const event = parseEvent(data);
       invariant(this.handler, 'WebsocketTransport handler should be set');
       this.handler(event);
       if (event.type === 'ping') {

--- a/code/core/src/core-server/utils/get-server-channel.ts
+++ b/code/core/src/core-server/utils/get-server-channel.ts
@@ -3,9 +3,10 @@ import type { IncomingMessage } from 'node:http';
 import type { ChannelHandler } from 'storybook/internal/channels';
 import { Channel, HEARTBEAT_INTERVAL } from 'storybook/internal/channels';
 
-import { isJSON, parse, stringify } from 'telejson';
+import { stringify } from 'telejson';
 import WebSocket, { WebSocketServer } from 'ws';
 
+import { parseEvent } from '../../channels/parse-event';
 import { logger } from '../../node-logger';
 import { UniversalStore } from '../../shared/universal-store';
 import { type HostValidationOptions, isValidHost } from './getHostValidationMiddleware';
@@ -64,7 +65,7 @@ export class ServerChannelTransport {
     this.socket.on('connection', (wss) => {
       wss.on('message', (raw) => {
         const data = raw.toString();
-        const event = typeof data === 'string' && isJSON(data) ? parse(data, {}) : data;
+        const event = parseEvent(data);
         this.handler?.(event);
       });
     });


### PR DESCRIPTION
## What does this PR do?

Resolves the duplicated telejson deserialization pattern across all three channel transport implementations.

### Problem

The conditional `typeof data === 'string' && isJSON(data) ? parse(data, ...) : data` expression was copied in three places with subtly different `parse` options:

| File | Options passed to `parse` |
|------|---------------------------|
| `channels/websocket/index.ts` | none (missing options entirely) |
| `channels/postmessage/index.ts` | `global.CHANNEL_OPTIONS \|\| {}` |
| `core-server/utils/get-server-channel.ts` | `{}` (empty) |

The websocket transport was silently ignoring `CHANNEL_OPTIONS`, which could cause deserialization mismatches when custom options are configured.

### Fix

Extract a `parseEvent(data)` helper to `code/core/src/channels/parse-event.ts` that always uses `global.CHANNEL_OPTIONS || {}`. All three transport implementations now call the shared helper, ensuring consistent behaviour and making future option changes a single-file edit.

Closes #34291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated incoming event message parsing logic across all communication transport mechanisms—WebSocket, PostMessage, and server utilities—into a centralized handler. This unified approach ensures consistent message processing standards across all channels, eliminates redundant code, and enhances long-term maintainability and reliability of the internal communication infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->