### PR TITLE
fix(core): call process.exit(0) after successful build and index commands

### DIFF
--- a/code/core/src/bin/core.ts
+++ b/code/core/src/bin/core.ts
@@ -189,6 +189,7 @@ command('build')
     });
 
     logger.outro('Storybook build completed successfully');
+    process.exit(0);
   });
 
 command('index')
@@ -216,6 +217,7 @@ command('index')
       ...options,
       packageJson,
     }).catch(() => process.exit(1));
+    process.exit(0);
   });
 
 program.on('command:*', ([invalidCmd]) => {


### PR DESCRIPTION
## Summary

Fixes #34446

The `build` and `index` commands in `code/core/src/bin/core.ts` log success but never call `process.exit(0)`. With Vite/chokidar and other tools that register file watchers or keep-alive handles, the Node.js process hangs indefinitely after the build completes—it only exits when those handles eventually time out or are garbage collected.

The error path already calls `process.exit(1)`, so adding `process.exit(0)` to the success path is the consistent fix. This matches the pattern used by the CLI's `dev` wrapper (which also exits with 0 on success).

## Changes

- `command('build')`: add `process.exit(0)` after `logger.outro('Storybook build completed successfully')`
- `command('index')`: add `process.exit(0)` after the awaited index call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `build` and `index` commands now properly terminate upon successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->