### PR TITLE
fix: dedupe builder-vite project annotation imports

### DIFF
--- a/code/builders/builder-vite/src/codegen-project-annotations.test.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateProjectAnnotationsCodeFromPreviews } from './codegen-project-annotations';
+
+describe('generateProjectAnnotationsCodeFromPreviews', () => {
+  it('keeps generated preview import identifiers unique when aliases collide', () => {
+    const result = generateProjectAnnotationsCodeFromPreviews({
+      // These paths previously produced the same generated `preview_<hash>` identifier.
+      previewAnnotations: ['/virtual/path/0000r/preview.js', '/virtual/path/00020/preview.js'],
+      projectRoot: '/virtual',
+      frameworkName: 'frameworkName',
+      isCsf4: false,
+    });
+
+    const importVariables = [...result.matchAll(/import \* as (\w+) from/g)].map(
+      (match) => match[1]
+    );
+
+    expect(importVariables).toHaveLength(2);
+    expect(new Set(importVariables).size).toBe(importVariables.length);
+    expect(result).toContain(`hmrPreviewAnnotationModules[0] ?? ${importVariables[0]}`);
+    expect(result).toContain(`hmrPreviewAnnotationModules[1] ?? ${importVariables[1]}`);
+  });
+});

--- a/code/builders/builder-vite/src/codegen-project-annotations.test.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.test.ts
@@ -21,4 +21,29 @@ describe('generateProjectAnnotationsCodeFromPreviews', () => {
     expect(result).toContain(`hmrPreviewAnnotationModules[0] ?? ${importVariables[0]}`);
     expect(result).toContain(`hmrPreviewAnnotationModules[1] ?? ${importVariables[1]}`);
   });
+
+  it('suffixes repeated collisions deterministically across more than two previews', () => {
+    const result = generateProjectAnnotationsCodeFromPreviews({
+      // These paths all collide under the current djb2 hash, so the fallback suffixing stays active.
+      previewAnnotations: [
+        '/virtual/path/0000r/preview.js',
+        '/virtual/path/00020/preview.js',
+        '/virtual/path/0001Q/preview.js',
+      ],
+      projectRoot: '/virtual',
+      frameworkName: 'frameworkName',
+      isCsf4: false,
+    });
+
+    const importVariables = [...result.matchAll(/import \* as (\w+) from/g)].map(
+      (match) => match[1]
+    );
+
+    expect(importVariables).toEqual([
+      importVariables[0],
+      `${importVariables[0]}_2`,
+      `${importVariables[0]}_3`,
+    ]);
+    expect(result).toContain(`hmrPreviewAnnotationModules[2] ?? ${importVariables[2]}`);
+  });
 });

--- a/code/builders/builder-vite/src/codegen-project-annotations.test.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.test.ts
@@ -39,6 +39,7 @@ describe('generateProjectAnnotationsCodeFromPreviews', () => {
       (match) => match[1]
     );
 
+    expect(importVariables[0]).toMatch(/^[A-Za-z_$][A-Za-z0-9_$]*$/);
     expect(importVariables).toEqual([
       importVariables[0],
       `${importVariables[0]}_2`,

--- a/code/builders/builder-vite/src/codegen-project-annotations.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.ts
@@ -44,11 +44,21 @@ export function generateProjectAnnotationsCodeFromPreviews(options: {
 
   const variables: string[] = [];
   const imports: string[] = [];
+  const usedVariables = new Set<string>();
   for (const previewAnnotation of previewAnnotationURLs) {
-    const variable =
+    const baseVariable =
       genSafeVariableName(filename(previewAnnotation)).replace(/_(45|46|47)/g, '_') +
       '_' +
       hash(previewAnnotation);
+    let variable = baseVariable;
+    let duplicateCount = 2;
+
+    while (usedVariables.has(variable)) {
+      variable = `${baseVariable}_${duplicateCount}`;
+      duplicateCount += 1;
+    }
+
+    usedVariables.add(variable);
     variables.push(variable);
     imports.push(genImport(previewAnnotation, { name: '*', as: variable }));
   }

--- a/code/builders/builder-vite/src/codegen-project-annotations.ts
+++ b/code/builders/builder-vite/src/codegen-project-annotations.ts
@@ -50,15 +50,7 @@ export function generateProjectAnnotationsCodeFromPreviews(options: {
       genSafeVariableName(filename(previewAnnotation)).replace(/_(45|46|47)/g, '_') +
       '_' +
       hash(previewAnnotation);
-    let variable = baseVariable;
-    let duplicateCount = 2;
-
-    while (usedVariables.has(variable)) {
-      variable = `${baseVariable}_${duplicateCount}`;
-      duplicateCount += 1;
-    }
-
-    usedVariables.add(variable);
+    const variable = getUniqueImportVariable(baseVariable, usedVariables);
     variables.push(variable);
     imports.push(genImport(previewAnnotation, { name: '*', as: variable }));
   }
@@ -115,7 +107,20 @@ export function generateProjectAnnotationsCodeFromPreviews(options: {
   `.trim();
 }
 
-/** djb2 hash — http://www.cse.yorku.ca/~oz/hash.html */
+function getUniqueImportVariable(baseVariable: string, usedVariables: Set<string>) {
+  let variable = baseVariable;
+  let duplicateCount = 2;
+
+  while (usedVariables.has(variable)) {
+    variable = `${baseVariable}_${duplicateCount}`;
+    duplicateCount += 1;
+  }
+
+  usedVariables.add(variable);
+  return variable;
+}
+
+/** djb2 hash - http://www.cse.yorku.ca/~oz/hash.html */
 function hash(value: string) {
   let acc = 5381;
   for (let i = 0; i < value.length; i++) {


### PR DESCRIPTION
## Summary
- dedupe builder-vite project annotation import aliases when hash-based names collide
- keep the existing alias format for the common case and suffix only repeated names
- add a focused regression covering colliding preview annotation paths

## Testing
- corepack yarn vitest run --config code/builders/builder-vite/vitest.config.ts code/builders/builder-vite/src/codegen-project-annotations.test.ts
- corepack yarn --cwd code lint:js:cmd builders/builder-vite/src/codegen-project-annotations.ts builders/builder-vite/src/codegen-project-annotations.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved collisions when generating import aliases for preview annotations so each import identifier is unique and deterministic (uses predictable suffixing when needed).

* **Tests**
  * Added tests that verify unique identifier generation, deterministic suffix sequencing for repeated collisions, and correct module reference assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->