### PR TITLE
Fix composed preview direct loads staying stuck in loading state

### DIFF
--- a/code/core/src/manager/components/preview/Preview.test.tsx
+++ b/code/core/src/manager/components/preview/Preview.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import React from 'react';
+
+import { SET_CURRENT_STORY } from 'storybook/internal/core-events';
+import type { API_StoryEntry } from 'storybook/internal/types';
+
+import { Preview } from './Preview';
+
+type MockConsumerState = {
+  customQueryParams: Record<string, never>;
+  previewInitialized: boolean;
+  refId: string;
+  refs: Record<string, { previewInitialized: boolean }>;
+  storyId: string;
+  viewMode: 'story';
+};
+
+type MockApi = ReturnType<typeof createApi>;
+
+let consumerState: MockConsumerState;
+let consumerApi: MockApi;
+
+vi.mock('storybook/internal/components', () => ({
+  Loader: () => null,
+  useTabsState: () => ({}),
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../hooks/useLandmark', () => ({
+  useLandmark: () => ({ landmarkProps: {} }),
+}));
+
+vi.mock('./FramesRenderer', () => ({
+  FramesRenderer: () => null,
+}));
+
+vi.mock('./Toolbar', () => ({
+  ToolbarComp: () => null,
+}));
+
+vi.mock('./Wrappers', () => ({
+  ApplyWrappers: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./tools/zoom', () => ({
+  ZoomProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ZoomConsumer: ({ children }: { children: (value: { value: number }) => React.ReactNode }) => (
+    <>{children({ value: 1 })}</>
+  ),
+}));
+
+vi.mock('./utils/components', () => {
+  const FrameWrap = React.forwardRef<HTMLElement, { children: React.ReactNode }>((props, ref) => (
+    <section ref={ref}>{props.children}</section>
+  ));
+  FrameWrap.displayName = 'FrameWrap';
+
+  return {
+    PreviewContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    FrameWrap,
+    CanvasWrap: ({ children, show }: { children: React.ReactNode; show: boolean }) =>
+      show ? <div>{children}</div> : null,
+    LoaderWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    IframeWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+vi.mock('storybook/manager-api', async () => ({
+  Consumer: ({
+    filter,
+    children,
+  }: {
+    filter: (input: { state: MockConsumerState; api: MockApi }) => unknown;
+    children: (value: unknown) => React.ReactNode;
+  }) => <>{children(filter({ state: consumerState, api: consumerApi }))}</>,
+  addons: { getChannel: () => ({ on: vi.fn() }) },
+  merge: (...values: Record<string, unknown>[]) => Object.assign({}, ...values),
+  types: { TAB: 'TAB' },
+}));
+
+const createEntry = (id = 'child-story--default'): Pick<API_StoryEntry, 'id' | 'refId'> =>
+  ({ id, refId: 'child-ref' }) as Pick<API_StoryEntry, 'id' | 'refId'>;
+
+const createApi = () => ({
+  applyQueryParams: vi.fn(),
+  emit: vi.fn(),
+  getData: vi.fn(),
+  getElements: vi.fn(),
+  getShowToolbarWithCustomisations: vi.fn().mockReturnValue(false),
+  renderPreview: undefined,
+});
+
+const createProps = (entry?: Pick<API_StoryEntry, 'id' | 'refId'>) => ({
+  api: consumerApi,
+  baseUrl: '/',
+  description: 'Preview',
+  entry,
+  id: 'main',
+  options: { showToolbar: false },
+  storyId: 'child-story--default',
+  tabId: undefined,
+  tabs: [{ id: 'canvas', title: 'Canvas', render: () => null }],
+  tools: [],
+  toolsExtra: [],
+  viewMode: 'story' as const,
+  withLoader: false,
+  wrappers: [],
+});
+
+describe('Preview', () => {
+  beforeEach(() => {
+    consumerApi = createApi();
+    consumerState = {
+      customQueryParams: {},
+      previewInitialized: true,
+      refId: 'child-ref',
+      refs: { 'child-ref': { previewInitialized: true } },
+      storyId: 'child-story--default',
+      viewMode: 'story',
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('emits SET_CURRENT_STORY when a composed entry appears after the initial render', () => {
+    const view = render(<Preview {...createProps(undefined)} />);
+
+    expect(consumerApi.emit).not.toHaveBeenCalled();
+
+    const entry = createEntry();
+    consumerApi.getData.mockReturnValue(entry);
+
+    view.rerender(<Preview {...createProps(entry)} />);
+
+    expect(consumerApi.emit).toHaveBeenCalledWith(SET_CURRENT_STORY, {
+      storyId: 'child-story--default',
+      viewMode: 'story',
+      options: { target: 'child-ref' },
+    });
+  });
+
+  it('does not emit SET_CURRENT_STORY on the initial render when the entry is already ready', () => {
+    const entry = createEntry();
+    consumerApi.getData.mockReturnValue(entry);
+
+    render(<Preview {...createProps(entry)} />);
+
+    expect(consumerApi.emit).not.toHaveBeenCalled();
+  });
+
+  it('does not re-emit SET_CURRENT_STORY for rerenders of the same selection', () => {
+    const entry = createEntry();
+    consumerApi.getData.mockReturnValue(entry);
+
+    const view = render(<Preview {...createProps(entry)} />);
+
+    consumerApi.emit.mockClear();
+    view.rerender(<Preview {...createProps(entry)} />);
+
+    expect(consumerApi.emit).not.toHaveBeenCalled();
+  });
+});

--- a/code/core/src/manager/components/preview/Preview.test.tsx
+++ b/code/core/src/manager/components/preview/Preview.test.tsx
@@ -4,9 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import React from 'react';
 
+import * as InternalComponents from 'storybook/internal/components';
 import { SET_CURRENT_STORY } from 'storybook/internal/core-events';
 import type { API_StoryEntry } from 'storybook/internal/types';
+import * as ManagerApi from 'storybook/manager-api';
+import { HelmetProvider } from 'react-helmet-async';
 
+import * as useLandmarkModule from '../../hooks/useLandmark';
+import * as FramesRendererModule from './FramesRenderer';
 import { Preview } from './Preview';
 
 type MockConsumerState = {
@@ -15,74 +20,22 @@ type MockConsumerState = {
   refId: string;
   refs: Record<string, { previewInitialized: boolean }>;
   storyId: string;
-  viewMode: 'story';
+  viewMode: 'docs' | 'story';
 };
 
 type MockApi = ReturnType<typeof createApi>;
 
 let consumerState: MockConsumerState;
 let consumerApi: MockApi;
+let currentEntry: Pick<API_StoryEntry, 'id' | 'refId'> | undefined;
 
-vi.mock('storybook/internal/components', () => ({
-  Loader: () => null,
-  useTabsState: () => ({}),
-}));
-
-vi.mock('react-helmet-async', () => ({
-  Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-vi.mock('../../hooks/useLandmark', () => ({
-  useLandmark: () => ({ landmarkProps: {} }),
-}));
-
-vi.mock('./FramesRenderer', () => ({
-  FramesRenderer: () => null,
-}));
-
-vi.mock('./Toolbar', () => ({
-  ToolbarComp: () => null,
-}));
-
-vi.mock('./Wrappers', () => ({
-  ApplyWrappers: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
-vi.mock('./tools/zoom', () => ({
-  ZoomProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ZoomConsumer: ({ children }: { children: (value: { value: number }) => React.ReactNode }) => (
-    <>{children({ value: 1 })}</>
-  ),
-}));
-
-vi.mock('./utils/components', () => {
-  const FrameWrap = React.forwardRef<HTMLElement, { children: React.ReactNode }>((props, ref) => (
-    <section ref={ref}>{props.children}</section>
-  ));
-  FrameWrap.displayName = 'FrameWrap';
-
-  return {
-    PreviewContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    FrameWrap,
-    CanvasWrap: ({ children, show }: { children: React.ReactNode; show: boolean }) =>
-      show ? <div>{children}</div> : null,
-    LoaderWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    IframeWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  };
-});
-
-vi.mock('storybook/manager-api', async () => ({
-  Consumer: ({
-    filter,
-    children,
-  }: {
-    filter: (input: { state: MockConsumerState; api: MockApi }) => unknown;
-    children: (value: unknown) => React.ReactNode;
-  }) => <>{children(filter({ state: consumerState, api: consumerApi }))}</>,
-  addons: { getChannel: () => ({ on: vi.fn() }) },
-  merge: (...values: Record<string, unknown>[]) => Object.assign({}, ...values),
-  types: { TAB: 'TAB' },
-}));
+vi.mock('storybook/internal/components', { spy: true });
+vi.mock('../../hooks/useLandmark', { spy: true });
+vi.mock('./FramesRenderer', { spy: true });
+vi.mock('./Toolbar', { spy: true });
+vi.mock('./Wrappers', { spy: true });
+vi.mock('./utils/components', { spy: true });
+vi.mock('storybook/manager-api', { spy: true });
 
 const createEntry = (id = 'child-story--default'): Pick<API_StoryEntry, 'id' | 'refId'> =>
   ({ id, refId: 'child-ref' }) as Pick<API_StoryEntry, 'id' | 'refId'>;
@@ -96,7 +49,10 @@ const createApi = () => ({
   renderPreview: undefined,
 });
 
-const createProps = (entry?: Pick<API_StoryEntry, 'id' | 'refId'>) => ({
+const createProps = (
+  entry?: Pick<API_StoryEntry, 'id' | 'refId'>,
+  viewMode: 'docs' | 'story' = 'story'
+) => ({
   api: consumerApi,
   baseUrl: '/',
   description: 'Preview',
@@ -108,14 +64,27 @@ const createProps = (entry?: Pick<API_StoryEntry, 'id' | 'refId'>) => ({
   tabs: [{ id: 'canvas', title: 'Canvas', render: () => null }],
   tools: [],
   toolsExtra: [],
-  viewMode: 'story' as const,
+  viewMode,
   withLoader: false,
   wrappers: [],
 });
 
+const renderPreview = (
+  entry?: Pick<API_StoryEntry, 'id' | 'refId'>,
+  viewMode: 'docs' | 'story' = 'story'
+) =>
+  render(
+    <HelmetProvider>
+      <Preview {...createProps(entry, viewMode)} />
+    </HelmetProvider>
+  );
+
 describe('Preview', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+
     consumerApi = createApi();
+    currentEntry = undefined;
     consumerState = {
       customQueryParams: {},
       previewInitialized: true,
@@ -124,6 +93,26 @@ describe('Preview', () => {
       storyId: 'child-story--default',
       viewMode: 'story',
     };
+
+    vi.mocked(InternalComponents.useTabsState).mockReturnValue({} as never);
+    consumerApi.getData.mockImplementation(() => currentEntry as never);
+
+    vi.mocked(useLandmarkModule.useLandmark).mockReturnValue({ landmarkProps: {} } as never);
+    vi.mocked(FramesRendererModule.FramesRenderer).mockImplementation(
+      function FramesRendererMock() {
+        return null;
+      }
+    );
+    vi.mocked(ManagerApi.Consumer).mockImplementation(function ConsumerMock({
+      filter,
+      children,
+    }: {
+      filter: (input: { state: MockConsumerState; api: MockApi }) => unknown;
+      children: (value: unknown) => React.ReactNode;
+    }) {
+      return <>{children(filter({ state: consumerState, api: consumerApi }))}</>;
+    });
+    vi.spyOn(ManagerApi.addons, 'getChannel').mockReturnValue({ on: vi.fn() } as never);
   });
 
   afterEach(() => {
@@ -131,14 +120,18 @@ describe('Preview', () => {
   });
 
   it('emits SET_CURRENT_STORY when a composed entry appears after the initial render', () => {
-    const view = render(<Preview {...createProps(undefined)} />);
+    const view = renderPreview(undefined);
 
     expect(consumerApi.emit).not.toHaveBeenCalled();
 
     const entry = createEntry();
-    consumerApi.getData.mockReturnValue(entry);
+    currentEntry = entry;
 
-    view.rerender(<Preview {...createProps(entry)} />);
+    view.rerender(
+      <HelmetProvider>
+        <Preview {...createProps(entry)} />
+      </HelmetProvider>
+    );
 
     expect(consumerApi.emit).toHaveBeenCalledWith(SET_CURRENT_STORY, {
       storyId: 'child-story--default',
@@ -149,21 +142,47 @@ describe('Preview', () => {
 
   it('does not emit SET_CURRENT_STORY on the initial render when the entry is already ready', () => {
     const entry = createEntry();
-    consumerApi.getData.mockReturnValue(entry);
+    currentEntry = entry;
 
-    render(<Preview {...createProps(entry)} />);
+    renderPreview(entry);
 
     expect(consumerApi.emit).not.toHaveBeenCalled();
   });
 
+  it('emits SET_CURRENT_STORY when the same composed entry rerenders in docs mode', () => {
+    const entry = createEntry();
+    currentEntry = entry;
+
+    const view = renderPreview(entry);
+
+    expect(consumerApi.emit).not.toHaveBeenCalled();
+
+    consumerState.viewMode = 'docs';
+    view.rerender(
+      <HelmetProvider>
+        <Preview {...createProps(entry, 'docs')} />
+      </HelmetProvider>
+    );
+
+    expect(consumerApi.emit).toHaveBeenCalledWith(SET_CURRENT_STORY, {
+      storyId: 'child-story--default',
+      viewMode: 'docs',
+      options: { target: 'child-ref' },
+    });
+  });
+
   it('does not re-emit SET_CURRENT_STORY for rerenders of the same selection', () => {
     const entry = createEntry();
-    consumerApi.getData.mockReturnValue(entry);
+    currentEntry = entry;
 
-    const view = render(<Preview {...createProps(entry)} />);
+    const view = renderPreview(entry);
 
     consumerApi.emit.mockClear();
-    view.rerender(<Preview {...createProps(entry)} />);
+    view.rerender(
+      <HelmetProvider>
+        <Preview {...createProps(entry)} />
+      </HelmetProvider>
+    );
 
     expect(consumerApi.emit).not.toHaveBeenCalled();
   });

--- a/code/core/src/manager/components/preview/Preview.test.tsx
+++ b/code/core/src/manager/components/preview/Preview.test.tsx
@@ -103,6 +103,7 @@ describe('Preview', () => {
         return null;
       }
     );
+    // Feed Preview the current manager state/api without depending on the real provider tree.
     vi.mocked(ManagerApi.Consumer).mockImplementation(function ConsumerMock({
       filter,
       children,

--- a/code/core/src/manager/components/preview/Preview.tsx
+++ b/code/core/src/manager/components/preview/Preview.tsx
@@ -42,13 +42,17 @@ export const createCanvasTab = (): Addon_BaseType => ({
   render: () => null,
 });
 
+const getSelectedEntryKey = (entry: PreviewProps['entry'], viewMode: PreviewProps['viewMode']) =>
+  entry && viewMode.match(/docs|story/)
+    ? `${viewMode}:${entry.refId ?? 'storybook_internal'}:${entry.id}`
+    : undefined;
+
 const Preview = React.memo<PreviewProps>(function Preview(props) {
   const {
     api,
     id: previewId,
     options,
     viewMode,
-    storyId,
     entry = undefined,
     description,
     baseUrl,
@@ -90,27 +94,24 @@ const Preview = React.memo<PreviewProps>(function Preview(props) {
   const { showToolbar } = options;
   const customisedShowToolbar = api.getShowToolbarWithCustomisations(showToolbar);
 
-  const previousStoryId = useRef(storyId);
+  const previousSelectionKey = useRef(getSelectedEntryKey(entry, viewMode));
 
   useEffect(() => {
-    if (entry && viewMode) {
-      // Don't emit the event on first ("real") render, only when entry changes
-      if (storyId === previousStoryId.current) {
-        return;
-      }
+    const selectionKey = getSelectedEntryKey(entry, viewMode);
 
-      previousStoryId.current = storyId;
-
-      if (viewMode.match(/docs|story/)) {
-        const { refId, id } = entry;
-        api.emit(SET_CURRENT_STORY, {
-          storyId: id,
-          viewMode,
-          options: { target: refId },
-        });
-      }
+    if (!entry || !selectionKey || selectionKey === previousSelectionKey.current) {
+      return;
     }
-  }, [entry, viewMode, storyId, api]);
+
+    previousSelectionKey.current = selectionKey;
+
+    const { refId, id } = entry;
+    api.emit(SET_CURRENT_STORY, {
+      storyId: id,
+      viewMode,
+      options: { target: refId },
+    });
+  }, [entry, viewMode, api]);
 
   const mainRef = useRef<HTMLElement>(null);
   const { landmarkProps } = useLandmark(


### PR DESCRIPTION
## Summary
- sync the first resolved composed preview selection when a direct load starts without an entry and the ref index arrives later
- key the initial `SET_CURRENT_STORY` suppression off the resolved entry selection instead of only the current story id
- add a focused Preview regression for the composed-entry-arrives-later path

## Validation
- `corepack yarn nx compile core`
- `corepack yarn vitest run -c code/core/vitest.config.ts code/core/src/manager/components/preview/Preview.test.tsx code/core/src/manager-api/tests/stories.test.ts`
- `corepack yarn --cwd code exec oxfmt core/src/manager/components/preview/Preview.tsx core/src/manager/components/preview/Preview.test.tsx`
- `corepack yarn --cwd code lint:js:cmd core/src/manager/components/preview/Preview.tsx core/src/manager/components/preview/Preview.test.tsx --fix`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test suite for the Preview component to validate selection and rendering behaviors across mode changes.

* **Refactor**
  * Improved selection-tracking and emission logic in Preview to avoid redundant updates and ensure correct behavior when switching between story and docs modes, resulting in a more stable and reliable preview experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->