### PR TITLE
Fix composed controls loading on direct child routes

### DIFF
--- a/code/core/src/controls/components/ControlsPanel.test.ts
+++ b/code/core/src/controls/components/ControlsPanel.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCurrentStoryPreviewInitialized } from './controlsPanelState';
+
+describe('getCurrentStoryPreviewInitialized', () => {
+  it('uses the root preview state for local stories', () => {
+    expect(getCurrentStoryPreviewInitialized(true, {}, { refId: undefined })).toBe(true);
+    expect(getCurrentStoryPreviewInitialized(false, {}, undefined)).toBe(false);
+  });
+
+  it('uses the selected ref preview state for composed stories', () => {
+    expect(
+      getCurrentStoryPreviewInitialized(
+        false,
+        {
+          external: { previewInitialized: true },
+        },
+        { refId: 'external' }
+      )
+    ).toBe(true);
+  });
+});

--- a/code/core/src/controls/components/ControlsPanel.test.ts
+++ b/code/core/src/controls/components/ControlsPanel.test.ts
@@ -19,4 +19,20 @@ describe('getCurrentStoryPreviewInitialized', () => {
       )
     ).toBe(true);
   });
+
+  it('returns false when the composed ref does not exist', () => {
+    expect(getCurrentStoryPreviewInitialized(true, {}, { refId: 'nonexistent' })).toBe(false);
+  });
+
+  it('returns false when the composed ref is not initialized', () => {
+    expect(
+      getCurrentStoryPreviewInitialized(
+        true,
+        {
+          external: { previewInitialized: false },
+        },
+        { refId: 'external' }
+      )
+    ).toBe(false);
+  });
 });

--- a/code/core/src/controls/components/ControlsPanel.tsx
+++ b/code/core/src/controls/components/ControlsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 
 import type { ArgTypes } from 'storybook/internal/types';
 
@@ -21,6 +21,7 @@ import {
 } from '../../../../addons/docs/src/blocks/components/ArgsTable/ArgsTable';
 import type { PresetColor } from '../../../../addons/docs/src/blocks/controls/types';
 import { PARAM_KEY } from '../constants';
+import { getCurrentStoryPreviewInitialized } from './controlsPanelState';
 import { SaveStory } from './SaveStory';
 
 // Remove undefined values (top-level only)
@@ -55,7 +56,6 @@ interface ControlsPanelProps {
 
 export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) => {
   const api = useStorybookApi();
-  const [isLoading, setIsLoading] = useState(true);
   const [args, updateArgs, resetArgs, initialArgs] = useArgs();
   const [globals] = useGlobals();
   const rows = useArgTypes();
@@ -65,16 +65,9 @@ export const ControlsPanel = ({ saveStory, createStory }: ControlsPanelProps) =>
     presetColors,
     disableSaveFromUI = false,
   } = useParameter<ControlsParameters>(PARAM_KEY, {});
-  const { path, previewInitialized } = useStorybookState();
+  const { path, previewInitialized, refs } = useStorybookState();
   const storyData = api.getCurrentStoryData();
-
-  // If the story is prepared, then show the args table
-  // and reset the loading states
-  useEffect(() => {
-    if (previewInitialized) {
-      setIsLoading(false);
-    }
-  }, [previewInitialized]);
+  const isLoading = !getCurrentStoryPreviewInitialized(previewInitialized, refs, storyData);
 
   const hasControls = Object.values(rows).some((arg) => arg?.control);
 

--- a/code/core/src/controls/components/controlsPanelState.ts
+++ b/code/core/src/controls/components/controlsPanelState.ts
@@ -1,0 +1,11 @@
+export const getCurrentStoryPreviewInitialized = (
+  previewInitialized: boolean,
+  refs: Record<string, { previewInitialized?: boolean }>,
+  storyData?: { refId?: string }
+) => {
+  if (storyData?.refId) {
+    return Boolean(refs[storyData.refId]?.previewInitialized);
+  }
+
+  return previewInitialized;
+};

--- a/code/core/src/manager/components/preview/Preview.test.ts
+++ b/code/core/src/manager/components/preview/Preview.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPreviewSelectionKey, shouldSyncPreviewSelection } from './selection';
+
+describe('shouldSyncPreviewSelection', () => {
+  it('skips the initial local selection when nothing changed', () => {
+    const selectionKey = getPreviewSelectionKey('button--primary');
+
+    expect(
+      shouldSyncPreviewSelection({
+        currentSelectionKey: selectionKey,
+        previousSelectionKey: selectionKey,
+        hasInitializedSelection: false,
+      })
+    ).toBe(false);
+  });
+
+  it('syncs an initial composed selection even when the route key is unchanged', () => {
+    const selectionKey = getPreviewSelectionKey('button--primary', 'external');
+
+    expect(
+      shouldSyncPreviewSelection({
+        currentSelectionKey: selectionKey,
+        previousSelectionKey: selectionKey,
+        refId: 'external',
+        hasInitializedSelection: false,
+      })
+    ).toBe(true);
+  });
+
+  it('syncs when the selected story changes', () => {
+    expect(
+      shouldSyncPreviewSelection({
+        currentSelectionKey: getPreviewSelectionKey('button--secondary'),
+        previousSelectionKey: getPreviewSelectionKey('button--primary'),
+        hasInitializedSelection: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/code/core/src/manager/components/preview/Preview.tsx
+++ b/code/core/src/manager/components/preview/Preview.tsx
@@ -15,6 +15,7 @@ import { type Combo, Consumer, addons, merge, types } from 'storybook/manager-ap
 import { useLandmark } from '../../hooks/useLandmark';
 import { FramesRenderer } from './FramesRenderer';
 import { ToolbarComp } from './Toolbar';
+import { getPreviewSelectionKey, shouldSyncPreviewSelection } from './selection';
 import { ApplyWrappers } from './Wrappers';
 import { ZoomConsumer, ZoomProvider } from './tools/zoom';
 import * as S from './utils/components';
@@ -49,6 +50,7 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
     options,
     viewMode,
     storyId,
+    refId,
     entry = undefined,
     description,
     baseUrl,
@@ -90,16 +92,26 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
   const { showToolbar } = options;
   const customisedShowToolbar = api.getShowToolbarWithCustomisations(showToolbar);
 
-  const previousStoryId = useRef(storyId);
+  const selectionKey = getPreviewSelectionKey(storyId, refId);
+  const previousSelectionKey = useRef(selectionKey);
+  const hasInitializedSelection = useRef(Boolean(entry && !refId));
 
   useEffect(() => {
     if (entry && viewMode) {
-      // Don't emit the event on first ("real") render, only when entry changes
-      if (storyId === previousStoryId.current) {
+      const shouldSyncSelection = shouldSyncPreviewSelection({
+        currentSelectionKey: selectionKey,
+        previousSelectionKey: previousSelectionKey.current,
+        refId,
+        hasInitializedSelection: hasInitializedSelection.current,
+      });
+
+      hasInitializedSelection.current = true;
+
+      if (!shouldSyncSelection) {
         return;
       }
 
-      previousStoryId.current = storyId;
+      previousSelectionKey.current = selectionKey;
 
       if (viewMode.match(/docs|story/)) {
         const { refId, id } = entry;
@@ -110,7 +122,7 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
         });
       }
     }
-  }, [entry, viewMode, storyId, api]);
+  }, [entry, viewMode, selectionKey, refId, api]);
 
   const mainRef = useRef<HTMLElement>(null);
   const { landmarkProps } = useLandmark(

--- a/code/core/src/manager/components/preview/selection.ts
+++ b/code/core/src/manager/components/preview/selection.ts
@@ -1,0 +1,14 @@
+export const getPreviewSelectionKey = (storyId: string, refId?: string) =>
+  `${refId ?? '__local__'}:${storyId}`;
+
+export const shouldSyncPreviewSelection = ({
+  currentSelectionKey,
+  previousSelectionKey,
+  refId,
+  hasInitializedSelection,
+}: {
+  currentSelectionKey: string;
+  previousSelectionKey: string;
+  refId?: string;
+  hasInitializedSelection: boolean;
+}) => currentSelectionKey !== previousSelectionKey || Boolean(refId && !hasInitializedSelection);

--- a/code/core/src/manager/components/preview/utils/types.tsx
+++ b/code/core/src/manager/components/preview/utils/types.tsx
@@ -12,6 +12,7 @@ import type { API, LeafEntry, State } from 'storybook/manager-api';
 export interface PreviewProps {
   api: API;
   viewMode: API_ViewMode;
+  refId?: string;
   refs: State['refs'];
   storyId: StoryId;
   entry: LeafEntry;

--- a/code/core/src/manager/container/Preview.tsx
+++ b/code/core/src/manager/container/Preview.tsx
@@ -116,6 +116,7 @@ const mapper = ({
     options: layout,
     description: getDescription(entry),
     viewMode,
+    refId,
     refs,
     storyId,
     baseUrl: PREVIEW_URL || 'iframe.html',


### PR DESCRIPTION
## Summary
- read controls readiness from the currently selected composed ref instead of only the root preview state
- treat the first resolved composed selection as a sync point so direct child routes still emit `SET_CURRENT_STORY`
- add focused regression coverage for the preview-selection and controls readiness helpers

Fixes #34358.

## Testing
- `corepack yarn vitest run --config code/core/vitest.config.ts code/core/src/controls/components/ControlsPanel.test.ts code/core/src/manager/components/preview/Preview.test.ts`
- `corepack yarn prettier --check code/core/src/controls/components/ControlsPanel.tsx code/core/src/controls/components/ControlsPanel.test.ts code/core/src/controls/components/controlsPanelState.ts code/core/src/manager/components/preview/Preview.tsx code/core/src/manager/components/preview/Preview.test.ts code/core/src/manager/components/preview/selection.ts code/core/src/manager/components/preview/utils/types.tsx code/core/src/manager/container/Preview.tsx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for external story references in preview selection syncing.

* **Bug Fixes**
  * More accurate preview initialization handling for composed/external stories.
  * Selection synchronization refined to avoid missed or duplicate preview updates.

* **Tests**
  * Added tests covering preview initialization and selection-sync behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->