### PR TITLE
WIP: Demo run of docs-review skill to update Stories docs section

### DIFF
--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -73,6 +73,8 @@ Read the page and classify it using the doc types in `references/docs-strategy.m
 
 Always select **one** primary type, even if the page contains secondary elements.
 
+After selecting the primary type, identify any **secondary sections** — sections with their own heading whose content follows a different doc type's shape. Note these for Step 3. See "Common Secondary Sections" in `references/docs-strategy.md` for expected combinations.
+
 ### 3. Diagnose the Draft
 
 Evaluate the page against the quality dimensions in `references/docs-principles.md`, in order:
@@ -84,6 +86,8 @@ Evaluate the page against the quality dimensions in `references/docs-principles.
 5. Task usability
 6. Example quality
 7. Economy
+
+For secondary sections, evaluate dimensions 3 (Information Shape) and 5 (Task Usability) against the secondary section's own doc type, not the page's primary type. All other dimensions apply page-wide.
 
 If the page shows signs of structural weakness, load `references/docs-antipatterns.md` and check for common patterns.
 
@@ -99,7 +103,7 @@ Use the thresholds in `references/docs-strategy.md`:
 
 **Hard rule:** When the draft is structurally weak, do not stop at sentence-level edits. Reorder, split, replace examples, or rewrite the page shape.
 
-**Split/escalation rule:** If the dominant job is unclear or the page serves multiple unrelated jobs, switch to `strategy` mode or recommend a page split before polishing.
+**Split/escalation rule:** If the dominant job is unclear or the page serves multiple unrelated jobs, switch to `strategy` mode or recommend a page split before polishing. Well-structured secondary sections (see `references/docs-strategy.md`) are not a reason to split.
 
 ### 5. Improve or Plan
 

--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: docs-review
+description: Review, improve, rewrite, author, or plan Storybook documentation in /docs. Use this when asked to review docs, improve a page, rewrite documentation, draft new docs, or advise on docs strategy.
+---
+
+# Documentation Review
+
+## Scope
+
+This skill applies to documentation files in `/docs` and docs-owned snippet files in `docs/_snippets/`. Do not use this skill for non-docs files (code, configuration, READMEs outside `/docs`).
+
+## Use This Skill When
+
+- Asked to review, improve, rewrite, or author documentation in `/docs`.
+- Asked for advice on page structure, doc type, audience, or content strategy for `/docs`.
+- Asked to fix formatting, style, or compliance issues in `/docs`.
+
+## Use a Light Touch When
+
+- The request is a trivial grammar or typo fix that does not need full diagnosis.
+- The page is already structurally sound and only needs minor editorial cleanup.
+
+## Reference Files
+
+This skill uses four reference files under `references/`. Load them in order and only as needed:
+
+| File | Owns | When to Load |
+|------|------|--------------|
+| `references/docs-principles.md` | North star, quality dimensions, dual-reader requirement | Always — read first |
+| `references/docs-strategy.md` | Modes, doc types, intervention thresholds, page-shape guidance | Always — read second |
+| `references/docs-antipatterns.md` | Diagnosis patterns and corrective moves | When diagnosing a weak or confusing draft |
+| `references/storybook-style.md` | Editorial, MDX components, frontmatter, formatting, validation rules | In `maintenance` mode, or as the final pass of edit modes |
+
+### Ownership Rules
+
+- Strategy references do not own formatting or component rules.
+- `storybook-style.md` does not own doc-type or intervention logic.
+- This file (`SKILL.md`) owns workflow and handoffs only.
+
+## Workflow
+
+Follow this sequence for every request. Steps 1–4 are diagnosis; steps 5–7 are action.
+
+### 1. Determine the Requested Outcome
+
+Read the user's request and map it to a mode:
+
+| Request Pattern | Mode |
+|----------------|------|
+| "Fix links, callouts, formatting" | `maintenance` |
+| "Make this clearer", "improve this page" | `improve` |
+| "This doc is a mess; rewrite it" | `rewrite` |
+| "Draft docs for feature X" | `author` |
+| "What kind of page should this be?" | `strategy` |
+| "Review this doc" (unspecified) | **hybrid** — see below |
+
+**Hybrid behavior:** For vague asks like "review this doc":
+- If the draft is obviously weak or the ask implies planning → critique-first (lead with diagnosis).
+- If the page is decent and the ask implies cleanup → improve-first (lead with edits).
+
+**Default:** When ambiguous, default to `improve`, not `maintenance`.
+
+### 2. Determine the Primary Doc Type
+
+Read the page and classify it using the doc types in `references/docs-strategy.md`:
+
+- `concept` — explains what something is and why it matters
+- `task` — walks the reader through accomplishing a goal
+- `reference` — lookup for options, API, or config
+- `troubleshooting` — diagnose and fix a problem
+- `migration` — move from one version or approach to another
+- `decision guide` — choose between options
+
+Always select **one** primary type, even if the page contains secondary elements.
+
+### 3. Diagnose the Draft
+
+Evaluate the page against the quality dimensions in `references/docs-principles.md`, in order:
+
+1. Intent clarity
+2. Audience fit
+3. Information shape
+4. Conceptual clarity
+5. Task usability
+6. Example quality
+7. Economy
+
+If the page shows signs of structural weakness, load `references/docs-antipatterns.md` and check for common patterns.
+
+### 4. Choose the Intervention Level
+
+Use the thresholds in `references/docs-strategy.md`:
+
+- No structural issues, minor style problems → `maintenance`
+- Structure is okay but framing, order, or examples are weak → `improve`
+- Structure is wrong for the page's job → `rewrite`
+- Page does not exist → `author`
+- User wants advice, not edits → `strategy`
+
+**Hard rule:** When the draft is structurally weak, do not stop at sentence-level edits. Reorder, split, replace examples, or rewrite the page shape.
+
+**Split/escalation rule:** If the dominant job is unclear or the page serves multiple unrelated jobs, switch to `strategy` mode or recommend a page split before polishing.
+
+### 5. Improve or Plan
+
+Execute based on the chosen mode:
+
+- **`maintenance`:** Apply editorial and compliance fixes. Load `references/storybook-style.md` as primary guide.
+- **`improve`:** Strengthen framing, order, explanation, and examples. Keep the page's identity. Use `references/storybook-style.md` for the final pass.
+- **`rewrite`:** Materially replace the page. Preserve sound content; discard or restructure the rest. Use `references/storybook-style.md` for the final pass.
+- **`author`:** Write the page from scratch using the primary doc type's shape as a guide. Use `references/storybook-style.md` for the final pass.
+- **`strategy`:** Return a planning artifact containing:
+  - Audience
+  - Page job
+  - Primary doc type
+  - Recommended outline
+  - Split/merge recommendation (if applicable)
+  - Preserve list (content worth keeping)
+  - Do **not** edit files or run validation.
+
+When editing, you may also improve docs-owned snippet files in `docs/_snippets/` if example quality depends on them.
+
+### 6. Apply Storybook Style
+
+For edit modes (`maintenance`, `improve`, `rewrite`, `author`):
+
+- Load `references/storybook-style.md` if not already loaded.
+- Apply voice, tone, heading, link, component, and frontmatter rules.
+- This step is always downstream of structural and editorial work — never the first pass.
+
+### 7. Validate
+
+For edit modes only:
+
+```bash
+yarn fmt:write
+yarn docs:check
+```
+
+Fix any errors reported by `yarn docs:check`, then run it again to confirm.
+
+**Do not run validation in `strategy` mode** or when no files were edited.
+
+## Handoffs
+
+- **PR creation:** Do not create a PR automatically. If the user asks for end-to-end execution including a PR, hand off to the `pr` skill.
+- **Snippet files:** This skill may edit files in `docs/_snippets/` when example quality requires it, but does not own snippet creation for non-docs purposes.

--- a/.agents/skills/docs-review/references/docs-antipatterns.md
+++ b/.agents/skills/docs-review/references/docs-antipatterns.md
@@ -10,13 +10,15 @@ Each antipattern includes the problem, how to recognize it, and what to do about
 
 **Fix:** Open with what the thing is and what the reader can do with it. Move background to a later section or inline it where it supports a specific point.
 
-## 2. Mixed Concept/Task/Reference Shape
+## 2. Unseparated Mixed Doc Types
 
-**Problem:** A single page tries to explain a concept, walk through a procedure, and serve as an API reference. The reader cannot scan for what they need.
+**Problem:** A single page interleaves explanatory prose, step-by-step instructions, and reference tables without clear sectional boundaries. The reader cannot scan for what they need.
 
-**Recognize it:** The page alternates between explanatory prose, step-by-step instructions, and option/config tables with no clear structure guiding the transitions.
+**Recognize it:** The page alternates between doc type shapes *within the same sections* — e.g., conceptual paragraphs between procedure steps, or config tables dropped mid-narrative with no heading. There are no clear headings signaling a transition from one type of content to another.
 
-**Fix:** Identify the primary doc type. Extract secondary content into its own section with a clear heading, or recommend splitting into separate pages. The primary type determines the page's shape.
+**Not this antipattern:** A page with a clear primary type and well-separated secondary sections (each with its own heading and following its own type's shape) is fine. See "Common Secondary Sections" in `docs-strategy.md`.
+
+**Fix:** Identify the primary doc type. For secondary content that belongs on this page, extract it into its own clearly headed section and ensure it follows its type's shape. For secondary content large enough to stand alone, recommend splitting into a separate page. The primary type determines the page's overall shape.
 
 ## 3. Edge Cases Before the Default Path
 

--- a/.agents/skills/docs-review/references/docs-antipatterns.md
+++ b/.agents/skills/docs-review/references/docs-antipatterns.md
@@ -1,0 +1,83 @@
+# Docs Antipatterns
+
+Each antipattern includes the problem, how to recognize it, and what to do about it.
+
+## 1. Background-First Opening
+
+**Problem:** The page opens with history, motivation, or context before telling the reader what the page is about or what they will be able to do.
+
+**Recognize it:** The first heading or paragraph talks about why something was built, how it evolved, or what problem it solves in the abstract — before stating what the feature *is*.
+
+**Fix:** Open with what the thing is and what the reader can do with it. Move background to a later section or inline it where it supports a specific point.
+
+## 2. Mixed Concept/Task/Reference Shape
+
+**Problem:** A single page tries to explain a concept, walk through a procedure, and serve as an API reference. The reader cannot scan for what they need.
+
+**Recognize it:** The page alternates between explanatory prose, step-by-step instructions, and option/config tables with no clear structure guiding the transitions.
+
+**Fix:** Identify the primary doc type. Extract secondary content into its own section with a clear heading, or recommend splitting into separate pages. The primary type determines the page's shape.
+
+## 3. Edge Cases Before the Default Path
+
+**Problem:** Exceptions, caveats, and special configurations appear before the reader sees the standard approach.
+
+**Recognize it:** The first code example or instruction set handles a non-default scenario. Callouts with warnings appear before the basic usage.
+
+**Fix:** Lead with the default path. Move edge cases, exceptions, and advanced configuration after the reader has seen the standard approach. Exception: safety-critical warnings that must precede action.
+
+## 4. Technically Valid but Weak Examples
+
+**Problem:** Code examples are syntactically correct but do not represent realistic usage. They teach the API surface without showing how a real project would use the feature.
+
+**Recognize it:** Examples use placeholder names like `foo`/`bar`, show only the minimum required props, or demonstrate a feature in isolation from any meaningful context.
+
+**Fix:** Replace with examples that reflect real usage patterns. Use realistic component names, props, and data. Show enough context that the reader can adapt the example to their own project.
+
+## 5. Late Term Definition
+
+**Problem:** A key term is used several times before it is defined. The reader must re-read earlier sections once they finally encounter the definition.
+
+**Recognize it:** A Storybook-specific term (e.g., "decorator", "loader", "play function") appears in the opening paragraphs but is not defined or linked until later.
+
+**Fix:** Define or link the term on first use. If the page is *about* the term, the opening sentence should define it.
+
+## 6. Feature List Without Helping the Reader Act or Decide
+
+**Problem:** The page lists what a feature can do without helping the reader understand when to use it, how to choose between options, or what to do next.
+
+**Recognize it:** Bullet points or paragraphs describe capabilities ("X supports Y", "You can also Z") without connecting them to reader goals or decisions.
+
+**Fix:** Frame capabilities around reader tasks or decisions. "Use X when you need Y" is more useful than "X supports Y."
+
+## 7. Buried Procedure Outcome
+
+**Problem:** A task page walks through steps but never states what the reader will have when they are done. The outcome is implied, not stated.
+
+**Recognize it:** The procedure ends with the last step. There is no "you should now see…" or "this gives you…" summary.
+
+**Fix:** State the expected outcome after the procedure. If possible, show what success looks like (a screenshot, a terminal output, or a description of the resulting behavior).
+
+## 8. Preserving Weak Structure Because It Is "Clean"
+
+**Problem:** A page has correct grammar, consistent formatting, and no broken links — but its structure does not serve the reader. A `maintenance` pass would miss the real issue.
+
+**Recognize it:** The page feels polished but unhelpful. Readers would need to read the whole page to find what they need. Sections are ordered by implementation detail rather than reader need.
+
+**Fix:** Escalate to `improve` or `rewrite`. Clean formatting is not a reason to preserve a page shape that does not work.
+
+## 9. Overexplaining Basics While Underexplaining Storybook-Specific Behavior
+
+**Problem:** The page spends space on concepts the target audience already knows (e.g., what a component is, how imports work) while glossing over Storybook-specific behavior that is actually confusing.
+
+**Recognize it:** Paragraphs explaining general web development concepts sit alongside one-sentence descriptions of Storybook features that have no obvious analog.
+
+**Fix:** Assume basic web development knowledge (HTML, CSS, JavaScript, components). Invest explanation space in Storybook-specific concepts, behaviors, and mental models.
+
+## 10. Tightening Prose When Rewrite Is Actually Needed
+
+**Problem:** Sentence-level edits are applied to a page whose fundamental organization is wrong. The page gets shorter and cleaner but remains unhelpful.
+
+**Recognize it:** After a pass of prose tightening, the page still does not clearly serve its intended job. The reader's experience is not materially better.
+
+**Fix:** Step back and diagnose at the page level. If the shape is wrong, restructure or rewrite — do not keep polishing.

--- a/.agents/skills/docs-review/references/docs-principles.md
+++ b/.agents/skills/docs-review/references/docs-principles.md
@@ -1,0 +1,46 @@
+# Docs Principles
+
+## North Star
+
+Good documentation reduces **time-to-understanding** or **time-to-success** for the reader. Every edit, restructure, or rewrite should move the page closer to one of these outcomes.
+
+## Dual-Reader Requirement
+
+Storybook docs must work for two audiences simultaneously:
+
+1. **Frontend developers** scanning for answers, examples, and steps they can act on immediately.
+2. **LLMs and retrieval systems** that parse docs for accurate, structured information to surface in AI-assisted workflows.
+
+Write for the human first. Structure for both.
+
+## Quality Dimensions
+
+Use these dimensions to evaluate whether a page is doing its job. They are ordered from most structural to most surface-level — fix the top of the list before polishing the bottom.
+
+### 1. Intent Clarity
+
+The page states what it will help the reader do or understand within the first two sentences. A reader (or retrieval system) can decide whether this page is relevant without scrolling.
+
+### 2. Audience Fit
+
+The page assumes the right level of prior knowledge. It does not over-explain web fundamentals or under-explain Storybook-specific behavior. It meets the reader where they are.
+
+### 3. Information Shape
+
+The page is organized around the reader's task or question, not around the feature's implementation. Sections follow a logical progression: context → action → result, or definition → usage → edge cases.
+
+### 4. Conceptual Clarity
+
+Abstract ideas are grounded in concrete terms. Relationships between concepts are explicit. The reader can build a mental model, not just follow steps.
+
+### 5. Task Usability
+
+Procedures are complete, ordered, and testable. The reader can follow them without guessing at missing steps. The default path comes first; variations and edge cases follow.
+
+### 6. Example Quality
+
+Code examples are representative of real usage, not minimal to the point of being misleading. They demonstrate the concept or task the page is about, not just syntactic validity.
+
+### 7. Economy
+
+Every sentence earns its place. Redundant explanations, filler transitions, and throat-clearing preamble are removed. Brevity serves the reader — but not at the cost of clarity.

--- a/.agents/skills/docs-review/references/docs-principles.md
+++ b/.agents/skills/docs-review/references/docs-principles.md
@@ -27,7 +27,7 @@ The page assumes the right level of prior knowledge. It does not over-explain we
 
 ### 3. Information Shape
 
-The page is organized around the reader's task or question, not around the feature's implementation. Sections follow a logical progression: context → action → result, or definition → usage → edge cases.
+The page is organized around the reader's task or question, not around the feature's implementation. Sections follow a logical progression: context → action → result, or definition → usage → edge cases. When a page contains secondary sections of a different doc type, each section follows the progression appropriate to its own type.
 
 ### 4. Conceptual Clarity
 

--- a/.agents/skills/docs-review/references/docs-strategy.md
+++ b/.agents/skills/docs-review/references/docs-strategy.md
@@ -1,0 +1,60 @@
+# Docs Strategy
+
+## Modes
+
+The skill operates in one of five modes. Select the mode before doing any substantive work.
+
+| Mode | When to use | Output |
+|------|-------------|--------|
+| `maintenance` | The page is structurally sound; only editorial, compliance, or formatting fixes are needed. | Clean up style, components, frontmatter, and formatting. Run validation. |
+| `improve` | The page works but could be clearer, better organized, or better illustrated. | Strengthen framing, order, explanation, and examples while keeping the page's identity. Run validation. |
+| `rewrite` | Local edits will not fix the page because its shape, framing, or scope is fundamentally wrong. | Materially replace the page. Preserve any sound content; discard or restructure the rest. Run validation. |
+| `author` | A new page needs to be created, or a draft needs to be completed from notes or a brief. | Write the page from scratch using the appropriate doc type as a guide. Run validation. |
+| `strategy` | The user wants planning, not edits — page-job analysis, outline, split/merge recommendation. | Return a planning artifact: audience, page job, primary doc type, recommended outline, split/merge recommendation, and a preserve list. Do **not** run formatting or validation. |
+
+### Mode Selection Rules
+
+- If the user explicitly names a mode (e.g., "rewrite this"), use it.
+- If the user says "review this doc" without further specifics, use **hybrid behavior**:
+  - Critique-first for `strategy` asks or obviously weak drafts.
+  - Improve-first for normal cleanup or improvement asks.
+- If the request is ambiguous (e.g., "improve this doc", "make this better"), default to `improve`.
+- If diagnosis reveals the page is structurally weak, escalate from `improve` to `rewrite` — do not stop at sentence-level edits when the page shape is the problem.
+
+## Doc Types
+
+Every page has one primary doc type. Select it before editing. If the page contains secondary elements of another type, that is fine — but the primary type determines the page's shape and evaluation criteria.
+
+| Doc Type | Page Job | Shape |
+|----------|----------|-------|
+| `concept` | Help the reader understand what something is and why it matters. | Definition → mental model → relationship to other concepts → when to use. |
+| `task` | Help the reader accomplish a specific goal. | Goal statement → prerequisites → ordered steps → expected result → troubleshooting. |
+| `reference` | Help the reader look up specific details (options, API, config). | Brief intro → structured entries (name, type, default, description) → examples where helpful. |
+| `troubleshooting` | Help the reader diagnose and fix a problem. | Symptom → cause → fix → verification. |
+| `migration` | Help the reader move from one version or approach to another. | What changed → why → step-by-step migration path → breaking changes → verification. |
+| `decision guide` | Help the reader choose between options. | Decision context → options with trade-offs → recommendation → how to switch later. |
+
+### Mapping Overview Pages
+
+Overview pages in `/docs` (e.g., section landing pages) do not get a special type:
+
+- Default to `concept` — most overviews explain what a feature area is and how its parts relate.
+- Use `decision guide` when the page is primarily comparative (e.g., choosing a builder or renderer).
+
+### Split and Escalation
+
+If diagnosis reveals the page is overloaded — serving multiple jobs with no clear primary — switch to `strategy` mode or recommend a page split before polishing. Signs of overload:
+
+- The page mixes a conceptual explanation with a step-by-step procedure that could stand alone.
+- The page covers multiple unrelated features under one heading.
+- The page has grown an FAQ or troubleshooting section that rivals the main content in length.
+
+## Intervention Thresholds
+
+Use the smallest intervention that materially improves reader usefulness:
+
+- **No structural issues, minor style problems** → `maintenance`
+- **Structure is okay but framing, order, or examples are weak** → `improve`
+- **Structure is wrong for the page's job** → `rewrite`
+- **Page does not exist** → `author`
+- **User wants advice, not edits** → `strategy`

--- a/.agents/skills/docs-review/references/docs-strategy.md
+++ b/.agents/skills/docs-review/references/docs-strategy.md
@@ -23,7 +23,7 @@ The skill operates in one of five modes. Select the mode before doing any substa
 
 ## Doc Types
 
-Every page has one primary doc type. Select it before editing. If the page contains secondary elements of another type, that is fine — but the primary type determines the page's shape and evaluation criteria.
+Every page has one primary doc type. Select it before editing. A page may also contain **secondary sections** — clearly headed sections whose content follows a different doc type's shape. This is normal and expected. The primary type determines the page's overall shape and evaluation criteria; each secondary section is evaluated by its own type's criteria.
 
 | Doc Type | Page Job | Shape |
 |----------|----------|-------|
@@ -41,13 +41,37 @@ Overview pages in `/docs` (e.g., section landing pages) do not get a special typ
 - Default to `concept` — most overviews explain what a feature area is and how its parts relate.
 - Use `decision guide` when the page is primarily comparative (e.g., choosing a builder or renderer).
 
+### Common Secondary Sections
+
+Some doc type combinations appear frequently and are well-structured by convention:
+
+| Primary Type | Common Secondary Section | Example |
+|---|---|---|
+| `task` | `reference` — API options or configuration table at the end | A "Configure visual tests" task page ending with a table of config options. |
+| `task` | `troubleshooting` — common errors after the procedure | A "Set up Storybook" task page ending with "Common issues" entries. |
+| `concept` | `task` — brief how-to showing the concept in action | A "Decorators" concept page including a short "Add a decorator" procedure. |
+| `concept` | `reference` — summary table of related API surface | A "Controls" concept page ending with a table of annotation types. |
+| `migration` | `troubleshooting` — known issues during migration | A migration guide ending with "If you see error X" fix entries. |
+| `decision guide` | `reference` — comparison table of options | A "Choose a builder" page with a detailed feature-comparison table. |
+
+A secondary section is well-structured when it:
+
+1. Has its own clear heading that signals the content shift (e.g., "API reference", "Troubleshooting", "Quick start").
+2. Follows the shape expected for its doc type (e.g., a reference section uses structured entries, not prose).
+3. Supports the primary page job rather than introducing an unrelated topic.
+
 ### Split and Escalation
 
-If diagnosis reveals the page is overloaded — serving multiple jobs with no clear primary — switch to `strategy` mode or recommend a page split before polishing. Signs of overload:
+If diagnosis reveals the page is overloaded — serving multiple jobs with no clear primary — switch to `strategy` mode or recommend a page split before polishing.
 
-- The page mixes a conceptual explanation with a step-by-step procedure that could stand alone.
+**Not overload:** A page with well-structured secondary sections (see above) is not overloaded. A task page with a reference table at the end, or a concept page with a brief procedure, is normal.
+
+**Signs of genuine overload:**
+
+- The page has no clear primary doc type — two or more types compete for dominance with roughly equal weight.
 - The page covers multiple unrelated features under one heading.
-- The page has grown an FAQ or troubleshooting section that rivals the main content in length.
+- A secondary section has grown large enough to stand alone as its own page (rough signal: it exceeds half the length of the primary content).
+- Conceptual prose and step-by-step instructions are interleaved throughout the page rather than separated into distinct sections.
 
 ## Intervention Thresholds
 

--- a/.agents/skills/docs-review/references/storybook-style.md
+++ b/.agents/skills/docs-review/references/storybook-style.md
@@ -1,0 +1,228 @@
+# Storybook Style
+
+This file owns Storybook-specific editorial, MDX component, frontmatter, and validation rules. It does **not** own doc-type identification, mode routing, or intervention logic — those belong in `docs-strategy.md`.
+
+## Voice and Tone
+
+### Point of View
+
+- Second person ("you") for addressing the reader — this is the default.
+- First person plural ("we") when speaking from Storybook's perspective (e.g., "We recommend…") or walking through something together (e.g., "Let's take a look…").
+- Do not use first person singular ("I") or third person for the reader ("the user").
+
+### Tone
+
+- Professional but conversational — write as if explaining to a colleague, not a textbook.
+- Encouraging without being excessive — "That's great!" is fine occasionally; avoid over-the-top enthusiasm.
+- Solution-focused — emphasize what readers *can* accomplish rather than limitations.
+- Direct and confident — state recommendations clearly ("We recommend…") rather than hedging unnecessarily.
+
+### Sentence Structure
+
+- Prefer active voice over passive ("Storybook renders the component" not "The component is rendered by Storybook").
+- Use short, direct sentences for emphasis and introductions.
+- Longer sentences are acceptable when explaining complex relationships, but avoid run-ons.
+- Lead with purpose — open sections by stating what something is or why it matters, not with background.
+
+### Instructions
+
+- Use imperative mood for step-by-step instructions: "Run this command", "Add the following", "Create a new file".
+- Use suggestive phrasing for optional or alternative approaches: "You can also…", "You might want to…".
+- Use declarative phrasing to introduce code examples with context: "To define the args of a single story, use the `args` CSF story key:".
+
+### Contractions
+
+- Use contractions naturally (don't, can't, won't, you'll, it's, we're) — they reinforce the conversational tone.
+- Avoid contractions in callout warnings or other serious/cautionary contexts where precision matters.
+
+### Technical Terms
+
+- Define key terms on first use, then use them freely afterward (e.g., "Component Story Format (CSF)" then "CSF").
+- Link to related concepts rather than re-explaining them inline.
+- Assume basic web development knowledge (HTML, CSS, JavaScript, components) — don't over-explain fundamentals.
+- Use backticks for all code-like terms (see [Inline Formatting](#inline-formatting)).
+
+### Hedging
+
+- Use "can" for capabilities and "may" or "might" for conditional outcomes.
+- Use "should" for recommendations, "must" for requirements.
+- Use "typically" or "generally" when describing common patterns that have exceptions.
+- Don't hedge when the statement is straightforward — say "This adds…" not "This should add…".
+
+### Word Choice
+
+- Avoid minimizing language ("simply", "just", "easily", "obviously") — what's simple for one reader may not be for another.
+- Use "powerful", "useful", or "great" sparingly and only when warranted.
+- Be specific rather than vague — "renders in under 2 seconds" over "renders quickly".
+
+### Introducing Examples
+
+- Set up *why* before showing *how* — provide a brief sentence of context before code blocks.
+- Use patterns like: "Here's how you could…", "For example, if you…", "To do X, use Y:".
+- End the lead-in sentence with a colon when the code block directly follows.
+
+### Section Openings
+
+- Open with a 1–2 sentence summary of what the section covers and why it matters.
+- Get to the point quickly — minimize preamble.
+- The opening sentence should work as a standalone definition or value statement.
+
+### Paragraph Length
+
+- Keep paragraphs to 2–4 sentences for scannability.
+- Introductory paragraphs should be 1–2 sentences.
+- Break up longer explanations with headings, lists, or callouts.
+
+## Headings
+
+- H1 via frontmatter `title` only; never use `# Heading` in the body. `[auto]`
+- H2/H3 use sentence case (capitalize first word and proper nouns only).
+- Don't skip heading levels. `[auto]`
+
+## Links
+
+- Internal: relative paths to `.mdx` files, e.g. `[text](../path/to/file.mdx)`. `[auto]`
+- External: full URLs, always wrapped in markdown link syntax (no bare URLs in prose). `[auto]`
+
+## Lists
+
+- Unordered lists use `-` (not `*` or `+`). `[oxfmt]`
+
+## Inline Formatting
+
+- Backticks for file paths, function names, variable names, component names, CLI commands, config keys, type names.
+- Bold for UI labels and emphasis; italics sparingly.
+
+## Custom Components
+
+### Callout
+
+- Always specify `variant` (`"info"` or `"warning"`). Bare `<Callout>` is not allowed.
+- Standardized icon usage:
+  - 💡 — tips and helpful information (`variant="info"`)
+  - 🧪 — experimental/preview features (`variant="info"` or `variant="warning"`)
+  - ℹ️ — additional context (`variant="info"`)
+  - 📣 — announcements, combined with `title` prop (`variant="info"`)
+  - ♿ — accessibility-specific (`variant="info"`)
+  - ⚠️ — should use `variant="warning"`, not `variant="info"`. `[auto]`
+  - Icons are optional; if used, they must follow the mapping above.
+- `variant="positive"` is non-standard; use `variant="info"` instead. `[auto]`
+
+### Other Components
+
+- `<If renderer={[...]}>` / `<If notRenderer={[...]}>` — conditional rendering.
+- `<CodeSnippets path="..." />` — path must exist in `docs/_snippets/`. `[auto]`
+- `<Video src="..." />` — embedded video.
+- `<YouTubeCallout id="..." title="..." />` — YouTube embed.
+
+## Frontmatter
+
+- Values are not wrapped in quotes, unless the value contains special characters (e.g. `&`, `|`, `:`, commas) that require quoting. `[auto]`
+- When quoting is needed, use single quotes.
+- Only use `sidebar.title` when it differs from `title`. If it matches, omit it. `[auto]`
+
+**Good example:**
+
+```yaml
+---
+title: Component Story Format (CSF)
+sidebar:
+  title: CSF
+  order: 2
+---
+```
+
+**Bad example:**
+
+```yaml
+---
+title: "ArgTypes"
+sidebar:
+  title: "ArgTypes"
+  order: 2
+---
+```
+
+## Block JSX Elements
+
+Block-level JSX elements (e.g. `<Callout>`, `<details>`, `<If>`) follow these rules:
+
+- New line before and after elements (unless the content before/after is a comment, in which case there should be no new line between the comment and the element).
+- New line before and after content inside elements (`<summary>` is an exception — no new line between the opening `<details>` tag and the `<summary>` tag).
+- Content is not indented, except when the content would normally be indented (e.g. nested list items, content inside code blocks).
+
+**Good example:**
+
+````mdx
+<If renderer={['react']}>
+
+Other content.
+
+<Callout variant="info">
+
+This is a callout.
+
+- This is a list item inside the callout
+  - This is a nested list item inside the callout
+
+```json
+{
+  "key": "value"
+}
+```
+
+</Callout>
+
+More other content.
+
+<details>
+<summary>This is a summary</summary>
+
+This is content inside the details element.
+
+</details>
+
+More other content.
+
+</If>
+{/* End supported renderers */}
+````
+
+**Bad example:**
+
+````mdx
+<If renderer={['react']}>
+Other content.
+
+<Callout>
+This is a callout.
+
+- This is a list item inside the callout
+- This is a nested list item inside the callout
+
+```json
+{
+  "key": "value"
+}
+```
+
+</Callout>
+More other content.
+<details>
+
+<summary>This is a summary</summary>
+This is content inside the details element.
+
+</details>
+More other content.
+
+</If>
+
+{/* End supported renderers */}
+````
+
+## Validation
+
+Items marked `[auto]` above are checked by `yarn docs:check` (see `scripts/docs/check-docs.ts`). Items marked `[oxfmt]` are handled by `yarn fmt:write`.
+
+These are final-stage validation tools. Run them after structural and editorial work is complete, not as the first step.

--- a/docs/_snippets/component-loader.md
+++ b/docs/_snippets/component-loader.md
@@ -1,0 +1,349 @@
+```ts filename="TodoItem.stories.ts" renderer="angular" language="ts" tabTitle="CSF 3"
+import { type Meta, type StoryObj, moduleMetadata } from '@storybook/angular';
+
+import { CommonModule } from '@angular/common';
+
+import { TodoItem } from './TodoItem.component';
+
+const meta: Meta<TodoItem> = {
+  component: TodoItem,
+  decorators: [
+    moduleMetadata({
+      declarations: [TodoItem],
+      imports: [CommonModule],
+    }),
+  ],
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<TodoItem>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export const Primary: Story = {
+  render: (args, { loaded: { todo } }) => ({
+    props: {
+      args,
+      todo,
+    },
+  }),
+};
+```
+
+```jsx filename="TodoItem.stories.js|jsx" renderer="react" language="js"
+import { TodoItem } from './TodoItem';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export default {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => <TodoItem {...args} {...todo} />,
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+export const Primary = {};
+```
+
+```tsx filename="TodoItem.stories.ts|tsx" renderer="react" language="ts"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import { TodoItem } from './TodoItem';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+const meta = {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => <TodoItem {...args} {...todo} />,
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+} satisfies Meta<typeof TodoItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+```
+
+```jsx filename="TodoItem.stories.js|jsx" renderer="solid" language="js"
+import { TodoItem } from './TodoItem';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export default {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => <TodoItem {...args} {...todo} />,
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+export const Primary = {};
+```
+
+```tsx filename="TodoItem.stories.ts|tsx" renderer="solid" language="ts"
+import type { Meta, StoryObj } from 'storybook-solidjs-vite';
+
+import { TodoItem } from './TodoItem';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+const meta = {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => <TodoItem {...args} {...todo} />,
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+} satisfies Meta<typeof TodoItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+```
+
+```svelte filename="TodoItem.stories.svelte" renderer="svelte" language="js" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import TodoItem from './TodoItem.svelte';
+
+  const { Story } = defineMeta({
+    component: TodoItem,
+    render: template,
+    loaders: [
+      async () => ({
+        todo: await (
+          await fetch('https://jsonplaceholder.typicode.com/todos/1')
+        ).json(),
+      }),
+    ],
+  });
+</script>
+
+{#snippet template(args, { loaded: { todo } })}
+  <TodoItem {...args} {...todo} />
+{/snippet}
+
+<Story name="Primary" />
+```
+
+```js filename="TodoItem.stories.js" renderer="svelte" language="js" tabTitle="CSF 3"
+import TodoItem from './TodoItem.svelte';
+
+export default {
+  component: TodoItem,
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export const Primary = {
+  render: (args, { loaded: { todo } }) => ({
+    Component: TodoItem,
+    props: {
+      ...args,
+      todo,
+    },
+  }),
+};
+```
+
+```svelte filename="TodoItem.stories.svelte" renderer="svelte" language="ts" tabTitle="Svelte CSF"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import TodoItem from './TodoItem.svelte';
+
+  const { Story } = defineMeta({
+    component: TodoItem,
+    render: template,
+    loaders: [
+      async () => ({
+        todo: await (
+          await fetch('https://jsonplaceholder.typicode.com/todos/1')
+        ).json(),
+      }),
+    ],
+  });
+</script>
+
+{#snippet template(args, { loaded: { todo } })}
+  <TodoItem {...args} {...todo} />
+{/snippet}
+
+<Story name="Primary" />
+```
+
+```ts filename="TodoItem.stories.ts" renderer="svelte" language="ts" tabTitle="CSF 3"
+// Replace your-framework with svelte-vite or sveltekit
+import type { Meta, StoryObj } from '@storybook/your-framework';
+
+import TodoItem from './TodoItem.svelte';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/svelte/api/csf
+ * to learn how to use render functions.
+ */
+const meta = {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => ({
+    Component: TodoItem,
+    props: {
+      ...args,
+      ...todo,
+    },
+  }),
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+} satisfies Meta<typeof TodoItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+```
+
+```js filename="TodoItem.stories.js" renderer="vue" language="js"
+import TodoItem from './TodoItem.vue';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export default {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => ({
+    components: { TodoItem },
+    setup() {
+      return { args, todo: todo };
+    },
+    template: '<TodoItem :todo="todo" />',
+  }),
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+export const Primary = {};
+```
+
+```ts filename="TodoItem.stories.ts" renderer="vue" language="ts"
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+
+import TodoItem from './TodoItem.vue';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+const meta = {
+  component: TodoItem,
+  render: (args, { loaded: { todo } }) => ({
+    components: { TodoItem },
+    setup() {
+      return { args, todo: todo };
+    },
+    template: '<TodoItem :todo="todo" />',
+  }),
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+} satisfies Meta<typeof TodoItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+```
+
+```js filename="TodoItem.stories.js" renderer="web-components" language="js"
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export default {
+  component: 'demo-todo-item',
+  render: (args, { loaded: { todo } }) => TodoItem({ ...args, ...todo }),
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+export const Primary = {};
+```
+
+```ts filename="TodoItem.stories.ts" renderer="web-components" language="ts"
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+const meta: Meta = {
+  component: 'demo-todo-item',
+  render: (args, { loaded: { todo } }) => TodoItem({ ...args, ...todo }),
+  loaders: [
+    async () => ({
+      todo: await (await fetch('https://jsonplaceholder.typicode.com/todos/1')).json(),
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Primary: Story = {};
+```

--- a/docs/writing-stories/PLAN-2.md
+++ b/docs/writing-stories/PLAN-2.md
@@ -1,0 +1,118 @@
+# Plan: Re-review writing-stories docs with section-level classification
+
+## Context
+
+The `docs/writing-stories/` section was already improved by a demo run of `/docs-review`, but that run used the **old skill** that treated mixed doc types as an antipattern. The skill has since been updated (`2d1f06a2671`) to support **section-level classification** — well-structured secondary sections (e.g., a task section within a concept page) are now evaluated by their own doc type's criteria rather than triggering split recommendations.
+
+The previous run was too aggressive in some places, stripping well-structured secondary task sections that should have been preserved. This plan re-runs `/docs-review` on pages that need correction, using the updated skill.
+
+---
+
+## Pages that need a fresh `/docs-review` pass
+
+### 1. `index.mdx` — Rewrite (restore secondary sections)
+
+**Mode:** `rewrite` | **Primary type:** concept | **Secondary sections:** task
+
+The demo run converted this from a comprehensive tutorial into essentially a table of contents, removing multiple secondary task sections with code examples:
+
+- "Custom rendering" (framework-specific task guidance with code)
+- "Using the play function" (interaction testing with code example)
+- "Using parameters" (configuration with code example)
+- "Using decorators" (wrapper functionality with code examples)
+- "Stories for two or more components" (multi-component pattern with examples)
+
+These were **well-structured secondary task sections** within a concept overview — exactly the pattern the updated skill now supports. The rewrite should restore inline examples while keeping the streamlined structure.
+
+**What to preserve from the demo run:** The improved opening, the "Where to put stories" cleanup, the CSF streamlining, the "Next steps" section (as addition, not replacement).
+
+**What to restore from `next`:** Secondary task sections with code examples, adapted to be clearly headed and properly scoped. Use the phase-0.md strategy artifact as a guide, but don't strip task sections just because they're a different doc type.
+
+### 2. `build-pages-with-storybook.mdx` — Improve (restore context container pattern)
+
+**Mode:** `improve` | **Primary type:** task | **Secondary sections:** task (framework-specific)
+
+The demo run removed the detailed "Avoiding mocking dependencies" section (React/Solid only) which included:
+
+- Context-based container approach explanation
+- File structure example
+- Multiple implementation code examples
+- Mocking containers in Storybook example
+
+This was replaced with 3 summary paragraphs pointing to mocking-providers. The removed content is a well-structured, framework-specific task section that provides implementation details not found in the linked page.
+
+**Action:** Re-run `/docs-review` to evaluate whether this content should be restored as a secondary task section, or whether the mocking-providers page adequately covers it.
+
+### 3. `decorators.mdx` — Improve (evaluate with section-level lens)
+
+**Mode:** `improve` | **Primary type:** concept | **Secondary sections:** task, reference
+
+The demo run's changes here were mostly good (decorator ordering diagram, cleaner cross-refs). Re-run to evaluate secondary sections (e.g., "Context" reference section, framework-specific task sections) with the updated criteria.
+
+### 4. `loaders.mdx` — Improve (component loaders + section evaluation)
+
+**Mode:** `improve` | **Primary type:** concept | **Secondary sections:** task, reference
+
+Two issues:
+
+1. The "Component loaders" section (added by demo run) has only prose — needs a code example
+2. Re-evaluate secondary sections with the updated skill
+
+### 5. `args.mdx` — Improve (evaluate with section-level lens)
+
+**Mode:** `improve` | **Primary type:** concept | **Secondary sections:** task, reference
+
+Demo run changes were mostly formatting cleanup. Re-run to evaluate the React-specific "Setting args from within a story" task section and "Mapping to complex arg values" reference section with updated criteria.
+
+---
+
+## Pages that are fine as-is
+
+These pages had appropriate changes from the demo run that don't conflict with section-level classification:
+
+- `typescript.mdx` — formatting cleanup only
+- `parameters.mdx` — cross-reference additions
+- `play-function.mdx` — redundant opening removed
+- `naming-components-and-hierarchy.mdx` — CSF 3.0 qualifier removed, opening added
+- `tags.mdx` — formatting cleanup
+- `mocking-data-and-modules/*.mdx` — formatting and cross-reference improvements
+- `stories-for-multiple-components.mdx` — formatting cleanup
+- `choosing-the-right-api.mdx` — new page, well-structured
+
+---
+
+## Cross-reference audit (after re-reviews)
+
+**Mode:** `maintenance` across all files
+
+After the above passes settle, do a final cross-reference pass:
+
+1. Add `choosing-the-right-api.mdx` to "Next steps" in `index.mdx`
+2. Link `choosing-the-right-api.mdx` from `args.mdx`, `parameters.mdx`, `loaders.mdx`, `decorators.mdx`
+3. Ensure back-links to `index.mdx` from sub-pages that lack them
+
+---
+
+## Execution sequence
+
+1. `/docs-review` rewrite `index.mdx` (highest impact — shapes the rest)
+2. `/docs-review` improve `build-pages-with-storybook.mdx`
+3. `/docs-review` improve `decorators.mdx`, `loaders.mdx`, `args.mdx` (can be done in any order)
+4. Cross-reference audit (`maintenance` mode, all files)
+5. Verification: `yarn docs:check` && `yarn fmt:write`
+
+## Verification
+
+- `yarn docs:check` — validate snippet references, formatting, links
+- `yarn fmt:write` — auto-format
+- Spot-check rendered output for sidebar ordering, secondary section headings, and link correctness
+
+## Critical files
+
+- `docs/writing-stories/index.mdx` — restore secondary task sections
+- `docs/writing-stories/build-pages-with-storybook.mdx` — restore context container pattern
+- `docs/writing-stories/loaders.mdx` — add component loaders code example
+- `docs/writing-stories/decorators.mdx` — evaluate secondary sections
+- `docs/writing-stories/args.mdx` — evaluate secondary sections
+- `.agents/skills/docs-review/SKILL.md` — the updated skill definition
+- `.agents/skills/docs-review/references/docs-strategy.md` — section-level classification rules

--- a/docs/writing-stories/PLAN.md
+++ b/docs/writing-stories/PLAN.md
@@ -1,0 +1,145 @@
+# Plan: Improve the writing-stories docs section
+
+## Context
+
+The `/docs/writing-stories/` section (15 files) is Storybook's primary guide for story authoring. It has solid coverage but suffers from structural issues: the entry page is overloaded (18+ conditional blocks mixing concept/task/reference), sidebar ordering doesn't match a learning progression, composition info is fragmented across 3 pages, and several pages have content gaps or inconsistencies. This plan addresses these issues using the `/docs-review` skill.
+
+---
+
+## Phase 0: Strategy pass on `index.mdx`
+
+**Mode:** `strategy` | **Impact:** Unblocks Phases 1 and 2a
+
+`index.mdx` tries to be an intro, CSF format reference, rendering tutorial, and composition guide simultaneously. Run `/docs-review` in `strategy` mode to produce a split recommendation:
+
+- **Trimmed `index.mdx`** (concept): What a story is, where stories live, CSF at a high level, pointers to sub-pages
+- **Move out**: Custom rendering details (React hooks, Solid signals, render functions) to the CSF API reference or a new "Customizing story rendering" task page
+- **Move out**: Abbreviated "Using parameters/decorators/play function" sections become a "Next steps" list
+
+**Deliverable:** Strategy artifact with new outline, what to preserve, what to relocate.
+
+---
+
+## Phase 1: Sidebar reordering
+
+**Mode:** `maintenance` (frontmatter only) | **Impact:** High (navigation)
+
+Reorder to match a learning progression:
+
+| File                                  | New order | Rationale                       |
+| ------------------------------------- | --------- | ------------------------------- |
+| `index.mdx`                           | 1         | Entry point first               |
+| `args.mdx`                            | 2         | Core concept                    |
+| `typescript.mdx`                      | 3         | Types for what you just learned |
+| `parameters.mdx`                      | 4         | Static metadata                 |
+| `decorators.mdx`                      | 5         | Wrapping/context                |
+| `loaders.mdx`                         | 6         | Async data                      |
+| `tags.mdx`                            | 7         | Organization                    |
+| `play-function.mdx`                   | 8         | Interaction testing             |
+| `naming-components-and-hierarchy.mdx` | 9         | Sidebar org                     |
+| `mocking-data-and-modules/`           | 10        | Advanced                        |
+| `build-pages-with-storybook.mdx`      | 11        | Advanced composition            |
+| `stories-for-multiple-components.mdx` | 12        | Advanced composition            |
+
+---
+
+## Phase 2: High-impact content improvements
+
+### 2a. `index.mdx` -- Rewrite
+
+**Mode:** `rewrite` | **Doc type:** concept
+
+Execute the Phase 0 split:
+
+- 2-sentence intent-setting opening
+- Reduce conditional blocks from 18+ to ~6
+- Move React Hooks / Solid Signals / custom rendering details out
+- Replace inlined sub-page summaries with a "Next steps" list
+- Keep: what stories are, where they live, CSF overview, first example
+
+### 2b. `decorators.mdx` -- Improve
+
+**Mode:** `improve` | **Doc type:** task
+
+- Add explanation of _why_ decorator ordering matters (inner renders inside outer) with a concrete example
+- Expand "Using decorators to provide data" with one example or replace with direct cross-reference
+- Fix stray colon on line 57
+
+### 2c. `loaders.mdx` -- Improve
+
+**Mode:** `improve` | **Doc type:** task
+
+- Reframe opening: lead with use case (async data before render), then clarify when args/mocking are better
+- Add "Component loaders" section between story and global levels
+- Cross-reference parameter inheritance in "Loader inheritance" section
+- Add "See also" link to mocking section
+
+### 2d. `naming-components-and-hierarchy.mdx` -- Improve
+
+**Mode:** `improve` | **Doc type:** task
+
+- Remove "CSF 3.0" version qualifier (it's been default since Storybook 7)
+- Add intent-setting opening sentence
+- Add connection back to `index.mdx`
+
+---
+
+## Phase 3: Targeted content fixes
+
+### 3a. `mocking-modules.mdx` -- Improve
+
+- Address TODO on line 12: replace React-only inline example with `<CodeSnippets>` or add framework-agnostic note
+
+### 3b. `build-pages-with-storybook.mdx` -- Improve
+
+- Add note for non-React/Solid users pointing to mocking sub-section
+- Trim "Avoiding mocking dependencies" (move detailed React context pattern to mocking-providers page)
+- Strengthen "Args composition for presentational screens" (the unique value of this page)
+
+### 3c. `play-function.mdx` -- Maintenance
+
+- Remove redundant opening paragraph (nearly identical text repeated)
+
+### 3d. `parameters.mdx` -- Maintenance
+
+- Add cross-reference to `loaders.mdx` in "Rules of parameter inheritance"
+
+---
+
+## Phase 4: Gap-filling
+
+### 4a. New decision guide: "Choosing the right story API"
+
+**Mode:** `author` | **Doc type:** decision guide
+
+Cover:
+
+- **Args vs loaders vs parameters**: Args for controllable inputs, parameters for addon config, loaders for async data
+- **Decorators vs render functions**: Decorators for wrapping, render for changing what renders
+- **Mocking approaches**: Module vs provider vs network
+
+Place at order ~8, shifting later pages.
+
+### 4b. Cross-reference audit
+
+**Mode:** `maintenance` (all files)
+
+Ensure:
+
+- Each sub-page links to `index.mdx` and related pages
+- Mocking section referenced from `loaders.mdx`, `decorators.mdx`, `build-pages-with-storybook.mdx`
+- Addons section referenced where addon behavior is discussed
+
+---
+
+## Execution approach
+
+Each step uses `/docs-review` with the specified mode and page. Work through phases sequentially (0 -> 1 -> 2 -> 3 -> 4). Within phases, pages can be done in any order.
+
+## Verification
+
+After each phase:
+
+- Run `yarn docs:check` to validate snippet references and formatting rules
+- Run `yarn fmt:write` to auto-format
+- Spot-check the Storybook docs site locally or review rendered MDX for readability

--- a/docs/writing-stories/args.mdx
+++ b/docs/writing-stories/args.mdx
@@ -1,7 +1,7 @@
 ---
 title: Args
 sidebar:
-  order: 1
+  order: 2
 ---
 
 <YouTubeCallout id="0gOfS6K0x0E" title="Build better UIs with Storybook Args" />

--- a/docs/writing-stories/args.mdx
+++ b/docs/writing-stories/args.mdx
@@ -10,7 +10,7 @@ A story is a component with a set of arguments that define how the component sho
 
 When an arg’s value changes, the component re-renders, allowing you to interact with components in Storybook’s UI via addons that affect args.
 
-Learn how and why to write stories in [the introduction](./index.mdx). For details on how args work, read on.
+Learn how and why to write stories in [the introduction](./index.mdx). For help deciding between args, parameters, and loaders, see [choosing the right API](./choosing-the-right-api.mdx). For details on how args work, read on.
 
 ## Args object
 

--- a/docs/writing-stories/build-pages-with-storybook.mdx
+++ b/docs/writing-stories/build-pages-with-storybook.mdx
@@ -1,7 +1,7 @@
 ---
 title: Building pages with Storybook
 sidebar:
-  order: 9
+  order: 12
   title: Building pages and screens
 ---
 
@@ -45,79 +45,28 @@ This approach is beneficial when the various subcomponents export a complex list
 
 ## Mocking connected components
 
-Connected components are components that depend on external data or services. For example, a full page component is often a connected component. When you render a connected component in Storybook, you need to mock the data or modules that the component depends on. There are various layers in which you can do that.
+Connected components depend on external data or services. When you render them in Storybook, you need to mock those dependencies. See the [mocking data and modules](./mocking-data-and-modules/index.mdx) section for full details on each approach:
 
-### [Mocking imports](./mocking-data-and-modules/mocking-modules.mdx)
+- [**Mocking modules**](./mocking-data-and-modules/mocking-modules.mdx) — control the behavior of imported modules
+- [**Mocking network requests**](./mocking-data-and-modules/mocking-network-requests.mdx) — intercept REST or GraphQL API calls
+- [**Mocking providers**](./mocking-data-and-modules/mocking-providers.mdx) — supply context providers with controlled values
 
-Components can depend on modules that are imported into the component file. These can be from external packages or internal to your project. When rendering those components in Storybook or testing them, you may want to mock those modules to control their behavior.
-
-### [Mocking API Services](./mocking-data-and-modules/mocking-network-requests.mdx)
-
-For components that make network requests (e.g., fetching data from a REST or GraphQL API), you can mock those requests in your stories.
-
-### [Mocking providers](./mocking-data-and-modules/mocking-providers.mdx)
-
-Components can receive data or configuration from context providers. For example, a styled component might access its theme from a ThemeProvider or Redux uses React context to provide components access to app data. You can mock a provider and the value it's providing and wrap your component with it in your stories.
-
-<If renderer={['react', 'solid']}>
-
-### Avoiding mocking dependencies
-
-It's possible to avoid mocking the dependencies of connected "container" components entirely by passing them around via props or React context. However, it requires a strict split of the container and presentational component logic. For example, if you have a component responsible for data fetching logic and rendering DOM, it will need to be mocked as previously described.
-
-It’s common to import and embed container components amongst presentational components. However, as we discovered earlier, we’ll likely have to mock their dependencies or the imports to render them within Storybook.
-
-Not only can this quickly grow to become a tedious task, but it’s also challenging to mock container components that use local states. So, instead of importing containers directly, a solution to this problem is to create a React context that provides the container components. It allows you to freely embed container components as usual, at any level in the component hierarchy without worrying about subsequently mocking their dependencies; since we can swap out the containers themselves with their mocked presentational counterpart.
-
-We recommend dividing context containers up over specific pages or views in your app. For example, if you had a `ProfilePage` component, you might set up a file structure as follows:
-
-```
-ProfilePage.js
-ProfilePage.stories.js
-ProfilePageContainer.js
-ProfilePageContext.js
-```
-
-<Callout variant="info" icon="💡">
-
-It’s also often helpful to set up a “global” container context (perhaps named `GlobalContainerContext`) for container components that may be rendered on every page of your app and add them to the top level of your application. While it’s possible to place every container within this global context, it should only provide globally required containers.
-
-</Callout>
-
-Let’s look at an example implementation of this approach.
-
-First, create a React context, and name it `ProfilePageContext`. It does nothing more than export a React context:
-
-<CodeSnippets path="mock-context-create.md" />
-
-`ProfilePage` is our presentational component. It will use the `useContext` hook to retrieve the container components from `ProfilePageContext`:
-
-<CodeSnippets path="mock-context-in-use.md" />
-
-#### Mocking containers in Storybook
-
-In the context of Storybook, instead of providing container components through context, we’ll instead provide their mocked counterparts. In most cases, the mocked versions of these components can often be borrowed directly from their associated stories.
-
-<CodeSnippets path="mock-context-container.md" />
+<If notRenderer={['react', 'solid']}>
 
 <Callout variant="info">
 
-If the same context applies to all `ProfilePage` stories, we can use a [decorator](./decorators.mdx).
+The mocking providers approach is most relevant for frameworks with context providers (like React and Solid). For your framework, [mocking modules](./mocking-data-and-modules/mocking-modules.mdx) and [mocking network requests](./mocking-data-and-modules/mocking-network-requests.mdx) are typically the best strategies.
 
 </Callout>
 
-#### Providing containers to your application
+</If>
 
-Now, in the context of your application, you’ll need to provide `ProfilePage` with all of the container components it requires by wrapping it with `ProfilePageContext.Provider`:
+<If renderer={[‘react’, ‘solid’]}>
 
-For example, in Next.js, this would be your `pages/profile.js` component.
+### Avoiding mocking dependencies
 
-<CodeSnippets path="mock-context-container-provider.md" />
+You can avoid mocking connected “container” components by splitting container and presentational logic and passing data via props or context. This requires a strict separation — if a component handles both data fetching and rendering, it will still need mocking.
 
-#### Mocking global containers in Storybook
-
-If you’ve set up `GlobalContainerContext`, you’ll need to set up a decorator within Storybook’s `preview.js` to provide context to all stories. For example:
-
-<CodeSnippets path="mock-context-container-global.md" />
+An alternative is to create a context that provides container components, allowing you to swap them with mocked presentational counterparts in Storybook. See [mocking providers](./mocking-data-and-modules/mocking-providers.mdx) for details on this approach.
 
 </If>

--- a/docs/writing-stories/build-pages-with-storybook.mdx
+++ b/docs/writing-stories/build-pages-with-storybook.mdx
@@ -65,8 +65,59 @@ The mocking providers approach is most relevant for frameworks with context prov
 
 ### Avoiding mocking dependencies
 
-You can avoid mocking connected “container” components by splitting container and presentational logic and passing data via props or context. This requires a strict separation — if a component handles both data fetching and rendering, it will still need mocking.
+You can avoid mocking connected “container” components entirely by splitting container and presentational logic, passing data via props or context. This requires a strict separation — if a component handles both data fetching and rendering, it will still need mocking.
 
-An alternative is to create a context that provides container components, allowing you to swap them with mocked presentational counterparts in Storybook. See [mocking providers](./mocking-data-and-modules/mocking-providers.mdx) for details on this approach.
+Rather than importing containers directly (which requires mocking their dependencies), you can create a context that provides the container components. This lets you freely embed containers at any level in the component hierarchy and swap them with mocked presentational counterparts in Storybook.
+
+We recommend dividing context containers by specific pages or views in your app. For example, if you have a `ProfilePage` component, you might set up a file structure like this:
+
+```
+ProfilePage.js
+ProfilePage.stories.js
+ProfilePageContainer.js
+ProfilePageContext.js
+```
+
+<Callout variant=”info” icon=”💡”>
+
+It’s also often helpful to set up a “global” container context (perhaps named `GlobalContainerContext`) for container components that may be rendered on every page of your app and add them to the top level of your application. While it’s possible to place every container within this global context, it should only provide globally required containers.
+
+</Callout>
+
+Here’s how to implement this approach:
+
+First, create a React context and name it `ProfilePageContext`. It does nothing more than export a React context:
+
+<CodeSnippets path=”mock-context-create.md” />
+
+`ProfilePage` is your presentational component. It uses the `useContext` hook to retrieve the container components from `ProfilePageContext`:
+
+<CodeSnippets path=”mock-context-in-use.md” />
+
+#### Mocking containers in Storybook
+
+In Storybook, instead of providing container components through context, you provide their mocked counterparts. In most cases, the mocked versions of these components can be borrowed directly from their associated stories.
+
+<CodeSnippets path=”mock-context-container.md” />
+
+<Callout variant=”info”>
+
+If the same context applies to all `ProfilePage` stories, you can use a [decorator](./decorators.mdx).
+
+</Callout>
+
+#### Providing containers to your application
+
+In your application, you need to provide `ProfilePage` with all of the container components it requires by wrapping it with `ProfilePageContext.Provider`:
+
+For example, in Next.js, this would be your `pages/profile.js` component.
+
+<CodeSnippets path=”mock-context-container-provider.md” />
+
+#### Mocking global containers in Storybook
+
+If you’ve set up `GlobalContainerContext`, you need to set up a decorator within Storybook’s `preview.js` to provide context to all stories. For example:
+
+<CodeSnippets path=”mock-context-container-global.md” />
 
 </If>

--- a/docs/writing-stories/choosing-the-right-api.mdx
+++ b/docs/writing-stories/choosing-the-right-api.mdx
@@ -1,0 +1,58 @@
+---
+title: Choosing the right story API
+sidebar:
+  order: 8
+  title: Choosing the right API
+---
+
+Storybook provides several APIs for controlling how stories receive data and render components. This guide helps you choose the right one for your situation.
+
+## Args vs parameters vs loaders
+
+These three APIs all provide data to your stories, but they serve different purposes:
+
+| API                                | Purpose                                 | Controllable via UI                             | When to use                                                                              |
+| ---------------------------------- | --------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [**Args**](./args.mdx)             | Component inputs (props, slots, inputs) | Yes, via [Controls](../essentials/controls.mdx) | Default choice for any data that maps to component inputs                                |
+| [**Parameters**](./parameters.mdx) | Static metadata for addons and features | No                                              | Configuring addon behavior (e.g., backgrounds, viewports) or attaching non-prop metadata |
+| [**Loaders**](./loaders.mdx)       | Async data fetched before render        | No                                              | Loading data from an API or performing async setup before the story renders              |
+
+**Start with args.** They integrate with Controls, actions, and other Storybook tooling. Use parameters when you need to configure addon behavior, not component behavior. Use loaders only when you need async data that can't be defined statically.
+
+## Decorators vs render functions
+
+Both decorators and render functions change what a story renders, but in different ways:
+
+| Approach                                     | What it does                                 | When to use                                                                                                                  |
+| -------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [**Decorators**](./decorators.mdx)           | Wrap a story in additional markup or context | Adding providers (theme, router, store), layout wrappers, or global setup that applies across stories                        |
+| [**Render functions**](../api/csf/index.mdx) | Replace what the story renders entirely      | Composing multiple components, passing args to non-standard positions, or rendering a component differently than its default |
+
+**Use decorators for wrapping, render functions for replacing.** If you need to add a provider or layout around a story, use a decorator. If you need to change _what_ renders (e.g., placing a Button inside an Alert), use a render function.
+
+Decorators can be shared across stories (component-level or global), while render functions are typically defined per-story or per-component.
+
+## Mocking approaches
+
+When your component depends on external data or services, choose the mocking approach that matches where the dependency lives:
+
+| Approach                                                                     | What it mocks                                     | When to use                                                    |
+| ---------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------- |
+| [**Module mocks**](./mocking-data-and-modules/mocking-modules.mdx)           | Imported modules (utilities, services, libraries) | The component imports a function or module you want to control |
+| [**Network mocks**](./mocking-data-and-modules/mocking-network-requests.mdx) | HTTP requests (REST, GraphQL)                     | The component fetches data from an API at render time          |
+| [**Provider mocks**](./mocking-data-and-modules/mocking-providers.mdx)       | Context providers (theme, auth, store)            | The component reads from a context provider                    |
+
+You can combine these approaches. For example, a page component might use provider mocks for its theme, module mocks for a utility function, and network mocks for its API calls.
+
+## Quick reference
+
+| I want to...                          | Use                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| Pass props to my component            | [Args](./args.mdx)                                                       |
+| Configure an addon                    | [Parameters](./parameters.mdx)                                           |
+| Fetch async data before render        | [Loaders](./loaders.mdx)                                                 |
+| Wrap my story in a provider or layout | [Decorators](./decorators.mdx)                                           |
+| Change what my story renders          | [Render function](../api/csf/index.mdx)                                  |
+| Control an imported module            | [Module mocks](./mocking-data-and-modules/mocking-modules.mdx)           |
+| Intercept API requests                | [Network mocks](./mocking-data-and-modules/mocking-network-requests.mdx) |
+| Supply a context provider             | [Provider mocks](./mocking-data-and-modules/mocking-providers.mdx)       |

--- a/docs/writing-stories/decorators.mdx
+++ b/docs/writing-stories/decorators.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 A decorator is a way to wrap a story in extra “rendering” functionality. Many addons define decorators to augment your stories with extra rendering or gather details about how your story renders.
 
-When writing stories, decorators are typically used to wrap stories with extra markup or context mocking.
+When [writing stories](./index.mdx), decorators are typically used to wrap stories with extra markup or context mocking. For help deciding between decorators and render functions, see [choosing the right API](./choosing-the-right-api.mdx).
 
 ## Wrap stories with extra markup
 
@@ -47,11 +47,11 @@ Some components require a “harness” to render in a useful way. For instance,
 The second argument to a decorator function is the **story context** which contains the properties:
 
 - `args` - the story arguments. You can use some [`args`](./args.mdx) in your decorators and drop them in the story implementation itself.
-- `argTypes`- Storybook's [argTypes](../api/arg-types.mdx) allow you to customize and fine-tune your stories [`args`](./args.mdx).
+- `argTypes` - Storybook’s [argTypes](../api/arg-types.mdx) allow you to customize and fine-tune your stories [`args`](./args.mdx).
 - `globals` - Storybook-wide [globals](../essentials/toolbars-and-globals.mdx#globals). In particular you can use the [toolbars feature](../essentials/toolbars-and-globals.mdx#global-types-and-the-toolbar-annotation) to allow you to change these values using Storybook’s UI.
-- `hooks` - Storybook's API hooks (e.g., `useArgs`, `useGlobals`). These are available in both decorators and story render functions. When using these hooks in a render function alongside framework hooks (e.g., React's `useState`, `useEffect`), use Storybook's hook equivalents from `storybook/preview-api` instead to avoid errors on re-render.
-- `parameters`- the story's static metadata, most commonly used to control Storybook's behavior of features and addons.
-- `viewMode`- Storybook's current active window (e.g., canvas, docs).
+- `hooks` - Storybook’s API hooks (e.g., `useArgs`, `useGlobals`). These are available in both decorators and story render functions. When using these hooks in a render function alongside framework hooks (e.g., React’s `useState`, `useEffect`), use Storybook’s hook equivalents from `storybook/preview-api` instead to avoid errors on re-render.
+- `parameters` - the story’s static metadata, most commonly used to control Storybook’s behavior of features and addons.
+- `viewMode` - Storybook’s current active window (e.g., canvas, docs).
 
 This context can be used to adjust the behavior of your decorator based on the story's arguments or other metadata. For example, you could create a decorator that allows you to optionally apply a layout to the story, by defining `parameters.pageLayout = 'page'` (or `'page-mobile'`):
 

--- a/docs/writing-stories/decorators.mdx
+++ b/docs/writing-stories/decorators.mdx
@@ -1,7 +1,7 @@
 ---
 title: Decorators
 sidebar:
-  order: 3
+  order: 5
 ---
 
 A decorator is a way to wrap a story in extra “rendering” functionality. Many addons define decorators to augment your stories with extra rendering or gather details about how your story renders.
@@ -54,7 +54,6 @@ The second argument to a decorator function is the **story context** which conta
 - `viewMode`- Storybook's current active window (e.g., canvas, docs).
 
 This context can be used to adjust the behavior of your decorator based on the story's arguments or other metadata. For example, you could create a decorator that allows you to optionally apply a layout to the story, by defining `parameters.pageLayout = 'page'` (or `'page-mobile'`):
-:
 
 <CodeSnippets path="decorator-parameterized-in-preview.md" />
 
@@ -82,7 +81,7 @@ The same applies to Storybook hooks you want to call in your decorator. For inst
 
 ### Using decorators to provide data
 
-If your components are “connected” and require side-loaded data to render, you can use decorators to provide that data in a mocked way without having to refactor your components to take that data as an arg. There are several techniques to achieve this. Depending on exactly how you are loading that data. Read more in the [building pages in Storybook](./build-pages-with-storybook.mdx) section.
+If your components require side-loaded data (e.g., from a context provider or global store), you can use decorators to provide that data in a mocked way without refactoring your components. See [mocking providers](./mocking-data-and-modules/mocking-providers.mdx) for details on wrapping stories with context providers, or [building pages in Storybook](./build-pages-with-storybook.mdx) for broader strategies.
 
 ## Story decorators
 
@@ -132,4 +131,14 @@ All decorators relevant to a story will run in the following order once the stor
 
 - Global decorators, in the order they are defined
 - Component decorators, in the order they are defined
-- Story decorators, in the order they are defined, starting from the innermost decorator and working outwards and up the hierarchy in the same order
+- Story decorators, in the order they are defined
+
+Each decorator wraps the result of the next one, so the first global decorator is the **outermost** wrapper and the last story decorator is the **innermost** (closest to the component). For example, if you define a global theme provider decorator and a story-level padding decorator, the rendered output looks like this:
+
+```
+Theme provider (global)
+  └─ Padding (story)
+       └─ Component
+```
+
+This ordering matters when decorators depend on each other. A decorator that reads from a context provider must be rendered _inside_ the decorator that provides that context.

--- a/docs/writing-stories/index.mdx
+++ b/docs/writing-stories/index.mdx
@@ -1,27 +1,17 @@
 ---
 title: How to write stories
 sidebar:
-  order: 2
+  order: 1
   title: Stories
 ---
 
-<If renderer="svelte">
-
-A story captures the rendered state of a UI component. Given a set of arguments, it can be a simple object with annotations or a component that describes its behavior and appearance.
-
-</If>
-
-<If notRenderer="svelte">
-
 A story captures the rendered state of a UI component. It's an object with annotations that describe the component's behavior and appearance given a set of arguments.
 
-</If>
-
-Storybook uses the generic term arguments (args for short) when talking about React’s `props`, Vue’s `props`, Angular’s `@Input`, and other similar concepts.
+Storybook uses the generic term arguments (args for short) when talking about React's `props`, Vue's `props`, Angular's `@Input`, and other similar concepts.
 
 ## Where to put stories
 
-A component’s stories are defined in a story file that lives alongside the component file. The story file is for development-only, and it won't be included in your production bundle. In your filesystem, it looks something like this:
+A component's stories are defined in a story file that lives alongside the component file. The story file is for development-only, and it won't be included in your production bundle. In your filesystem, it looks something like this:
 
 ```
 components/
@@ -34,7 +24,7 @@ components/
 
 <If renderer="svelte">
 
-We can define stories according to the [Component Story Format](../api/csf/index.mdx) (CSF), an ES6 module-based standard that is easy to write and portable between tools, or rely on the community-led project [`Svelte CSF`](https://storybook.js.org/addons/@storybook/addon-svelte-csf) which provides a similar experience.
+We define stories according to the [Component Story Format](../api/csf/index.mdx) (CSF), an ES6 module-based standard that is easy to write and portable between tools. You can also use the community-led [`Svelte CSF`](https://storybook.js.org/addons/@storybook/addon-svelte-csf) project, which provides a native Svelte authoring experience.
 
 With Svelte CSF, the essential elements are the `defineMeta` function, which describes the component, and the `Story` component, which describes the stories. This pattern is different from the standard CSF, which uses a [default export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#Using_the_default_export) and [named exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#Using_named_exports) to apply the same concepts.
 
@@ -52,7 +42,7 @@ The key ingredients are the meta (or [default export](https://developer.mozilla.
 
 <If renderer="svelte">
 
-The `defineMeta` function in Svelte CSF with native templating syntax controls how Storybook lists your stories and provides information used by addons. However, if you're not using this story format and relying on standard CSF, use the _default_ export to achieve the same result. Below is an example of a story file with both approaches:
+The `defineMeta` function in Svelte CSF controls how Storybook lists your stories and provides information used by addons. If you're using standard CSF instead, use the _default_ export to achieve the same result:
 
 <CodeSnippets path="button-story-default-export-with-component.md" />
 
@@ -60,7 +50,7 @@ The `defineMeta` function in Svelte CSF with native templating syntax controls h
 
 <If notRenderer="svelte">
 
-The _default_ export metadata controls how Storybook lists your stories and provides information used by addons. For example, here’s the meta (or default export) for a story file `Button.stories.js|ts`:
+The _default_ export metadata controls how Storybook lists your stories and provides information used by addons. For example, here's the meta for a story file `Button.stories.js|ts`:
 
 <CodeSnippets path="button-story-default-export-with-component.md" />
 
@@ -76,213 +66,50 @@ Starting with Storybook version 7.0, story titles are analyzed statically as par
 
 <If renderer="svelte">
 
-If you're using Svelte CSF, define your stories with the `Story` component, otherwise use the named exports of a standard CSF file. We recommend you use UpperCamelCase for your story exports. Here’s how to render `Button` in the “primary” state and export a story called `Primary` using both methods.
+If you're using Svelte CSF, define your stories with the `Story` component, otherwise use the named exports of a standard CSF file. We recommend you use UpperCamelCase for your story exports. Here's how to render `Button` in the "primary" state and export a story called `Primary`:
 
 </If>
 
 <If notRenderer="svelte">
 
-Use the _named_ exports of a CSF file to define your component’s stories. We recommend you use UpperCamelCase for your story exports. Here’s how to render `Button` in the “primary” state and export a story called `Primary`.
+Use the _named_ exports of a CSF file to define your component's stories. We recommend you use UpperCamelCase for your story exports. Here's how to render `Button` in the "primary" state and export a story called `Primary`:
 
 </If>
 
 <CodeSnippets path="button-story-with-args.md" />
 
-<If renderer="svelte">
-
-Unlike regular CSF, when using Svelte CSF, you cannot use [`args`](./args.mdx) for children. Instead, you pass children in-between the opening and closing `Story` tags and it will be passed to the component as the `children` snippet prop.
-
-```svelte title="Alert.stories.svelte"
-<script module>
-  import { defineMeta } from '@storybook/addon-svelte-csf';
-
-  import Alert from './Alert.svelte';
-
-  const { Story } = defineMeta({
-    component: Alert,
-  });
-</script>
-
-{/* Renders <Alert>Alert text</Alert> */}
-<Story name="Alert with children">
-  Alert text
-</Story>
-```
-
-If you want to render the children as the entire story itself, you can use the `asChild` prop of the `Story` component, which will ignore the default component rendering and render the children directly.
-
-```svelte title="Button.stories.svelte"
-<Story
-  name="Default Button in alert"
-  asChild
-/>
-  <Alert>
-    Alert text
-    <Button />
-  </Alert>
-</Story>
-```
-
-<Callout variant="warning">
-
-Note that features which require `args`, like [Controls](../essentials/controls.mdx), will not work when using `asChild`. You can customize the rendering of a story and retain the ability to use `args` by using a [custom render function](#custom-rendering).
-
-</Callout>
-
-</If>
-
-#### Custom rendering
-
-<If renderer="svelte">
-
-By default, stories will render the component defined in the `defineMeta` call (for Svelte CSF) or in the default export (for CSF), with the `args` passed to it.
-
-If you need to customize the rendering of your story, you can provide a snippet (for Svelte CSF) or a `render` function (for CSF) that accepts `args` and renders whatever you need.
-
-For example, if you want to render a `Button` inside an `Alert`:
-
-```svelte title="Button.stories.svelte"
-<Story
-  name="Primary in alert"
-  args={{
-    label: 'Button',
-    primary: true,
-  }}>
-  {#snippet template(args)}
-    <Alert>
-      Alert text
-      <Button {...args} />
-    </Alert>
-  {/snippet}
-</Story>
-```
-
-<Callout variant="info">
-
-Note how the template snippet or `render` function spreads `args` onto the Button component. This ensures that features like [Controls](../essentials/controls.mdx) will work as expected, allowing you to dynamically change the Button's properties in the Storybook UI.
-
-</Callout>
-
-You can re-use the same render function across stories by applying it at the meta level. For Svelte CSF, this can be done by defining the template snippet outside of the story and assigning it to the `render` property of the `defineMeta` function. For CSF, you can define a `render` function in the meta (or default export).
-
-```svelte title="Button.stories.svelte"
-<script module>
-  import { defineMeta } from '@storybook/addon-svelte-csf';
-  import Button from './Button.svelte';
-
-  const { Story } = defineMeta({
-    component: Button,
-    render: template,
-  });
-</script>
-
-{#snippet template(args)}
-  <Alert>
-    Alert text
-    <Button {...args} />
-  </Alert>
-{/snippet}
-
-<Story name="Default in alert" args={{ label: 'Button' }} />
-
-<Story name="Primary in alert" args={{ label: 'Button', primary: true }} />
-```
-
-Whatever you define at the meta level can be overridden at the story level, so you can still customize the rendering of individual stories if needed.
-
-Finally, `render` functions and template snippets receive a second `context` argument, which contains all other details for the story, including [`parameters`](./parameters.mdx), [`globals`](../essentials/toolbars-and-globals.mdx), and more.
-
-</If>
-
-<If notRenderer="svelte">
-
-By default, stories will render the component defined in the meta (or default export), with the `args` passed to it. If you need to render something else, you can provide a function to the `render` property that returns the desired output.
-
-For example, if you want to render a `Button` inside an `Alert`, you can define a custom render function like this:
-
-<CodeSnippets path="render-custom-in-story.md" />
-
-<Callout variant="info">
-
-Note how the `render` function spreads `args` onto the Button component. This ensures that features like [Controls](../essentials/controls.mdx) will work as expected, allowing you to dynamically change the Button's properties in the Storybook UI.
-
-</Callout>
-
-You can re-use the same render function across stories by applying it at the meta level:
-
-<CodeSnippets path="render-custom-in-meta.md" />
-
-Whatever you define at the meta level can be overridden at the story level, so you can still customize the rendering of individual stories if needed.
-
-Finally, `render` functions receive a second `context` argument, which contains all other details for the story, including [`parameters`](./parameters.mdx), [`globals`](../essentials/toolbars-and-globals.mdx), and more.
-
-</If>
-
-<If renderer="react">
-
-#### Working with React Hooks
-
-[React Hooks](https://react.dev/reference/react) are convenient helper methods to create components using a more streamlined approach. You can use them while creating your component's stories if you need them, although you should treat them as an advanced use case. We **recommend** [args](./args.mdx) as much as possible when writing your own stories. As an example, here’s a story that uses React Hooks to change the button's state:
-
-<CodeSnippets path="button-story.md" />
-
-</If>
-
-<If renderer="solid">
-
-#### Working with Solid Signals
-
-[Solid Signals](https://docs.solidjs.com/concepts/intro-to-reactivity) are convenient helper methods to create components using a more streamlined approach. You can use them while creating your component's stories if you need them, although you should treat them as an advanced use case. We **recommend** [args](./args.mdx) as much as possible when writing your own stories. As an example, here’s a story that uses Solid Signals to change the button's state:
-
-<CodeSnippets path="button-story.md" />
-
-</If>
+By default, Storybook renders the component from the meta with the story's `args` passed to it. If you need to customize how a story renders, you can provide a [`render` function](../api/csf/index.mdx) to control the output.
 
 ### Rename stories
 
-By default, Storybook uses the name of the story export as the basis for the story name. However, you can customize the name of your story by adding a `name` property to the story object. This is useful when you want to provide a more descriptive or user-friendly name for your story.
+You can customize the display name of a story by adding a `name` property to the story object. Storybook uses the export name by default.
 
 <If renderer="svelte">
 
-If you're using Svelte CSF, the `name` property is usually fairly descriptive and user-friendly already, so there is little need for renaming. However, the `name` is used as the basis for the export name, which must be unique within a file. In rare cases, this can lead to naming conflicts. For example, stories with the names "Primary" and "Primary!" would both be transformed to the "Primary" export name. To avoid this, you can use the `exportName` property to specify a unique export name for your story. `exportName` is also helpful to provide a more useful named export when re-using stories, e.g. as [portable stories](../api/portable-stories/portable-stories-vitest.mdx).
+With Svelte CSF, the `name` property is typically descriptive enough. However, because `name` determines the export name (which must be unique within a file), you may occasionally need the `exportName` property to resolve conflicts or to provide a more useful named export for [portable stories](../api/portable-stories/portable-stories-vitest.mdx).
 
 </If>
 
 <CodeSnippets path="button-story-rename-story.md" />
 
-<If notRenderer="svelte">
-
-Your story will now be shown in the sidebar with the given text.
-
-</If>
-
 {/* Maintaining a prior heading */}
 
 <a id="using-args" />
+<a id="custom-rendering" />
 
-## How to write stories
+## Writing stories with args
 
-<If renderer="svelte">
-
-With Svelte, stories can be defined as objects using standard CSF or with Svelte CSF's `Story` component. Both methods describe how to render a component. You can have multiple stories per component, and those stories can build upon one another. For example, we can add Secondary and Tertiary stories based on our Primary story above.
-
-</If>
-
-<If notRenderer="svelte">
-
-A story is an object that describes how to render a component. You can have multiple stories per component, and those stories can build upon one another. For example, we can add Secondary and Tertiary stories based on our Primary story from above.
-
-</If>
+You can have multiple stories per component, and those stories can build upon one another. For example, we can add Secondary and Tertiary stories based on our Primary story from above.
 
 <CodeSnippets path="button-story-using-args.md" />
 
-What’s more, you can import `args` to reuse when writing stories for other components, and it's helpful when you’re building composite components. For example, if we make a `ButtonGroup` story, we might remix two stories from its child component `Button`.
+You can also import args to reuse when writing stories for other components. This is helpful when building composite components. For example, if we make a `ButtonGroup` story, we might remix two stories from its child component `Button`:
 
 <CodeSnippets path="button-group-story.md" />
 
-When Button’s signature changes, you only need to change Button’s stories to reflect the new schema, and ButtonGroup’s stories will automatically be updated. This pattern allows you to reuse your data definitions across the component hierarchy, making your stories more maintainable.
+When Button's signature changes, you only need to change Button's stories to reflect the new schema, and ButtonGroup's stories will automatically be updated. This pattern allows you to reuse your data definitions across the component hierarchy, making your stories more maintainable.
 
-That’s not all! Each of the args from the story function are live editable using Storybook’s [Controls](../essentials/controls.mdx) panel. It means your team can dynamically change components in Storybook to stress test and find edge cases.
+Each of the args from the story function are live editable using Storybook's [Controls](../essentials/controls.mdx) panel. Your team can dynamically change components in Storybook to stress test and find edge cases.
 
 <Video src="../_assets/writing-stories/addon-controls-demo-optimized.mp4" />
 
@@ -294,7 +121,7 @@ You can also use the Controls panel to edit or save a new story after adjusting 
 
 <Callout variant="info">
 
-This feature is not supported with the Svelte CSF. To opt-in to this feature with Svelte, you must use Storybook's [Component Story Format](../api/csf/index.mdx).
+Editing and saving stories from the Controls panel is not supported with Svelte CSF. To use this feature with Svelte, you must use Storybook's [Component Story Format](../api/csf/index.mdx).
 
 </Callout>
 
@@ -304,67 +131,15 @@ Addons can enhance args. For instance, [Actions](../essentials/actions.mdx) auto
 
 <Video src="../_assets/writing-stories/addon-actions-demo-optimized.mp4" />
 
-### Using the play function
+## Next steps
 
-Storybook's `play` function is a convenient helper methods to test component scenarios that otherwise require user intervention. They're small code snippets that execute once your story renders. For example, suppose you wanted to validate a form component, you could write the following story using the `play` function to check how the component responds when filling in the inputs with information:
+Now that you understand the basics of writing stories, you can explore the rest of the story APIs:
 
-<CodeSnippets path="login-form-with-play-function.md" />
-
-You can interact with and debug your story's play function in the [interactions panel](../writing-tests/interaction-testing.mdx#debugging-interaction-tests).
-
-### Using parameters
-
-Parameters are Storybook’s method of defining static metadata for stories. A story’s parameters can be used to provide configuration to various addons at the level of a story or group of stories.
-
-For instance, suppose you wanted to test your Button component against a different set of backgrounds than the other components in your app. You might add a component-level `backgrounds` parameter:
-
-<CodeSnippets path="parameters-in-meta.md" />
-
-![Parameters background color](../_assets/writing-stories/parameters-background-colors.png)
-
-This parameter would instruct the backgrounds feature to reconfigure itself whenever a Button story is selected. Most features and addons are configured via a parameter-based API and can be influenced at a [global](./parameters.mdx#global-parameters), [component](./parameters.mdx#component-parameters), and [story](./parameters.mdx#story-parameters) level.
-
-### Using decorators
-
-Decorators are a mechanism to wrap a component in arbitrary markup when rendering a story. Components are often created with assumptions about ‘where’ they render. Your styles might expect a theme or layout wrapper, or your UI might expect specific context or data providers.
-
-<If renderer="svelte">
-
-A simple example is adding padding to a component’s stories. With Svelte, you
-can either use an auxiliary component to wrap your stories with the required
-spacing or layout elements, or ignore the concept of decorators entirely and
-define them inline in a template.
-
-<CodeSnippets path="margindecorator.md" />
-
-</If>
-
-<If notRenderer="svelte">
-
-A simple example is adding padding to a component’s stories. Accomplish this using a decorator that wraps the stories in a `div` with padding, like so:
-
-</If>
-
-<CodeSnippets path="button-story-component-decorator.md" />
-
-Decorators [can be more complex](./decorators.mdx#context-for-mocking) and are often provided by [addons](../configure/user-interface/storybook-addons.mdx). You can also configure decorators at the [story](./decorators.mdx#story-decorators), [component](./decorators.mdx#component-decorators) and [global](./decorators.mdx#global-decorators) level.
-
-## Stories for two or more components
-
-Sometimes you may have two or more components created to work together. For instance, if you have a parent `List` component, it may require child `ListItem` components.
-
-<CodeSnippets path="list-story-starter.md" />
-
-In such cases, it makes sense to [customize the rendering](#custom-rendering) to output the `List` component with different numbers of `ListItem` children.
-
-<CodeSnippets path="list-story-expanded.md" />
-
-You can also reuse _story data_ from the child `ListItem` in your `List` component. That’s easier to maintain because you don’t have to update it in multiple places.
-
-<CodeSnippets path="list-story-reuse-data.md" />
-
-<Callout variant="info" icon="💡">
-
-Note that there are disadvantages in writing stories like this as you cannot take full advantage of the args mechanism and composing args as you build even more complex composite components. For more discussion, see the [multi component stories](../writing-stories/stories-for-multiple-components.mdx) workflow documentation.
-
-</Callout>
+- [**Args**](./args.mdx) to learn how args work in detail
+- [**TypeScript**](./typescript.mdx) to write type-safe stories
+- [**Parameters**](./parameters.mdx) to configure static metadata for stories and addons
+- [**Decorators**](./decorators.mdx) to wrap stories with extra rendering or context
+- [**Loaders**](./loaders.mdx) to load async data before a story renders
+- [**Play function**](./play-function.mdx) to simulate user interactions after a story renders
+- [**Naming and hierarchy**](./naming-components-and-hierarchy.mdx) to organize your stories in the sidebar
+- [**Stories for multiple components**](./stories-for-multiple-components.mdx) to compose stories across components

--- a/docs/writing-stories/index.mdx
+++ b/docs/writing-stories/index.mdx
@@ -78,7 +78,155 @@ Use the _named_ exports of a CSF file to define your component's stories. We rec
 
 <CodeSnippets path="button-story-with-args.md" />
 
-By default, Storybook renders the component from the meta with the story's `args` passed to it. If you need to customize how a story renders, you can provide a [`render` function](../api/csf/index.mdx) to control the output.
+<If renderer="svelte">
+
+Unlike regular CSF, when using Svelte CSF, you cannot use [`args`](./args.mdx) for children. Instead, you pass children in-between the opening and closing `Story` tags and it will be passed to the component as the `children` snippet prop.
+
+```svelte title="Alert.stories.svelte"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Alert from './Alert.svelte';
+
+  const { Story } = defineMeta({
+    component: Alert,
+  });
+</script>
+
+{/* Renders <Alert>Alert text</Alert> */}
+<Story name="Alert with children">
+  Alert text
+</Story>
+```
+
+If you want to render the children as the entire story itself, you can use the `asChild` prop of the `Story` component, which will ignore the default component rendering and render the children directly.
+
+```svelte title="Button.stories.svelte"
+<Story
+  name="Default Button in alert"
+  asChild
+/>
+  <Alert>
+    Alert text
+    <Button />
+  </Alert>
+</Story>
+```
+
+<Callout variant="warning">
+
+Features which require `args`, like [Controls](../essentials/controls.mdx), will not work when using `asChild`. You can customize the rendering of a story and retain the ability to use `args` by using a [custom render function](#custom-rendering).
+
+</Callout>
+
+</If>
+
+### Custom rendering
+
+<If renderer="svelte">
+
+By default, stories will render the component defined in the `defineMeta` call (for Svelte CSF) or in the default export (for CSF), with the `args` passed to it.
+
+If you need to customize the rendering of your story, you can provide a snippet (for Svelte CSF) or a `render` function (for CSF) that accepts `args` and renders whatever you need.
+
+For example, if you want to render a `Button` inside an `Alert`:
+
+```svelte title="Button.stories.svelte"
+<Story
+  name="Primary in alert"
+  args={{
+    label: 'Button',
+    primary: true,
+  }}>
+  {#snippet template(args)}
+    <Alert>
+      Alert text
+      <Button {...args} />
+    </Alert>
+  {/snippet}
+</Story>
+```
+
+<Callout variant="info">
+
+The template snippet or `render` function spreads `args` onto the Button component. This ensures that features like [Controls](../essentials/controls.mdx) will work as expected, allowing you to dynamically change the Button's properties in the Storybook UI.
+
+</Callout>
+
+You can re-use the same render function across stories by applying it at the meta level. For Svelte CSF, define the template snippet outside of the story and assign it to the `render` property of the `defineMeta` function. For CSF, define a `render` function in the meta (or default export).
+
+```svelte title="Button.stories.svelte"
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Button from './Button.svelte';
+
+  const { Story } = defineMeta({
+    component: Button,
+    render: template,
+  });
+</script>
+
+{#snippet template(args)}
+  <Alert>
+    Alert text
+    <Button {...args} />
+  </Alert>
+{/snippet}
+
+<Story name="Default in alert" args={{ label: 'Button' }} />
+
+<Story name="Primary in alert" args={{ label: 'Button', primary: true }} />
+```
+
+Whatever you define at the meta level can be overridden at the story level, so you can still customize the rendering of individual stories if needed.
+
+Finally, `render` functions and template snippets receive a second `context` argument, which contains all other details for the story, including [`parameters`](./parameters.mdx), [`globals`](../essentials/toolbars-and-globals.mdx), and more.
+
+</If>
+
+<If notRenderer="svelte">
+
+By default, stories will render the component defined in the meta (or default export), with the `args` passed to it. If you need to render something else, you can provide a function to the `render` property that returns the desired output.
+
+For example, if you want to render a `Button` inside an `Alert`, you can define a custom render function like this:
+
+<CodeSnippets path="render-custom-in-story.md" />
+
+<Callout variant="info">
+
+The `render` function spreads `args` onto the Button component. This ensures that features like [Controls](../essentials/controls.mdx) will work as expected, allowing you to dynamically change the Button's properties in the Storybook UI.
+
+</Callout>
+
+You can re-use the same render function across stories by applying it at the meta level:
+
+<CodeSnippets path="render-custom-in-meta.md" />
+
+Whatever you define at the meta level can be overridden at the story level, so you can still customize the rendering of individual stories if needed.
+
+Finally, `render` functions receive a second `context` argument, which contains all other details for the story, including [`parameters`](./parameters.mdx), [`globals`](../essentials/toolbars-and-globals.mdx), and more.
+
+</If>
+
+<If renderer="react">
+
+#### Working with React Hooks
+
+[React Hooks](https://react.dev/reference/react) are convenient helper methods to create components using a more streamlined approach. You can use them while creating your component's stories if you need them, although you should treat them as an advanced use case. We **recommend** [args](./args.mdx) as much as possible when writing your own stories. As an example, here's a story that uses React Hooks to change the button's state:
+
+<CodeSnippets path="button-story.md" />
+
+</If>
+
+<If renderer="solid">
+
+#### Working with Solid Signals
+
+[Solid Signals](https://docs.solidjs.com/concepts/intro-to-reactivity) are convenient helper methods to create components using a more streamlined approach. You can use them while creating your component's stories if you need them, although you should treat them as an advanced use case. We **recommend** [args](./args.mdx) as much as possible when writing your own stories. As an example, here's a story that uses Solid Signals to change the button's state:
+
+<CodeSnippets path="button-story.md" />
+
+</If>
 
 ### Rename stories
 
@@ -131,15 +279,69 @@ Addons can enhance args. For instance, [Actions](../essentials/actions.mdx) auto
 
 <Video src="../_assets/writing-stories/addon-actions-demo-optimized.mp4" />
 
+## Using the play function
+
+Storybook's `play` function lets you test component scenarios that otherwise require user intervention. It's a small code snippet that executes once your story renders. For example, if you want to validate a form component, you could write the following story using the `play` function to check how the component responds when filling in the inputs with information:
+
+<CodeSnippets path="login-form-with-play-function.md" />
+
+You can interact with and debug your story's play function in the [interactions panel](../writing-tests/interaction-testing.mdx#debugging-interaction-tests).
+
+For more details, see [Play function](./play-function.mdx).
+
+## Using parameters
+
+Parameters are Storybook's method of defining static metadata for stories. A story's parameters can be used to provide configuration to various addons at the level of a story or group of stories.
+
+For instance, suppose you want to test your Button component against a different set of backgrounds than the other components in your app. You might add a component-level `backgrounds` parameter:
+
+<CodeSnippets path="parameters-in-meta.md" />
+
+![Parameters background color](../_assets/writing-stories/parameters-background-colors.png)
+
+This parameter instructs the backgrounds feature to reconfigure itself whenever a Button story is selected. Most features and addons are configured via a parameter-based API and can be influenced at a [global](./parameters.mdx#global-parameters), [component](./parameters.mdx#component-parameters), and [story](./parameters.mdx#story-parameters) level.
+
+For more details, see [Parameters](./parameters.mdx).
+
+## Using decorators
+
+Decorators are a mechanism to wrap a component in arbitrary markup when rendering a story. Components are often created with assumptions about 'where' they render. Your styles might expect a theme or layout wrapper, or your UI might expect specific context or data providers.
+
+A simple example is adding padding to a component's stories. Accomplish this using a decorator that wraps the stories in a `div` with padding, like so:
+
+<CodeSnippets path="button-story-component-decorator.md" />
+
+Decorators [can be more complex](./decorators.mdx#context-for-mocking) and are often provided by [addons](../configure/user-interface/storybook-addons.mdx). You can also configure decorators at the [story](./decorators.mdx#story-decorators), [component](./decorators.mdx#component-decorators), and [global](./decorators.mdx#global-decorators) level.
+
+For more details, see [Decorators](./decorators.mdx).
+
+## Stories for two or more components
+
+Sometimes you may have two or more components created to work together. For instance, if you have a parent `List` component, it may require child `ListItem` components.
+
+<CodeSnippets path="list-story-starter.md" />
+
+In such cases, it makes sense to [customize the rendering](#custom-rendering) to output the `List` component with different numbers of `ListItem` children.
+
+<CodeSnippets path="list-story-expanded.md" />
+
+You can also reuse _story data_ from the child `ListItem` in your `List` component. That's easier to maintain because you don't have to update it in multiple places.
+
+<CodeSnippets path="list-story-reuse-data.md" />
+
+<Callout variant="info" icon="💡">
+
+There are disadvantages in writing stories like this as you cannot take full advantage of the args mechanism and composing args as you build even more complex composite components. For more discussion, see the [multi component stories](./stories-for-multiple-components.mdx) workflow documentation.
+
+</Callout>
+
 ## Next steps
 
-Now that you understand the basics of writing stories, you can explore the rest of the story APIs:
+Now that you understand the basics of writing stories, explore the rest of the story APIs:
 
 - [**Args**](./args.mdx) to learn how args work in detail
 - [**TypeScript**](./typescript.mdx) to write type-safe stories
-- [**Parameters**](./parameters.mdx) to configure static metadata for stories and addons
-- [**Decorators**](./decorators.mdx) to wrap stories with extra rendering or context
-- [**Loaders**](./loaders.mdx) to load async data before a story renders
-- [**Play function**](./play-function.mdx) to simulate user interactions after a story renders
+- [**Choosing the right API**](./choosing-the-right-api.mdx) to pick the right approach for your use case
 - [**Naming and hierarchy**](./naming-components-and-hierarchy.mdx) to organize your stories in the sidebar
-- [**Stories for multiple components**](./stories-for-multiple-components.mdx) to compose stories across components
+- [**Tags**](./tags.mdx) to control which stories appear where
+- [**Mocking**](./mocking-data-and-modules/index.mdx) to isolate components from external dependencies

--- a/docs/writing-stories/loaders.mdx
+++ b/docs/writing-stories/loaders.mdx
@@ -1,28 +1,28 @@
 ---
 title: Loaders
 sidebar:
-  order: 5
+  order: 6
 ---
 
-Loaders are asynchronous functions that load data for a story and its [decorators](./decorators.mdx). A story's loaders run before the story renders, and the loaded data injected into the story via its render context.
+Loaders are asynchronous functions that run before a story renders, letting you fetch data from a remote API, load assets, or perform other async setup. The loaded data is injected into the story via its render context.
 
-Loaders can be used to load any asset, lazy load components, or fetch data from a remote API. This feature was designed as a performance optimization to handle large story imports. However, [args](./args.mdx) is the recommended way to manage story data. We're building up an ecosystem of tools and techniques around Args that might not be compatible with loaded data.
-
-They are an advanced feature (i.e., escape hatch), and we only recommend using them if you have a specific need that other means can't fulfill.
+Use loaders when your story needs async data that can't be defined statically. For static story data, use [args](./args.mdx) instead. For mocking API responses or modules, see [mocking data and modules](./mocking-data-and-modules/index.mdx).
 
 ## Fetching API data
 
-Stories are isolated component examples that render internal data defined as part of the story or alongside the story as [args](./args.mdx).
-
-Loaders are helpful when you need to load story data externally (e.g., from a remote API). Consider the following example that fetches a todo item to display in a todo list:
+Consider the following example that fetches a todo item from a remote API to display in a todo list:
 
 <CodeSnippets path="loader-story.md" />
 
 The response obtained from the remote API call is combined into a `loaded` field on the story context, which is the second argument to a story function. For example, in React, the story's args were spread first to prioritize them over the static data provided by the loader. With other frameworks (e.g., Angular), you can write your stories as you'd usually do.
 
+## Component loaders
+
+To define a loader for all stories of a component, use the `loaders` key of the default CSF export. This works the same as a story loader, but applies to every story in the file.
+
 ## Global loaders
 
-We can also set a loader for **all stories** via the `loaders` export of your [`.storybook/preview.js`](../configure/index.mdx#configure-story-rendering) file (this is the file where you configure all stories):
+To define a loader for **all stories**, use the `loaders` export of your [`.storybook/preview.js|ts`](../configure/index.mdx#configure-story-rendering) file:
 
 <CodeSnippets path="storybook-preview-global-loader.md" />
 
@@ -30,12 +30,12 @@ In this example, we load a "current user" available as `loaded.currentUser` for 
 
 ## Loader inheritance
 
-Like [parameters](./parameters.mdx), loaders can be defined globally, at the component level, and for a single story (as we’ve seen).
+Like [parameters](./parameters.mdx#rules-of-parameter-inheritance), loaders can be defined globally, at the component level, and for a single story (as we’ve seen).
 
-All loaders, defined at all levels that apply to a story, run before the story renders in Storybook's canvas.
+All loaders, defined at all levels that apply to a story, run before the story renders in Storybook’s canvas.
 
 - All loaders run in parallel
-- All results are the `loaded` field in the story context
+- All results are merged into the `loaded` field in the story context
 - If there are keys that overlap, "later" loaders take precedence (from lowest to highest):
   - Global loaders, in the order they are defined
   - Component loaders, in the order they are defined

--- a/docs/writing-stories/loaders.mdx
+++ b/docs/writing-stories/loaders.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 Loaders are asynchronous functions that run before a story renders, letting you fetch data from a remote API, load assets, or perform other async setup. The loaded data is injected into the story via its render context.
 
-Use loaders when your story needs async data that can't be defined statically. For static story data, use [args](./args.mdx) instead. For mocking API responses or modules, see [mocking data and modules](./mocking-data-and-modules/index.mdx).
+Use loaders when your story needs async data that can't be defined statically. For static story data, use [args](./args.mdx) instead. For mocking API responses or modules, see [mocking data and modules](./mocking-data-and-modules/index.mdx). For help deciding between loaders, args, and parameters, see [choosing the right API](./choosing-the-right-api.mdx).
 
 ## Fetching API data
 
@@ -18,7 +18,9 @@ The response obtained from the remote API call is combined into a `loaded` field
 
 ## Component loaders
 
-To define a loader for all stories of a component, use the `loaders` key of the default CSF export. This works the same as a story loader, but applies to every story in the file.
+To define a loader for all stories of a component, use the `loaders` key of the default CSF export. This works the same as a story loader, but applies to every story in the file:
+
+<CodeSnippets path="component-loader.md" />
 
 ## Global loaders
 

--- a/docs/writing-stories/mocking-data-and-modules/index.mdx
+++ b/docs/writing-stories/mocking-data-and-modules/index.mdx
@@ -1,5 +1,17 @@
 ---
 title: Mocking data and modules
 sidebar:
-  order: 8
+  order: 11
 ---
+
+Components often depend on external data, services, or context providers. Storybook provides several ways to mock these dependencies so your stories render reliably without needing real backends or infrastructure.
+
+Choose the approach that matches where the dependency lives:
+
+- [**Mocking modules**](./mocking-modules.mdx) — control the behavior of imported functions, utilities, or libraries
+- [**Mocking network requests**](./mocking-network-requests.mdx) — intercept and simulate REST or GraphQL API calls
+- [**Mocking providers**](./mocking-providers.mdx) — supply context providers (theme, auth, store) with controlled values
+
+You can combine these approaches in the same story. For example, a page component might mock a context provider for its theme while also intercepting network requests for its data.
+
+For an overview of how these fit alongside other story APIs, see [choosing the right API](../choosing-the-right-api.mdx#mocking-approaches).

--- a/docs/writing-stories/mocking-data-and-modules/mocking-modules.mdx
+++ b/docs/writing-stories/mocking-data-and-modules/mocking-modules.mdx
@@ -9,7 +9,11 @@ Components often depend on other modules, such as other components, utility func
 
 For example, this simple component depends on two modules, a local utility function to access the user's browser session and an external package to generate a unique ID:
 
-{/* TODO: More renderers than just React */}
+<Callout variant="info">
+
+The examples on this page use React, but the mocking techniques apply to all renderers.
+
+</Callout>
 
 ```jsx title="AuthButton.jsx"
 import { v4 as uuidv4 } from 'uuid';
@@ -322,3 +326,9 @@ Webpack projects may encounter an `exports is not defined` error when using [aut
 ### Mocking conflicts with other testing tools
 
 If you've already set up mocking with other testing tools (e.g., [Jest](https://jestjs.io/)), you may encounter conflicts when using Storybook's mocking system. These conflicts can cause unexpected behavior, errors, or incorrect mocks when both tools try to mock the same module. This is a known issue when sharing mock files or configurations between Storybook and other testing tools. To address this situation, we recommend that you verify which tool is responsible for mocking a particular module and make sure the configurations do not overlap to avoid any conflicts.
+
+## See also
+
+- [Mocking network requests](./mocking-network-requests.mdx) for intercepting API calls
+- [Mocking providers](./mocking-providers.mdx) for supplying context providers
+- [Loaders](../loaders.mdx) for async data fetching before render

--- a/docs/writing-stories/mocking-data-and-modules/mocking-network-requests.mdx
+++ b/docs/writing-stories/mocking-data-and-modules/mocking-network-requests.mdx
@@ -86,3 +86,9 @@ The MSW addon allows you to write stories that use MSW to mock the GraphQL reque
 ## Configuring MSW for stories
 
 In the examples above, note how each story is configured with `parameters.msw` to define the request handlers for the mock server. Because it uses parameters in this way, it can also be configured at the [component](../parameters.mdx#component-parameters) or even [project](../parameters.mdx#global-parameters) level, allowing you to share the same mock server configuration across multiple stories.
+
+## See also
+
+- [Mocking modules](./mocking-modules.mdx) for controlling imported functions and libraries
+- [Mocking providers](./mocking-providers.mdx) for supplying context providers
+- [Loaders](../loaders.mdx) for loading async data before a story renders

--- a/docs/writing-stories/mocking-data-and-modules/mocking-providers.mdx
+++ b/docs/writing-stories/mocking-data-and-modules/mocking-providers.mdx
@@ -57,3 +57,9 @@ Now, you can define a `theme` parameter in your stories to adjust the theme prov
 This powerful approach allows you to provide any value (theme, user role, mock data, etc.) to your components in a way that is both flexible and maintainable.
 
 </If>
+
+## See also
+
+- [Mocking modules](./mocking-modules.mdx) for controlling imported functions and libraries
+- [Mocking network requests](./mocking-network-requests.mdx) for intercepting API calls
+- [Decorators](../decorators.mdx) for wrapping stories with providers and other context

--- a/docs/writing-stories/naming-components-and-hierarchy.mdx
+++ b/docs/writing-stories/naming-components-and-hierarchy.mdx
@@ -1,12 +1,12 @@
 ---
 title: Naming components and hierarchy
 sidebar:
-  order: 7
+  order: 10
 ---
 
 <YouTubeCallout id="VPfjrhDlkVc" title="How to Name Stories and Components" />
 
-Storybook provides a powerful way to organize your stories, giving you the necessary tools to categorize, search, and filter your stories based on your organization's needs and preferences.
+Once you've [written your first stories](./index.mdx), you'll want to organize them so they're easy to find. Storybook provides tools to categorize, search, and filter your stories based on your organization's needs and preferences.
 
 ## Structure and hierarchy
 

--- a/docs/writing-stories/parameters.mdx
+++ b/docs/writing-stories/parameters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Parameters
 sidebar:
-  order: 2
+  order: 4
 ---
 
 Parameters are a set of static, named metadata about a story, typically used to control the behavior of Storybook features and addons.
@@ -64,3 +64,5 @@ The way the global, component and story parameters are combined is:
 The merging of parameters is important. This means it is possible to override a single specific sub-parameter on a per-story basis while retaining most of the parameters defined globally.
 
 If you are defining an API that relies on parameters (e.g., an [**addon**](../addons/index.mdx)) it is a good idea to take this behavior into account.
+
+[Loaders](./loaders.mdx#loader-inheritance) follow the same inheritance pattern.

--- a/docs/writing-stories/parameters.mdx
+++ b/docs/writing-stories/parameters.mdx
@@ -4,7 +4,7 @@ sidebar:
   order: 4
 ---
 
-Parameters are a set of static, named metadata about a story, typically used to control the behavior of Storybook features and addons.
+Parameters are a set of static, named metadata about a story, typically used to control the behavior of Storybook features and addons. For help deciding between parameters, args, and loaders, see [choosing the right API](./choosing-the-right-api.mdx).
 
 <Callout variant="info">
 

--- a/docs/writing-stories/phase-0.md
+++ b/docs/writing-stories/phase-0.md
@@ -1,0 +1,81 @@
+## Strategy Artifact: `docs/writing-stories/index.mdx`
+
+### Audience
+
+Frontend developers new to Storybook who need to understand what stories are and how they're structured before diving into specific APIs (args, parameters, decorators, etc.).
+
+### Page Job
+
+Introduce the concept of stories — what they are, where they live, and how they're structured in CSF — then point readers to sub-pages for deeper topics.
+
+### Primary Doc Type
+
+`concept`
+
+### Diagnosis
+
+The page currently serves **four jobs simultaneously**:
+
+1. **Concept intro** — what a story is, where stories live (good, keep)
+2. **CSF format reference** — default exports, named exports, defining stories (partially keep)
+3. **Custom rendering tutorial** — render functions, React Hooks, Solid Signals (move out)
+4. **Sub-page summaries** — abbreviated sections on play function, parameters, decorators, multi-component stories (replace with "Next steps" links)
+
+This maps to the **"overloaded overview"** antipattern. The page has 18+ `<If>`/`<If notRenderer>` conditional blocks, mixing framework-specific rendering details with universal concepts.
+
+### Recommended Outline
+
+```
+1. Opening (2 sentences)
+   - What a story is and why it matters
+   - "Args" terminology note (keep existing)
+
+2. Where to put stories (keep as-is)
+   - File colocation pattern
+
+3. Component Story Format (streamlined)
+   - What CSF is, link to API reference
+   - Meta (default export) — brief explanation + one example
+   - Named exports — brief explanation + one example
+   - Renaming stories (keep, it's short)
+
+4. Writing stories with args (streamlined from "How to write stories")
+   - Multiple stories building on each other (Secondary, Tertiary)
+   - Reusing args across components (ButtonGroup example)
+   - Live editing with Controls (keep videos)
+
+5. Next steps (replace current inlined summaries)
+   - Links to: args, parameters, decorators, play function, custom rendering, multi-component stories
+```
+
+### What to Relocate
+
+| Content                                               | Current location                                      | Destination                                                                    |
+| ----------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Custom rendering (render functions, story/meta level) | "Custom rendering" subsection                         | Keep a 1-sentence mention + link to CSF API reference (`../api/csf/index.mdx`) |
+| React Hooks example                                   | `<If renderer="react">` block                         | CSF API reference or remove (it's an edge case, not intro material)            |
+| Solid Signals example                                 | `<If renderer="solid">` block                         | CSF API reference or remove                                                    |
+| Svelte CSF children/`asChild` details                 | `<If renderer="svelte">` blocks in "Defining stories" | Svelte-specific section of CSF API reference                                   |
+| "Using the play function" summary                     | Section under "How to write stories"                  | Replace with one-line link in "Next steps"                                     |
+| "Using parameters" summary                            | Section under "How to write stories"                  | Replace with one-line link in "Next steps"                                     |
+| "Using decorators" summary                            | Section under "How to write stories"                  | Replace with one-line link in "Next steps"                                     |
+| "Stories for two or more components"                  | Final section                                         | Replace with one-line link in "Next steps"                                     |
+
+### Preserve List
+
+- Opening definition of what a story is (both Svelte and non-Svelte variants)
+- "Args" terminology note
+- "Where to put stories" section (entire)
+- CSF explanation and link to API reference
+- Meta/default export example (`button-story-default-export-with-component.md`)
+- Named export / defining stories example (`button-story-with-args.md`)
+- "Rename stories" section
+- Args reuse pattern (Secondary/Tertiary example + ButtonGroup example)
+- Controls videos and explanation
+- Static title analysis callout (non-Svelte)
+
+### Expected Impact
+
+- Conditional blocks reduced from 18+ to ~6 (Svelte CSF vs standard CSF at intro level only)
+- Page becomes a clear concept page with a learning funnel to sub-pages
+- Custom rendering details move to where users look them up (API reference), not where they learn what stories are

--- a/docs/writing-stories/play-function.mdx
+++ b/docs/writing-stories/play-function.mdx
@@ -1,14 +1,14 @@
 ---
 title: Play function
 sidebar:
-  order: 4
+  order: 9
 ---
 
-`Play` functions are small snippets of code executed after the story renders. They enable you to interact with your components and test scenarios that otherwise require user intervention.
+`Play` functions are small snippets of code executed after the story renders. Aided by the [interactions panel](../writing-tests/interaction-testing.mdx#debugging-interaction-tests), they enable you to interact with your components and test scenarios that otherwise require user intervention.
 
 ## Writing stories with the play function
 
-Storybook's `play` functions are small code snippets that run once the story finishes rendering. Aided by the [interactions panel](../writing-tests/interaction-testing.mdx#debugging-interaction-tests), it allows you to build component interactions and test scenarios that were impossible without user intervention. For example, if you were working on a registration form and wanted to validate it, you could write the following story with the `play` function:
+For example, if you were working on a registration form and wanted to validate it, you could write the following story with the `play` function:
 
 <CodeSnippets path="play-function.md" />
 

--- a/docs/writing-stories/play-function.mdx
+++ b/docs/writing-stories/play-function.mdx
@@ -4,7 +4,7 @@ sidebar:
   order: 9
 ---
 
-`Play` functions are small snippets of code executed after the story renders. Aided by the [interactions panel](../writing-tests/interaction-testing.mdx#debugging-interaction-tests), they enable you to interact with your components and test scenarios that otherwise require user intervention.
+`Play` functions are small snippets of code executed after the story renders. Aided by the [interactions panel](../writing-tests/interaction-testing.mdx#debugging-interaction-tests), they enable you to interact with your components and test scenarios that otherwise require user intervention. For an introduction to writing stories, see [Stories](./index.mdx).
 
 ## Writing stories with the play function
 

--- a/docs/writing-stories/stories-for-multiple-components.mdx
+++ b/docs/writing-stories/stories-for-multiple-components.mdx
@@ -1,10 +1,10 @@
 ---
 title: Stories for multiple components
 sidebar:
-  order: 10
+  order: 13
 ---
 
-It's useful to write stories that [render two or more components](./index.mdx#stories-for-two-or-more-components) at once if those components are designed to work together. For example, `ButtonGroup`, `List`, and `Page` components.
+It's useful to write stories that [render two or more components](./index.mdx) at once if those components are designed to work together. For example, `ButtonGroup`, `List`, and `Page` components.
 
 ## Subcomponents
 

--- a/docs/writing-stories/tags.mdx
+++ b/docs/writing-stories/tags.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tags
 sidebar:
-  order: 6
+  order: 7
 ---
 
 Tags allow you to control which stories are included in your Storybook, enabling many different uses of the same total set of stories. For example, you can use tags to include/exclude tests from the [test runner](../writing-tests/integrations/test-runner.mdx#run-tests-for-a-subset-of-stories). For more complex use cases, see the [recipes](#recipes) section, below.

--- a/docs/writing-stories/typescript.mdx
+++ b/docs/writing-stories/typescript.mdx
@@ -1,5 +1,7 @@
 ---
 title: Writing stories in TypeScript
+sidebar:
+  order: 3
 ---
 
 Writing your stories in [TypeScript](https://www.typescriptlang.org/) makes you more productive. You don't have to jump between files to look up component props. Your code editor will alert you about missing required props and even autocomplete prop values, just like when using your components within your app. Plus, Storybook infers those component types to auto-generate the [Controls](../api/doc-blocks/doc-block-controls.mdx) table.


### PR DESCRIPTION
> [!NOTE]
> This is a demo run of the skill introduced in #34451.

## Run `#1` (using [this skill](https://github.com/storybookjs/storybook/pull/34451/changes/805b04867919eb9d36cd1cc06b9df3d24267b43b))

### Prompt

```
Make a plan to improve the writing-stories section of the docs
```

### Plan generated

_[Also viewable here, with formatting.](https://github.com/storybookjs/storybook/blob/docs-skill-demo/docs/writing-stories/PLAN.md)_

<details>
<summary>PLAN.md</summary>

```md
# Plan: Improve the writing-stories docs section

## Context

The `/docs/writing-stories/` section (15 files) is Storybook's primary guide for story authoring. It has solid coverage but suffers from structural issues: the entry page is overloaded (18+ conditional blocks mixing concept/task/reference), sidebar ordering doesn't match a learning progression, composition info is fragmented across 3 pages, and several pages have content gaps or inconsistencies. This plan addresses these issues using the `/docs-review` skill.

---

## Phase 0: Strategy pass on `index.mdx`

**Mode:** `strategy` | **Impact:** Unblocks Phases 1 and 2a

`index.mdx` tries to be an intro, CSF format reference, rendering tutorial, and composition guide simultaneously. Run `/docs-review` in `strategy` mode to produce a split recommendation:

- **Trimmed `index.mdx`** (concept): What a story is, where stories live, CSF at a high level, pointers to sub-pages
- **Move out**: Custom rendering details (React hooks, Solid signals, render functions) to the CSF API reference or a new "Customizing story rendering" task page
- **Move out**: Abbreviated "Using parameters/decorators/play function" sections become a "Next steps" list

**Deliverable:** Strategy artifact with new outline, what to preserve, what to relocate.

---

## Phase 1: Sidebar reordering

**Mode:** `maintenance` (frontmatter only) | **Impact:** High (navigation)

Reorder to match a learning progression:

| File                                  | New order | Rationale                       |
| ------------------------------------- | --------- | ------------------------------- |
| `index.mdx`                           | 1         | Entry point first               |
| `args.mdx`                            | 2         | Core concept                    |
| `typescript.mdx`                      | 3         | Types for what you just learned |
| `parameters.mdx`                      | 4         | Static metadata                 |
| `decorators.mdx`                      | 5         | Wrapping/context                |
| `loaders.mdx`                         | 6         | Async data                      |
| `tags.mdx`                            | 7         | Organization                    |
| `play-function.mdx`                   | 8         | Interaction testing             |
| `naming-components-and-hierarchy.mdx` | 9         | Sidebar org                     |
| `mocking-data-and-modules/`           | 10        | Advanced                        |
| `build-pages-with-storybook.mdx`      | 11        | Advanced composition            |
| `stories-for-multiple-components.mdx` | 12        | Advanced composition            |

---

## Phase 2: High-impact content improvements

### 2a. `index.mdx` -- Rewrite

**Mode:** `rewrite` | **Doc type:** concept

Execute the Phase 0 split:

- 2-sentence intent-setting opening
- Reduce conditional blocks from 18+ to ~6
- Move React Hooks / Solid Signals / custom rendering details out
- Replace inlined sub-page summaries with a "Next steps" list
- Keep: what stories are, where they live, CSF overview, first example

### 2b. `decorators.mdx` -- Improve

**Mode:** `improve` | **Doc type:** task

- Add explanation of _why_ decorator ordering matters (inner renders inside outer) with a concrete example
- Expand "Using decorators to provide data" with one example or replace with direct cross-reference
- Fix stray colon on line 57

### 2c. `loaders.mdx` -- Improve

**Mode:** `improve` | **Doc type:** task

- Reframe opening: lead with use case (async data before render), then clarify when args/mocking are better
- Add "Component loaders" section between story and global levels
- Cross-reference parameter inheritance in "Loader inheritance" section
- Add "See also" link to mocking section

### 2d. `naming-components-and-hierarchy.mdx` -- Improve

**Mode:** `improve` | **Doc type:** task

- Remove "CSF 3.0" version qualifier (it's been default since Storybook 7)
- Add intent-setting opening sentence
- Add connection back to `index.mdx`

---

## Phase 3: Targeted content fixes

### 3a. `mocking-modules.mdx` -- Improve

- Address TODO on line 12: replace React-only inline example with `<CodeSnippets>` or add framework-agnostic note

### 3b. `build-pages-with-storybook.mdx` -- Improve

- Add note for non-React/Solid users pointing to mocking sub-section
- Trim "Avoiding mocking dependencies" (move detailed React context pattern to mocking-providers page)
- Strengthen "Args composition for presentational screens" (the unique value of this page)

### 3c. `play-function.mdx` -- Maintenance

- Remove redundant opening paragraph (nearly identical text repeated)

### 3d. `parameters.mdx` -- Maintenance

- Add cross-reference to `loaders.mdx` in "Rules of parameter inheritance"

---

## Phase 4: Gap-filling

### 4a. New decision guide: "Choosing the right story API"

**Mode:** `author` | **Doc type:** decision guide

Cover:

- **Args vs loaders vs parameters**: Args for controllable inputs, parameters for addon config, loaders for async data
- **Decorators vs render functions**: Decorators for wrapping, render for changing what renders
- **Mocking approaches**: Module vs provider vs network

Place at order ~8, shifting later pages.

### 4b. Cross-reference audit

**Mode:** `maintenance` (all files)

Ensure:

- Each sub-page links to `index.mdx` and related pages
- Mocking section referenced from `loaders.mdx`, `decorators.mdx`, `build-pages-with-storybook.mdx`
- Addons section referenced where addon behavior is discussed

---

## Execution approach

Each step uses `/docs-review` with the specified mode and page. Work through phases sequentially (0 -> 1 -> 2 -> 3 -> 4). Within phases, pages can be done in any order.

## Verification

After each phase:

- Run `yarn docs:check` to validate snippet references and formatting rules
- Run `yarn fmt:write` to auto-format
- Spot-check the Storybook docs site locally or review rendered MDX for readability
``` 

</details>

### Phase 0 strategy result

_[Also viewable here, with formatting.](https://github.com/storybookjs/storybook/blob/docs-skill-demo/docs/writing-stories/phase-0.md)_

<details>
<summary>phase-0.md</summary>

```md
## Strategy Artifact: `docs/writing-stories/index.mdx`

### Audience

Frontend developers new to Storybook who need to understand what stories are and how they're structured before diving into specific APIs (args, parameters, decorators, etc.).

### Page Job

Introduce the concept of stories — what they are, where they live, and how they're structured in CSF — then point readers to sub-pages for deeper topics.

### Primary Doc Type

`concept`

### Diagnosis

The page currently serves **four jobs simultaneously**:

1. **Concept intro** — what a story is, where stories live (good, keep)
2. **CSF format reference** — default exports, named exports, defining stories (partially keep)
3. **Custom rendering tutorial** — render functions, React Hooks, Solid Signals (move out)
4. **Sub-page summaries** — abbreviated sections on play function, parameters, decorators, multi-component stories (replace with "Next steps" links)

This maps to the **"overloaded overview"** antipattern. The page has 18+ `<If>`/`<If notRenderer>` conditional blocks, mixing framework-specific rendering details with universal concepts.

### Recommended Outline

```
1. Opening (2 sentences)
   - What a story is and why it matters
   - "Args" terminology note (keep existing)

2. Where to put stories (keep as-is)
   - File colocation pattern

3. Component Story Format (streamlined)
   - What CSF is, link to API reference
   - Meta (default export) — brief explanation + one example
   - Named exports — brief explanation + one example
   - Renaming stories (keep, it's short)

4. Writing stories with args (streamlined from "How to write stories")
   - Multiple stories building on each other (Secondary, Tertiary)
   - Reusing args across components (ButtonGroup example)
   - Live editing with Controls (keep videos)

5. Next steps (replace current inlined summaries)
   - Links to: args, parameters, decorators, play function, custom rendering, multi-component stories
```

### What to Relocate

| Content                                               | Current location                                      | Destination                                                                    |
| ----------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
| Custom rendering (render functions, story/meta level) | "Custom rendering" subsection                         | Keep a 1-sentence mention + link to CSF API reference (`../api/csf/index.mdx`) |
| React Hooks example                                   | `<If renderer="react">` block                         | CSF API reference or remove (it's an edge case, not intro material)            |
| Solid Signals example                                 | `<If renderer="solid">` block                         | CSF API reference or remove                                                    |
| Svelte CSF children/`asChild` details                 | `<If renderer="svelte">` blocks in "Defining stories" | Svelte-specific section of CSF API reference                                   |
| "Using the play function" summary                     | Section under "How to write stories"                  | Replace with one-line link in "Next steps"                                     |
| "Using parameters" summary                            | Section under "How to write stories"                  | Replace with one-line link in "Next steps"                                     |
| "Using decorators" summary                            | Section under "How to write stories"                  | Replace with one-line link in "Next steps"                                     |
| "Stories for two or more components"                  | Final section                                         | Replace with one-line link in "Next steps"                                     |

### Preserve List

- Opening definition of what a story is (both Svelte and non-Svelte variants)
- "Args" terminology note
- "Where to put stories" section (entire)
- CSF explanation and link to API reference
- Meta/default export example (`button-story-default-export-with-component.md`)
- Named export / defining stories example (`button-story-with-args.md`)
- "Rename stories" section
- Args reuse pattern (Secondary/Tertiary example + ButtonGroup example)
- Controls videos and explanation
- Static title analysis callout (non-Svelte)

### Expected Impact

- Conditional blocks reduced from 18+ to ~6 (Svelte CSF vs standard CSF at intro level only)
- Page becomes a clear concept page with a learning funnel to sub-pages
- Custom rendering details move to where users look them up (API reference), not where they learn what stories are
```

</details>

### Output summary

```md
Phase 0 — Strategy artifact written to docs/writing-stories/phase-0.md

Phase 1 — Sidebar reordered to match learning progression (13 pages,
typescript.mdx now has explicit order)

Phase 2 — High-impact content improvements:
- 2a: Rewrote index.mdx — removed custom rendering details (React Hooks, Solid
Signals, Svelte children/asChild), removed inlined sub-page summaries (play
function, parameters, decorators, multi-component), added "Next steps" section.
Conditional blocks reduced from 18+ to 6.
- 2b: Improved decorators.mdx — fixed stray colon, replaced vague "provide data"
section with direct cross-references, added decorator ordering explanation with
visual diagram
- 2c: Improved loaders.mdx — reframed opening (use case first, alternatives
second), added "Component loaders" section, added cross-reference to parameter
inheritance
- 2d: Improved naming-components-and-hierarchy.mdx — added intent-setting opening
 with link back to index

Phase 3 — Targeted content fixes:
- 3a: Replaced TODO in mocking-modules.mdx with framework-agnostic callout
- 3b: Improved build-pages-with-storybook.mdx — consolidated mocking section into
 a concise list, trimmed "Avoiding mocking dependencies" to a short paragraph
with cross-reference, added non-React/Solid callout
- 3c: Removed redundant opening paragraph in play-function.mdx
- 3d: Added loaders cross-reference to parameters.mdx

Phase 4 — Gap-filling:
- 4a: Authored new choosing-the-right-api.mdx decision guide (args vs params vs
loaders, decorators vs render functions, mocking approaches, quick reference
table)
- 4b: Cross-reference audit — populated empty mocking-data-and-modules/index.mdx,
 added "See also" sections to all three mocking sub-pages, fixed broken fragment
link in stories-for-multiple-components.mdx

All changes pass yarn fmt:write and yarn docs:check.
```

## Run `#2` (using [this skill](https://github.com/storybookjs/storybook/pull/34451/changes/2d1f06a2671f641740c7805c33bd8baa2f0bf8c2))

### Prompt

```
Make a plan to improve the writing-stories section of the docs
```

### Plan generated

_[Also viewable here, with formatting.](https://github.com/storybookjs/storybook/blob/docs-skill-demo/docs/writing-stories/PLAN-2.md)_

<details>
<summary>PLAN-2.md</summary>

```md
# Plan: Re-review writing-stories docs with section-level classification

## Context

The `docs/writing-stories/` section was already improved by a demo run of `/docs-review`, but that run used the **old skill** that treated mixed doc types as an antipattern. The skill has since been updated (`2d1f06a2671`) to support **section-level classification** — well-structured secondary sections (e.g., a task section within a concept page) are now evaluated by their own doc type's criteria rather than triggering split recommendations.

The previous run was too aggressive in some places, stripping well-structured secondary task sections that should have been preserved. This plan re-runs `/docs-review` on pages that need correction, using the updated skill.

---

## Pages that need a fresh `/docs-review` pass

### 1. `index.mdx` — Rewrite (restore secondary sections)

**Mode:** `rewrite` | **Primary type:** concept | **Secondary sections:** task

The demo run converted this from a comprehensive tutorial into essentially a table of contents, removing multiple secondary task sections with code examples:

- "Custom rendering" (framework-specific task guidance with code)
- "Using the play function" (interaction testing with code example)
- "Using parameters" (configuration with code example)
- "Using decorators" (wrapper functionality with code examples)
- "Stories for two or more components" (multi-component pattern with examples)

These were **well-structured secondary task sections** within a concept overview — exactly the pattern the updated skill now supports. The rewrite should restore inline examples while keeping the streamlined structure.

**What to preserve from the demo run:** The improved opening, the "Where to put stories" cleanup, the CSF streamlining, the "Next steps" section (as addition, not replacement).

**What to restore from `next`:** Secondary task sections with code examples, adapted to be clearly headed and properly scoped. Use the phase-0.md strategy artifact as a guide, but don't strip task sections just because they're a different doc type.

### 2. `build-pages-with-storybook.mdx` — Improve (restore context container pattern)

**Mode:** `improve` | **Primary type:** task | **Secondary sections:** task (framework-specific)

The demo run removed the detailed "Avoiding mocking dependencies" section (React/Solid only) which included:

- Context-based container approach explanation
- File structure example
- Multiple implementation code examples
- Mocking containers in Storybook example

This was replaced with 3 summary paragraphs pointing to mocking-providers. The removed content is a well-structured, framework-specific task section that provides implementation details not found in the linked page.

**Action:** Re-run `/docs-review` to evaluate whether this content should be restored as a secondary task section, or whether the mocking-providers page adequately covers it.

### 3. `decorators.mdx` — Improve (evaluate with section-level lens)

**Mode:** `improve` | **Primary type:** concept | **Secondary sections:** task, reference

The demo run's changes here were mostly good (decorator ordering diagram, cleaner cross-refs). Re-run to evaluate secondary sections (e.g., "Context" reference section, framework-specific task sections) with the updated criteria.

### 4. `loaders.mdx` — Improve (component loaders + section evaluation)

**Mode:** `improve` | **Primary type:** concept | **Secondary sections:** task, reference

Two issues:

1. The "Component loaders" section (added by demo run) has only prose — needs a code example
2. Re-evaluate secondary sections with the updated skill

### 5. `args.mdx` — Improve (evaluate with section-level lens)

**Mode:** `improve` | **Primary type:** concept | **Secondary sections:** task, reference

Demo run changes were mostly formatting cleanup. Re-run to evaluate the React-specific "Setting args from within a story" task section and "Mapping to complex arg values" reference section with updated criteria.

---

## Pages that are fine as-is

These pages had appropriate changes from the demo run that don't conflict with section-level classification:

- `typescript.mdx` — formatting cleanup only
- `parameters.mdx` — cross-reference additions
- `play-function.mdx` — redundant opening removed
- `naming-components-and-hierarchy.mdx` — CSF 3.0 qualifier removed, opening added
- `tags.mdx` — formatting cleanup
- `mocking-data-and-modules/*.mdx` — formatting and cross-reference improvements
- `stories-for-multiple-components.mdx` — formatting cleanup
- `choosing-the-right-api.mdx` — new page, well-structured

---

## Cross-reference audit (after re-reviews)

**Mode:** `maintenance` across all files

After the above passes settle, do a final cross-reference pass:

1. Add `choosing-the-right-api.mdx` to "Next steps" in `index.mdx`
2. Link `choosing-the-right-api.mdx` from `args.mdx`, `parameters.mdx`, `loaders.mdx`, `decorators.mdx`
3. Ensure back-links to `index.mdx` from sub-pages that lack them

---

## Execution sequence

1. `/docs-review` rewrite `index.mdx` (highest impact — shapes the rest)
2. `/docs-review` improve `build-pages-with-storybook.mdx`
3. `/docs-review` improve `decorators.mdx`, `loaders.mdx`, `args.mdx` (can be done in any order)
4. Cross-reference audit (`maintenance` mode, all files)
5. Verification: `yarn docs:check` && `yarn fmt:write`

## Verification

- `yarn docs:check` — validate snippet references, formatting, links
- `yarn fmt:write` — auto-format
- Spot-check rendered output for sidebar ordering, secondary section headings, and link correctness

## Critical files

- `docs/writing-stories/index.mdx` — restore secondary task sections
- `docs/writing-stories/build-pages-with-storybook.mdx` — restore context container pattern
- `docs/writing-stories/loaders.mdx` — add component loaders code example
- `docs/writing-stories/decorators.mdx` — evaluate secondary sections
- `docs/writing-stories/args.mdx` — evaluate secondary sections
- `.agents/skills/docs-review/SKILL.md` — the updated skill definition
- `.agents/skills/docs-review/references/docs-strategy.md` — section-level classification rules
``` 

</details>

### Output summary

```md
# Summary: Re-review writing-stories docs with section-level classification

## Context

The `docs/writing-stories/` section had a prior demo run of the `/docs-review` skill that used an older version of the skill which treated mixed doc types as an antipattern. The skill was then updated (`2d1f06a2671`) to support **section-level classification** — well-structured secondary sections (e.g., a task section within a concept page) are now evaluated by their own doc type's criteria rather than triggering split recommendations.

This meant the demo run had been too aggressive in several places, stripping secondary task sections that were actually well-structured. This work re-ran `/docs-review` on affected pages using the updated skill.

---

## Step 1: `index.mdx` — Rewrite

**Problem:** The demo run converted this page from a comprehensive introductory tutorial into essentially a table of contents. Five secondary task sections with code examples were removed and replaced with a bare "Next steps" link list.

**Changes:**

- Restored the **"Custom rendering"** section under "Defining stories" — full Svelte CSF (template snippets, `asChild`, meta-level render) and non-Svelte (render functions at story and meta level) content with code examples and callouts
- Restored **"Working with React Hooks"** and **"Working with Solid Signals"** framework-specific subsections under custom rendering, scoped with `<If renderer>` blocks
- Restored **"Using the play function"** section with `login-form-with-play-function.md` snippet and link to the interactions panel, plus a "For more details" link to `play-function.mdx`
- Restored **"Using parameters"** section with `parameters-in-meta.md` snippet, the backgrounds screenshot, and explanation of parameter levels, plus a "For more details" link to `parameters.mdx`
- Restored **"Using decorators"** section with `button-story-component-decorator.md` snippet, links to decorator levels and addons, plus a "For more details" link to `decorators.mdx`
- Restored **"Stories for two or more components"** section with three code snippets (`list-story-starter.md`, `list-story-expanded.md`, `list-story-reuse-data.md`) and a callout linking to the multi-component stories workflow page
- Added `choosing-the-right-api.mdx` to the "Next steps" list
- Streamlined "Next steps" to avoid duplicating the sections now restored inline (removed args, typescript, parameters, decorators, play function, stories for multiple components; kept choosing the right API, naming/hierarchy, tags, mocking)
- Fixed two deprecated `<IfRenderer>` tags to `<If>` (caught by `yarn docs:check`)

**Preserved from demo run:** Improved opening paragraph, cleaner "Where to put stories" section, streamlined CSF explanation, "Next steps" section (now supplementary rather than the sole content after CSF).

## Step 2: `build-pages-with-storybook.mdx` — Improve

**Problem:** The demo run removed the detailed "Avoiding mocking dependencies" section (React/Solid only), replacing it with 3 summary paragraphs that point to `mocking-providers.mdx`. However, the mocking-providers page covers *how to mock providers with decorators*, not the container-context splitting architecture pattern. The removed content was a well-structured, framework-specific task section with implementation details not found elsewhere.

**Changes:**

- Restored the full **container-context splitting pattern** within the `<If renderer={['react', 'solid']}>` block:
  - Introductory explanation of the approach (why context over direct imports)
  - File structure example (`ProfilePage.js`, `ProfilePageContainer.js`, `ProfilePageContext.js`, etc.)
  - Callout about global container context
  - Step-by-step implementation with 4 code snippet references:
    - `mock-context-create.md` — creating the React context
    - `mock-context-in-use.md` — using `useContext` in the presentational component
    - `mock-context-container.md` — mocking containers in Storybook
    - `mock-context-container-provider.md` — providing containers in the app
    - `mock-context-container-global.md` — mocking global containers in preview
  - Three sub-headings: "Mocking containers in Storybook", "Providing containers to your application", "Mocking global containers in Storybook"
- Improved editorial clarity (e.g., "you" instead of "let's look at", tighter intro paragraphs)

## Step 3: `decorators.mdx` — Maintenance

**Problem:** Minor formatting inconsistency in the "Context for mocking" reference section.

**Changes:**

- Fixed missing spaces in the property list: `argTypes`, `parameters`, `viewMode` now consistently have a space before the dash separator

**Assessment:** Page was otherwise well-structured. All secondary sections (task sections for markup wrapping, Vue-specific features, decorator levels; reference section for context properties and inheritance rules) were properly headed and followed their own doc type shapes. No content restoration needed.

## Step 4: `loaders.mdx` — Improve

**Problem:** The "Component loaders" section (added by the demo run) had only one sentence of prose and no code example. Every other level (story-level with `loader-story.md`, global-level with `storybook-preview-global-loader.md`) had a `<CodeSnippets>` block. This broke the consistent pattern and left readers without a concrete example.

**Changes:**

- Created a new snippet file `docs/_snippets/component-loader.md` with examples for all renderers (Angular, React JS/TS, Solid JS/TS, Svelte CSF/CSF3 JS/TS, Vue JS/TS, Web Components JS/TS). Each example shows `loaders` on the default export / meta (as opposed to the story-level snippet which has it on the named export).
- Added `<CodeSnippets path="component-loader.md" />` to the "Component loaders" section

## Step 5: `args.mdx` — No changes (assessment only)

**Assessment:** Page is well-structured with properly classified secondary sections:

- Task sections: story/component/global args, args composition, "modify any aspect"
- Reference sections: URL args, complex arg mapping, addon usage (in details block)
- Framework-specific task section: React "Setting args from within a story" with `<If renderer="react">`

All secondary sections have clear headings and follow their own doc type shapes. No conflicts with section-level classification. No edits needed.

## Step 6: Cross-reference audit

**Added `choosing-the-right-api.mdx` links to 4 pages:**

- `args.mdx` — added to intro paragraph: "For help deciding between args, parameters, and loaders, see choosing the right API"
- `parameters.mdx` — added to opening paragraph: "For help deciding between parameters, args, and loaders, see choosing the right API"
- `loaders.mdx` — added to intro guidance paragraph: "For help deciding between loaders, args, and parameters, see choosing the right API"
- `decorators.mdx` — added to intro paragraph: "For help deciding between decorators and render functions, see choosing the right API"

**Added `index.mdx` back-links to 2 pages:**

- `decorators.mdx` — changed "When writing stories" to link to `./index.mdx`
- `play-function.mdx` — added "For an introduction to writing stories, see Stories" to opening paragraph

**Final cross-reference coverage:**

- `choosing-the-right-api.mdx` linked from 6 pages (was 2)
- `index.mdx` linked from 6 sub-pages (was 4)

## Verification

- `yarn fmt:write` — passes clean (all files formatted)
- `yarn docs:check` — passes clean (no errors: all snippet paths valid, no deprecated components, no broken heading hierarchy, no formatting violations)

## Files modified

| File | Change type |
|------|------------|
| `docs/writing-stories/index.mdx` | Rewrite — restored 5 secondary task sections |
| `docs/writing-stories/build-pages-with-storybook.mdx` | Improve — restored container-context pattern |
| `docs/writing-stories/decorators.mdx` | Maintenance — formatting fix + cross-references |
| `docs/writing-stories/loaders.mdx` | Improve — component loaders code example + cross-reference |
| `docs/writing-stories/args.mdx` | Cross-reference only |
| `docs/writing-stories/parameters.mdx` | Cross-reference only |
| `docs/writing-stories/play-function.mdx` | Cross-reference only |
| `docs/_snippets/component-loader.md` | New file — component-level loader snippet |
```