### PR TITLE
ESLint: fix use-storybook-testing-library to recommend storybook/test

### DIFF
--- a/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.test.ts
+++ b/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.test.ts
@@ -15,12 +15,15 @@ import rule from './use-storybook-testing-library';
 //------------------------------------------------------------------------------
 
 ruleTester.run('use-storybook-testing-library', rule, {
-  valid: ["import { within } from '@storybook/testing-library'"],
+  valid: [
+    "import { within } from 'storybook/test'",
+    "import { within } from '@storybook/testing-library'",
+  ],
 
   invalid: [
     {
       code: "import { within } from '@testing-library/dom'",
-      output: "import { within } from '@storybook/testing-library'",
+      output: "import { within } from 'storybook/test'",
       errors: [
         {
           messageId: 'dontUseTestingLibraryDirectly',
@@ -31,7 +34,7 @@ ruleTester.run('use-storybook-testing-library', rule, {
           suggestions: [
             {
               messageId: 'updateImports',
-              output: "import { within } from '@storybook/testing-library'",
+              output: "import { within } from 'storybook/test'",
             },
           ],
         },
@@ -39,7 +42,7 @@ ruleTester.run('use-storybook-testing-library', rule, {
     },
     {
       code: "import userEvent from '@testing-library/user-event'",
-      output: "import { userEvent } from '@storybook/testing-library'",
+      output: "import { userEvent } from 'storybook/test'",
       errors: [
         {
           messageId: 'dontUseTestingLibraryDirectly',
@@ -50,7 +53,7 @@ ruleTester.run('use-storybook-testing-library', rule, {
           suggestions: [
             {
               messageId: 'updateImports',
-              output: "import { userEvent } from '@storybook/testing-library'",
+              output: "import { userEvent } from 'storybook/test'",
             },
           ],
         },
@@ -58,7 +61,7 @@ ruleTester.run('use-storybook-testing-library', rule, {
     },
     {
       code: "import userEvent, { foo, bar as Bar } from '@testing-library/user-event'",
-      output: "import { userEvent, foo, bar as Bar } from '@storybook/testing-library'",
+      output: "import { userEvent, foo, bar as Bar } from 'storybook/test'",
       errors: [
         {
           messageId: 'dontUseTestingLibraryDirectly',
@@ -69,7 +72,7 @@ ruleTester.run('use-storybook-testing-library', rule, {
           suggestions: [
             {
               messageId: 'updateImports',
-              output: "import { userEvent, foo, bar as Bar } from '@storybook/testing-library'",
+              output: "import { userEvent, foo, bar as Bar } from 'storybook/test'",
             },
           ],
         },

--- a/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts
+++ b/code/lib/eslint-plugin/src/rules/use-storybook-testing-library.ts
@@ -27,7 +27,7 @@ export default createStorybookRule({
     messages: {
       updateImports: 'Update imports',
       dontUseTestingLibraryDirectly:
-        'Do not use `{{library}}` directly in the story. You should import the functions from `@storybook/test` (preferrably) or `@storybook/testing-library` instead.',
+        'Do not use `{{library}}` directly in the story. You should import the functions from `storybook/test` instead.',
     },
   },
 
@@ -104,7 +104,7 @@ export default createStorybookRule({
             *fix(fixer) {
               yield fixer.replaceTextRange(
                 getRangeWithoutQuotes(node.source),
-                '@storybook/testing-library'
+                'storybook/test'
               );
               if (hasDefaultImport(node.specifiers)) {
                 const specifiers = getSpecifiers(node);
@@ -120,7 +120,7 @@ export default createStorybookRule({
                 *fix(fixer) {
                   yield fixer.replaceTextRange(
                     getRangeWithoutQuotes(node.source),
-                    '@storybook/testing-library'
+                    'storybook/test'
                   );
                   if (hasDefaultImport(node.specifiers)) {
                     const specifiers = getSpecifiers(node);


### PR DESCRIPTION
Fixes #34422

The `use-storybook-testing-library` ESLint rule was recommending the deprecated `@storybook/test` package in the error message and auto-fixing imports to `@storybook/testing-library`. Since Storybook 9.0, the correct package is `storybook/test`.

**Changes:**
- Error message now says `storybook/test` instead of `@storybook/test`
- Auto-fix now replaces `@testing-library/*` imports with `storybook/test` instead of `@storybook/testing-library`
- Tests: added both `storybook/test` and `@storybook/testing-library` as valid imports (the legacy package is still accepted), updated expected fix output to `storybook/test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ESLint rule to recommend importing from `storybook/test` instead of `@storybook/testing-library` for testing utilities, with corresponding auto-fix updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->