### PR TITLE
Maintenance: extract createDynamicStylesPlay helper from pseudo-states stories

### DIFF
--- a/code/addons/pseudo-states/src/stories/Button.stories.tsx
+++ b/code/addons/pseudo-states/src/stories/Button.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { styled } from 'storybook/theming';
 
 import { Button } from './Button';
+import { createDynamicStylesPlay } from './dynamicStylesPlay';
 import './grid.css';
 import { PseudoStateGrid } from './PseudoStateGrid';
 
@@ -120,19 +121,5 @@ export const DynamicStyles: Story = {
   render: (args, context) => {
     return All.render!({ className: 'dynamic' }, context);
   },
-  play: async ({ id: storyId }) => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        // @ts-expect-error We're adding this nonstandard property
-        if (globalThis[`__dynamicRuleInjected_${storyId}`]) {
-          return;
-        }
-        // @ts-expect-error We're adding this nonstandard property
-        globalThis[`__dynamicRuleInjected_${storyId}`] = true;
-        const sheet = Array.from(document.styleSheets).at(-1);
-        sheet?.insertRule('.dynamic.button:hover { background-color: tomato }');
-        resolve();
-      }, 100);
-    });
-  },
+  play: createDynamicStylesPlay('.dynamic.button:hover { background-color: tomato }'),
 };

--- a/code/addons/pseudo-states/src/stories/CSSAtRules.stories.tsx
+++ b/code/addons/pseudo-states/src/stories/CSSAtRules.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useChannel, useStoryContext } from 'storybook/preview-api';
 
 import { Button } from './CSSAtRules';
+import { createDynamicStylesPlay } from './dynamicStylesPlay';
 import './grid.css';
 import { PseudoStateGrid } from './PseudoStateGrid';
 
@@ -50,21 +51,7 @@ export const DynamicStyles: Story = {
   render: (args, context) => {
     return All.render!({ className: 'dynamic' }, context);
   },
-  play: async ({ id: storyId }) => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        // @ts-expect-error We're adding this nonstandard property below
-        if (globalThis[`__dynamicRuleInjected_${storyId}`]) {
-          return;
-        }
-        // @ts-expect-error We're adding this nonstandard property
-        globalThis[`__dynamicRuleInjected_${storyId}`] = true;
-        const sheet = Array.from(document.styleSheets).at(-1);
-        sheet?.insertRule(
-          '@layer foo { .dynamic.button:hover { background-color: tomato!important } }'
-        );
-        resolve();
-      }, 100);
-    });
-  },
+  play: createDynamicStylesPlay(
+    '@layer foo { .dynamic.button:hover { background-color: tomato!important } }'
+  ),
 };

--- a/code/addons/pseudo-states/src/stories/dynamicStylesPlay.ts
+++ b/code/addons/pseudo-states/src/stories/dynamicStylesPlay.ts
@@ -1,0 +1,17 @@
+export function createDynamicStylesPlay(cssRule: string) {
+  return async ({ id: storyId }: { id: string }) => {
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // @ts-expect-error We're adding this nonstandard property
+        if (globalThis[`__dynamicRuleInjected_${storyId}`]) {
+          return;
+        }
+        // @ts-expect-error We're adding this nonstandard property
+        globalThis[`__dynamicRuleInjected_${storyId}`] = true;
+        const sheet = Array.from(document.styleSheets).at(-1);
+        sheet?.insertRule(cssRule);
+        resolve();
+      }, 100);
+    });
+  };
+}


### PR DESCRIPTION
Fixes #34357

The `DynamicStyles` play function was copy-pasted identically between `Button.stories.tsx` and `CSSAtRules.stories.tsx` — the deduplication guard, the timeout, the globalThis property assignment, and the `document.styleSheets` lookup all duplicated. Only the CSS rule string differed.

Extracted a `createDynamicStylesPlay(cssRule)` factory to `dynamicStylesPlay.ts`. Both story files now call the factory with their specific rule.

No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated repeated dynamic style injection logic from story files into a shared helper utility function
  * Simplified story implementations by delegating CSS rule injection and deduplication to the centralized helper, improving maintainability across multiple story definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->