### PR TITLE
Maintenance: Extract createPreviewAnnotations factory to internal/common

### DIFF
--- a/code/core/src/common/index.ts
+++ b/code/core/src/common/index.ts
@@ -42,6 +42,7 @@ export * from './utils/sync-main-preview-addons';
 export * from './utils/setup-addon-in-config';
 export * from './utils/wrap-getAbsolutePath-utils';
 export * from './js-package-manager';
+export * from './utils/preview-annotations';
 export * from './utils/scan-and-transform-files';
 export * from './utils/transform-imports';
 export * from '../shared/utils/module';

--- a/code/core/src/common/utils/preview-annotations.ts
+++ b/code/core/src/common/utils/preview-annotations.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from 'node:url';
+
+import type { PresetProperty } from 'storybook/internal/types';
+
+/**
+ * Creates a `previewAnnotations` preset function for a renderer package.
+ *
+ * @param packageName - The renderer package name (e.g. `'@storybook/vue3'`)
+ * @param extraEntries - Additional entry points to include before the docs entry (e.g. `['entry-preview-argtypes']`)
+ */
+export function createPreviewAnnotations(
+  packageName: string,
+  extraEntries: string[] = []
+): PresetProperty<'previewAnnotations'> {
+  return async (input = [], options) => {
+    const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
+
+    return (input as string[])
+      .concat([fileURLToPath(import.meta.resolve(`${packageName}/entry-preview`))])
+      .concat(extraEntries.map((entry) => fileURLToPath(import.meta.resolve(`${packageName}/${entry}`))))
+      .concat(
+        docsEnabled ? [fileURLToPath(import.meta.resolve(`${packageName}/entry-preview-docs`))] : []
+      );
+  };
+}

--- a/code/core/src/common/utils/preview-annotations.ts
+++ b/code/core/src/common/utils/preview-annotations.ts
@@ -17,7 +17,9 @@ export function createPreviewAnnotations(
 
     return (input as string[])
       .concat([fileURLToPath(import.meta.resolve(`${packageName}/entry-preview`))])
-      .concat(extraEntries.map((entry) => fileURLToPath(import.meta.resolve(`${packageName}/${entry}`))))
+      .concat(
+        extraEntries.map((entry) => fileURLToPath(import.meta.resolve(`${packageName}/${entry}`)))
+      )
       .concat(
         docsEnabled ? [fileURLToPath(import.meta.resolve(`${packageName}/entry-preview-docs`))] : []
       );

--- a/code/renderers/html/src/preset.ts
+++ b/code/renderers/html/src/preset.ts
@@ -1,18 +1,3 @@
-import { fileURLToPath } from 'node:url';
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-import type { PresetProperty } from 'storybook/internal/types';
-
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
-
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/html/entry-preview'))])
-    .concat(
-      docsEnabled ? [fileURLToPath(import.meta.resolve('@storybook/html/entry-preview-docs'))] : []
-    );
-};
+export const previewAnnotations = createPreviewAnnotations('@storybook/html');

--- a/code/renderers/preact/src/preset.ts
+++ b/code/renderers/preact/src/preset.ts
@@ -1,23 +1,6 @@
-import { fileURLToPath } from 'node:url';
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-import type { PresetProperty } from 'storybook/internal/types';
-
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
-
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/preact/entry-preview'))])
-    .concat(
-      docsEnabled
-        ? [fileURLToPath(import.meta.resolve('@storybook/preact/entry-preview-docs'))]
-        : []
-    );
-};
+export const previewAnnotations = createPreviewAnnotations('@storybook/preact');
 
 /**
  * Alias react and react-dom to preact/compat similar to the preact vite preset

--- a/code/renderers/svelte/src/preset.ts
+++ b/code/renderers/svelte/src/preset.ts
@@ -1,20 +1,3 @@
-import { fileURLToPath } from 'node:url';
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-import type { PresetProperty } from 'storybook/internal/types';
-
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
-
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/svelte/entry-preview'))])
-    .concat(
-      docsEnabled
-        ? [fileURLToPath(import.meta.resolve('@storybook/svelte/entry-preview-docs'))]
-        : []
-    );
-};
+export const previewAnnotations = createPreviewAnnotations('@storybook/svelte');

--- a/code/renderers/vue3/src/preset.ts
+++ b/code/renderers/vue3/src/preset.ts
@@ -1,18 +1,3 @@
-import { fileURLToPath } from 'node:url';
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-import type { PresetProperty } from 'storybook/internal/types';
-
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
-
-  return result
-    .concat(input)
-    .concat([fileURLToPath(import.meta.resolve('@storybook/vue3/entry-preview'))])
-    .concat(
-      docsEnabled ? [fileURLToPath(import.meta.resolve('@storybook/vue3/entry-preview-docs'))] : []
-    );
-};
+export const previewAnnotations = createPreviewAnnotations('@storybook/vue3');

--- a/code/renderers/web-components/src/preset.ts
+++ b/code/renderers/web-components/src/preset.ts
@@ -1,23 +1,5 @@
-import { fileURLToPath } from 'node:url';
+import { createPreviewAnnotations } from 'storybook/internal/common';
 
-import type { PresetProperty } from 'storybook/internal/types';
-
-export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
-  input = [],
-  options
-) => {
-  const docsEnabled = Object.keys(await options.presets.apply('docs', {}, options)).length > 0;
-  const result: string[] = [];
-
-  return result
-    .concat(input)
-    .concat([
-      fileURLToPath(import.meta.resolve('@storybook/web-components/entry-preview')),
-      fileURLToPath(import.meta.resolve('@storybook/web-components/entry-preview-argtypes')),
-    ])
-    .concat(
-      docsEnabled
-        ? [fileURLToPath(import.meta.resolve('@storybook/web-components/entry-preview-docs'))]
-        : []
-    );
-};
+export const previewAnnotations = createPreviewAnnotations('@storybook/web-components', [
+  'entry-preview-argtypes',
+]);


### PR DESCRIPTION
## What

Extracts a `createPreviewAnnotations(packageName, extraEntries?)` factory function to `storybook/internal/common` and uses it in all 5 renderer preset files.

Closes #34389

## Why

The `previewAnnotations` export was copy-pasted identically across 5 files (`html`, `preact`, `svelte`, `vue3`, `web-components`), differing only in the package name string and — for `web-components` — an extra `entry-preview-argtypes` annotation. This means any change to the `docsEnabled` check or result-building logic requires updating 5 files, with real risk of inconsistencies.

## Changes

- **New:** `code/core/src/common/utils/preview-annotations.ts` — `createPreviewAnnotations(packageName, extraEntries?)` factory
- **Updated:** `code/core/src/common/index.ts` — re-exports the new factory
- **Updated:** `code/renderers/{html,preact,svelte,vue3,web-components}/src/preset.ts` — replaced inlined function with `createPreviewAnnotations()` call

The `web-components` renderer passes `['entry-preview-argtypes']` as the second argument; all others use the default (no extra entries). Behaviour is identical to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized preview annotation handling into a shared utility and re-exported it from the common package.
  * Updated HTML, Preact, Svelte, Vue 3, and Web Components renderers to use the shared preview annotation logic, reducing duplication and ensuring consistent inclusion of preview-related entries (including optional docs and argtypes entries) across renderers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->