### PR TITLE
fix: keep Svelte PreviewRender dep-scan safe

### DIFF
--- a/code/renderers/svelte/src/internal-imports.test.ts
+++ b/code/renderers/svelte/src/internal-imports.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const previewRenderSource = readFileSync(
+  resolve(currentDir, "../static/PreviewRender.svelte"),
+  "utf8",
+);
+
+describe("published internal svelte imports", () => {
+  it("keeps PreviewRender on the self-referenced DecoratorHandler import", () => {
+    expect(previewRenderSource).toContain(
+      "import DecoratorHandler from '@storybook/svelte/internal/DecoratorHandler.svelte';",
+    );
+    expect(previewRenderSource).not.toContain(
+      "import DecoratorHandler from './DecoratorHandler.svelte';",
+    );
+  });
+});

--- a/code/renderers/svelte/static/PreviewRender.svelte
+++ b/code/renderers/svelte/static/PreviewRender.svelte
@@ -1,5 +1,9 @@
 <script>
-  import DecoratorHandler from './DecoratorHandler.svelte';
+  /*
+    ! DO NOT change this DecoratorHandler import to a relative path, it breaks Vite 8
+    ! Rolldown dependency scanning for the published static Svelte files.
+  */
+  import DecoratorHandler from '@storybook/svelte/internal/DecoratorHandler.svelte';
   import { dedent } from 'ts-dedent';
 
   const { name, title, storyFn, showError } = $props();


### PR DESCRIPTION
## Summary
- switch the published `@storybook/svelte/internal/PreviewRender.svelte` helper back to the self-referenced `@storybook/svelte/internal/DecoratorHandler.svelte` import instead of a relative `.svelte` path
- document why the published static helper must avoid relative internal Svelte imports for Vite 8 Rolldown dep scanning
- add a focused renderer regression that locks the published helper onto the self-referenced import path

## Testing
- `node node_modules\\vitest\\vitest.mjs run --config .tmp-contributor-11-vitest.config.mjs code\\renderers\\svelte\\src\\internal-imports.test.ts`
- `git diff --check`

Fixes #34304.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for internal import path behavior.

* **Chores**
  * Reorganized internal import paths for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->