### PR TITLE
Maintenance: extract createPortableStoriesImpl to eliminate nextjs/nextjs-vite portable-stories duplication

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -84,6 +84,7 @@
   ],
   "dependencies": {
     "@storybook/builder-vite": "workspace:*",
+    "@storybook/nextjs": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
     "styled-jsx": "5.1.6",

--- a/code/frameworks/nextjs-vite/src/portable-stories.ts
+++ b/code/frameworks/nextjs-vite/src/portable-stories.ts
@@ -11,17 +11,11 @@ import type {
 
 import type { Meta, ReactRenderer } from '@storybook/react';
 
-import {
-  composeConfigs,
-  composeStories as originalComposeStories,
-  composeStory as originalComposeStory,
-  setProjectAnnotations as originalSetProjectAnnotations,
-  setDefaultProjectAnnotations,
-} from 'storybook/preview-api';
-
-// ! ATTENTION: This needs to be a relative import so it gets prebundled. This is to avoid ESM issues in Nextjs + Jest setups
-import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as reactAnnotations } from '../../../renderers/react/src/portable-stories.tsx';
+import { createPortableStoriesImpl } from '@storybook/nextjs/portable-stories-impl';
 import * as nextJsAnnotations from './preview.tsx';
+
+const { setProjectAnnotations: _setProjectAnnotations, composeStory: _composeStory, composeStories: _composeStories } =
+  createPortableStoriesImpl(nextJsAnnotations);
 
 /**
  * Function that sets the globalConfig of your storybook. The global config is the preview module of
@@ -47,17 +41,8 @@ export function setProjectAnnotations(
     | NamedOrDefaultProjectAnnotations<any>
     | NamedOrDefaultProjectAnnotations<any>[]
 ): NormalizedProjectAnnotations<ReactRenderer> {
-  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
-  return originalSetProjectAnnotations(
-    projectAnnotations
-  ) as NormalizedProjectAnnotations<ReactRenderer>;
+  return _setProjectAnnotations(projectAnnotations);
 }
-
-// This will not be necessary once we have auto preset loading
-const INTERNAL_DEFAULT_PROJECT_ANNOTATIONS: ProjectAnnotations<ReactRenderer> = composeConfigs([
-  reactAnnotations,
-  nextJsAnnotations,
-]);
 
 /**
  * Function that will receive a story along with meta (e.g. a default export from a .stories file)
@@ -93,13 +78,7 @@ export function composeStory<TArgs extends Args = Args>(
   projectAnnotations?: ProjectAnnotations<ReactRenderer>,
   exportsName?: string
 ): ComposedStoryFn<ReactRenderer, Partial<TArgs>> {
-  return originalComposeStory<ReactRenderer, TArgs>(
-    story as StoryAnnotationsOrFn<ReactRenderer, Args>,
-    componentAnnotations,
-    projectAnnotations,
-    globalThis.globalProjectAnnotations ?? INTERNAL_DEFAULT_PROJECT_ANNOTATIONS,
-    exportsName
-  );
+  return _composeStory(story, componentAnnotations, projectAnnotations, exportsName);
 }
 
 /**
@@ -132,12 +111,6 @@ export function composeStory<TArgs extends Args = Args>(
 export function composeStories<TModule extends Store_CSFExports<ReactRenderer, any>>(
   csfExports: TModule,
   projectAnnotations?: ProjectAnnotations<ReactRenderer>
-) {
-  // @ts-expect-error (Converted from ts-ignore)
-  const composedStories = originalComposeStories(csfExports, projectAnnotations, composeStory);
-
-  return composedStories as unknown as Omit<
-    StoriesWithPartialProps<ReactRenderer, TModule>,
-    keyof Store_CSFExports
-  >;
+): Omit<StoriesWithPartialProps<ReactRenderer, TModule>, keyof Store_CSFExports> {
+  return _composeStories(csfExports, projectAnnotations);
 }

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -65,6 +65,11 @@
       "default": "./dist/node/index.js"
     },
     "./package.json": "./package.json",
+    "./portable-stories-impl": {
+      "types": "./dist/portable-stories-impl.d.ts",
+      "code": "./src/portable-stories-impl.ts",
+      "default": "./dist/portable-stories-impl.js"
+    },
     "./preset": "./dist/preset.js",
     "./preview": {
       "types": "./dist/preview.d.ts",

--- a/code/frameworks/nextjs/src/portable-stories-impl.ts
+++ b/code/frameworks/nextjs/src/portable-stories-impl.ts
@@ -1,0 +1,71 @@
+import type {
+  Args,
+  ComposedStoryFn,
+  NamedOrDefaultProjectAnnotations,
+  NormalizedProjectAnnotations,
+  ProjectAnnotations,
+  Store_CSFExports,
+  StoriesWithPartialProps,
+  StoryAnnotationsOrFn,
+} from 'storybook/internal/types';
+
+import type { Meta, ReactRenderer } from '@storybook/react';
+
+import {
+  composeConfigs,
+  composeStories as originalComposeStories,
+  composeStory as originalComposeStory,
+  setProjectAnnotations as originalSetProjectAnnotations,
+  setDefaultProjectAnnotations,
+} from 'storybook/preview-api';
+
+// ! ATTENTION: This needs to be a relative import so it gets prebundled. This is to avoid ESM issues in Nextjs + Jest setups
+import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as reactAnnotations } from '../../../renderers/react/src/portable-stories.tsx';
+
+export function createPortableStoriesImpl(nextJsAnnotations: ProjectAnnotations<ReactRenderer>) {
+  const INTERNAL_DEFAULT_PROJECT_ANNOTATIONS: ProjectAnnotations<ReactRenderer> = composeConfigs([
+    reactAnnotations,
+    nextJsAnnotations,
+  ]);
+
+  function setProjectAnnotations(
+    projectAnnotations:
+      | NamedOrDefaultProjectAnnotations<any>
+      | NamedOrDefaultProjectAnnotations<any>[]
+  ): NormalizedProjectAnnotations<ReactRenderer> {
+    setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
+    return originalSetProjectAnnotations(
+      projectAnnotations
+    ) as NormalizedProjectAnnotations<ReactRenderer>;
+  }
+
+  function composeStory<TArgs extends Args = Args>(
+    story: StoryAnnotationsOrFn<ReactRenderer, TArgs>,
+    componentAnnotations: Meta<TArgs | any>,
+    projectAnnotations?: ProjectAnnotations<ReactRenderer>,
+    exportsName?: string
+  ): ComposedStoryFn<ReactRenderer, Partial<TArgs>> {
+    return originalComposeStory<ReactRenderer, TArgs>(
+      story as StoryAnnotationsOrFn<ReactRenderer, Args>,
+      componentAnnotations,
+      projectAnnotations,
+      globalThis.globalProjectAnnotations ?? INTERNAL_DEFAULT_PROJECT_ANNOTATIONS,
+      exportsName
+    );
+  }
+
+  function composeStories<TModule extends Store_CSFExports<ReactRenderer, any>>(
+    csfExports: TModule,
+    projectAnnotations?: ProjectAnnotations<ReactRenderer>
+  ) {
+    // @ts-expect-error (Converted from ts-ignore)
+    const composedStories = originalComposeStories(csfExports, projectAnnotations, composeStory);
+
+    return composedStories as unknown as Omit<
+      StoriesWithPartialProps<ReactRenderer, TModule>,
+      keyof Store_CSFExports
+    >;
+  }
+
+  return { setProjectAnnotations, composeStory, composeStories, INTERNAL_DEFAULT_PROJECT_ANNOTATIONS };
+}

--- a/code/frameworks/nextjs/src/portable-stories.ts
+++ b/code/frameworks/nextjs/src/portable-stories.ts
@@ -11,17 +11,13 @@ import type {
 
 import type { Meta, ReactRenderer } from '@storybook/react';
 
-import {
-  composeConfigs,
-  composeStories as originalComposeStories,
-  composeStory as originalComposeStory,
-  setProjectAnnotations as originalSetProjectAnnotations,
-  setDefaultProjectAnnotations,
-} from 'storybook/preview-api';
-
-// ! ATTENTION: This needs to be a relative import so it gets prebundled. This is to avoid ESM issues in Nextjs + Jest setups
-import { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS as reactAnnotations } from '../../../renderers/react/src/portable-stories.tsx';
+import { createPortableStoriesImpl } from './portable-stories-impl.ts';
 import * as nextJsAnnotations from './preview.tsx';
+
+const { setProjectAnnotations: _setProjectAnnotations, composeStory: _composeStory, composeStories: _composeStories, INTERNAL_DEFAULT_PROJECT_ANNOTATIONS } =
+  createPortableStoriesImpl(nextJsAnnotations);
+
+export { INTERNAL_DEFAULT_PROJECT_ANNOTATIONS };
 
 /**
  * Function that sets the globalConfig of your storybook. The global config is the preview module of
@@ -47,17 +43,8 @@ export function setProjectAnnotations(
     | NamedOrDefaultProjectAnnotations<any>
     | NamedOrDefaultProjectAnnotations<any>[]
 ): NormalizedProjectAnnotations<ReactRenderer> {
-  setDefaultProjectAnnotations(INTERNAL_DEFAULT_PROJECT_ANNOTATIONS);
-  return originalSetProjectAnnotations(
-    projectAnnotations
-  ) as NormalizedProjectAnnotations<ReactRenderer>;
+  return _setProjectAnnotations(projectAnnotations);
 }
-
-// This will not be necessary once we have auto preset loading
-const INTERNAL_DEFAULT_PROJECT_ANNOTATIONS: ProjectAnnotations<ReactRenderer> = composeConfigs([
-  reactAnnotations,
-  nextJsAnnotations,
-]);
 
 /**
  * Function that will receive a story along with meta (e.g. a default export from a .stories file)
@@ -93,13 +80,7 @@ export function composeStory<TArgs extends Args = Args>(
   projectAnnotations?: ProjectAnnotations<ReactRenderer>,
   exportsName?: string
 ): ComposedStoryFn<ReactRenderer, Partial<TArgs>> {
-  return originalComposeStory<ReactRenderer, TArgs>(
-    story as StoryAnnotationsOrFn<ReactRenderer, Args>,
-    componentAnnotations,
-    projectAnnotations,
-    globalThis.globalProjectAnnotations ?? INTERNAL_DEFAULT_PROJECT_ANNOTATIONS,
-    exportsName
-  );
+  return _composeStory(story, componentAnnotations, projectAnnotations, exportsName);
 }
 
 /**
@@ -132,12 +113,6 @@ export function composeStory<TArgs extends Args = Args>(
 export function composeStories<TModule extends Store_CSFExports<ReactRenderer, any>>(
   csfExports: TModule,
   projectAnnotations?: ProjectAnnotations<ReactRenderer>
-) {
-  // @ts-expect-error (Converted from ts-ignore)
-  const composedStories = originalComposeStories(csfExports, projectAnnotations, composeStory);
-
-  return composedStories as unknown as Omit<
-    StoriesWithPartialProps<ReactRenderer, TModule>,
-    keyof Store_CSFExports
-  >;
+): Omit<StoriesWithPartialProps<ReactRenderer, TModule>, keyof Store_CSFExports> {
+  return _composeStories(csfExports, projectAnnotations);
 }


### PR DESCRIPTION
Closes #34470

## What I did

`portable-stories.ts` was duplicated almost entirely between `@storybook/nextjs` and `@storybook/nextjs-vite`. The two files were 143 lines long and differed only in 3 JSDoc comment lines referencing the package name in usage examples.

Created `createPortableStoriesImpl(nextJsAnnotations)` factory in `code/frameworks/nextjs/src/portable-stories-impl.ts`. Both frameworks now call this factory with their own `./preview.tsx` annotations and re-wrap each function with their package-specific JSDoc.

**Changes:**
- New `code/frameworks/nextjs/src/portable-stories-impl.ts` — shared implementation factory
- `code/frameworks/nextjs/src/portable-stories.ts` — thin wrapper with `@storybook/nextjs` JSDoc
- `code/frameworks/nextjs-vite/src/portable-stories.ts` — thin wrapper with `@storybook/nextjs-vite` JSDoc
- Added `./portable-stories-impl` export entry to `@storybook/nextjs`
- Added `@storybook/nextjs: workspace:*` to `@storybook/nextjs-vite` dependencies

Runtime behavior is unchanged — each package still uses its own `preview.tsx` to build `INTERNAL_DEFAULT_PROJECT_ANNOTATIONS`, and all public APIs have identical type signatures.

## Checklist for Contributors

### Testing

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

This is a pure refactor — no behavior changes. Tested by reviewing that the public API types and exports remain identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies for NextJS-Vite framework integration.
  * Reorganized portable stories implementation in NextJS framework.
  * Added new export entry for portable stories module to package exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->