### PR TITLE
Documentation: Remove duplicate words in docs and comments

### DIFF
--- a/code/addons/docs/docs/props-tables.md
+++ b/code/addons/docs/docs/props-tables.md
@@ -90,7 +90,7 @@ Props tables are automatically inferred from your components and stories, but so
 
 Props tables are rendered from an internal data structure called `ArgTypes`. When you declare a story's `component` metadata, Docs automatically extracts `ArgTypes` based on the component's properties.
 
-You can can customize what's shown in the props table by [customizing the `ArgTypes` data](#customizing-argtypes). This is currently available for `DocsPage` and `<ArgsTable story="xxx">` construct, but not for the `<ArgsTable of={component} />` construct,
+You can customize what's shown in the props table by [customizing the `ArgTypes` data](#customizing-argtypes). This is currently available for `DocsPage` and `<ArgsTable story="xxx">` construct, but not for the `<ArgsTable of={component} />` construct,
 
 ### Customizing ArgTypes
 

--- a/code/core/src/csf-tools/README.md
+++ b/code/core/src/csf-tools/README.md
@@ -6,7 +6,7 @@ An experimental library to read, analyze, transform, and write CSF programmatica
 - Analyze - Extract its metadata & stories based on the Babel AST
 - Write - Write the AST back to a file
 
-It can can parse MDX into CSF.
+It can parse MDX into CSF.
 
 Coming soon:
 

--- a/code/core/src/shared/universal-store/index.ts
+++ b/code/core/src/shared/universal-store/index.ts
@@ -216,7 +216,7 @@ export class UniversalStore<
   /**
    * The syncing construct is used to keep track of if the instance's state has been synced with the
    * other instances. A leader will immediately have the promise resolved. A follower will initially
-   * be in a PENDING state, and resolve the the leader has sent the existing state, or reject if no
+   * be in a PENDING state, and resolve when the leader has sent the existing state, or reject if no
    * leader has responded before the timeout.
    */
   private syncing?: {


### PR DESCRIPTION
## Description

Remove duplicate words found in documentation and code comments:

- **`props-tables.md`**: "You can can customize" → "You can customize"
- **`csf-tools/README.md`**: "It can can parse" → "It can parse"
- **`universal-store/index.ts`**: "resolve the the leader" → "resolve when the leader" (the duplicate "the" was also missing the word "when" for the sentence to make sense)

No functional changes.

## What I did

Fixed typos in three files across docs and code comments.

## Checklist

- [x] Changes are limited to documentation and comments
- [x] No functional code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed duplicate words and grammatical errors in documentation and code comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->