### PR TITLE
Maintenance: extract shared Next.js preview setup to eliminate nextjs/nextjs-vite preview.tsx duplication

### DIFF
--- a/code/frameworks/nextjs-vite/package.json
+++ b/code/frameworks/nextjs-vite/package.json
@@ -84,6 +84,7 @@
   ],
   "dependencies": {
     "@storybook/builder-vite": "workspace:*",
+    "@storybook/nextjs": "workspace:*",
     "@storybook/react": "workspace:*",
     "@storybook/react-vite": "workspace:*",
     "styled-jsx": "5.1.6",

--- a/code/frameworks/nextjs-vite/src/preview.tsx
+++ b/code/frameworks/nextjs-vite/src/preview.tsx
@@ -11,47 +11,14 @@ import { createNavigation } from '@storybook/nextjs-vite/navigation.mock';
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { createRouter } from '@storybook/nextjs-vite/router.mock';
 
-import { isNextRouterError } from 'next/dist/client/components/is-next-router-error.js';
+import { setupNextErrorPatching, parameters } from '@storybook/nextjs/preview-shared';
 
 import { HeadManagerDecorator } from './head-manager/decorator.tsx';
 import { ImageDecorator } from './images/decorator.tsx';
 import { RouterDecorator } from './routing/decorator.tsx';
 import { StyledJsxDecorator } from './styledJsx/decorator.tsx';
 
-function addNextHeadCount() {
-  const meta = document.createElement('meta');
-  meta.name = 'next-head-count';
-  meta.content = '0';
-  document.head.appendChild(meta);
-}
-
-function isAsyncClientComponentError(error: unknown) {
-  return (
-    typeof error === 'string' &&
-    (error.includes('Only Server Components can be async at the moment.') ||
-      error.includes('A component was suspended by an uncached promise.') ||
-      error.includes('async/await is not yet supported in Client Components'))
-  );
-}
-addNextHeadCount();
-
-// Copying Next patch of console.error:
-// https://github.com/vercel/next.js/blob/a74deb63e310df473583ab6f7c1783bc609ca236/packages/next/src/client/app-index.tsx#L15
-const origConsoleError = globalThis.console.error;
-globalThis.console.error = (...args: unknown[]) => {
-  const error = args[0];
-  if (isNextRouterError(error) || isAsyncClientComponentError(error)) {
-    return;
-  }
-  origConsoleError.apply(globalThis.console, args);
-};
-
-globalThis.addEventListener('error', (ev: WindowEventMap['error']): void => {
-  if (isNextRouterError(ev.error) || isAsyncClientComponentError(ev.error)) {
-    ev.preventDefault();
-    return;
-  }
-});
+setupNextErrorPatching();
 
 // Type assertion to handle the decorator type mismatch
 const asDecorator = (decorator: (Story: React.FC, context?: any) => React.ReactNode) =>
@@ -76,20 +43,4 @@ export const loaders: LoaderFunction<ReactRenderer> = async ({ globals, paramete
   }
 };
 
-export const parameters = {
-  docs: {
-    source: {
-      excludeDecorators: true,
-    },
-  },
-  react: {
-    rootOptions: {
-      onCaughtError(error: unknown) {
-        if (isNextRouterError(error)) {
-          return;
-        }
-        console.error(error);
-      },
-    },
-  },
-};
+export { parameters };

--- a/code/frameworks/nextjs/package.json
+++ b/code/frameworks/nextjs/package.json
@@ -71,6 +71,11 @@
       "code": "./src/preview.tsx",
       "default": "./dist/preview.js"
     },
+    "./preview-shared": {
+      "types": "./dist/preview-shared.d.ts",
+      "code": "./src/preview-shared.ts",
+      "default": "./dist/preview-shared.js"
+    },
     "./router.mock": {
       "types": "./dist/export-mocks/router/index.d.ts",
       "code": "./src/export-mocks/router/index.ts",

--- a/code/frameworks/nextjs/src/preview-shared.ts
+++ b/code/frameworks/nextjs/src/preview-shared.ts
@@ -1,0 +1,57 @@
+import { isNextRouterError } from 'next/dist/client/components/is-next-router-error.js';
+
+export function addNextHeadCount() {
+  const meta = document.createElement('meta');
+  meta.name = 'next-head-count';
+  meta.content = '0';
+  document.head.appendChild(meta);
+}
+
+export function isAsyncClientComponentError(error: unknown) {
+  return (
+    typeof error === 'string' &&
+    (error.includes('Only Server Components can be async at the moment.') ||
+      error.includes('A component was suspended by an uncached promise.') ||
+      error.includes('async/await is not yet supported in Client Components'))
+  );
+}
+
+export function setupNextErrorPatching() {
+  addNextHeadCount();
+
+  // Copying Next patch of console.error:
+  // https://github.com/vercel/next.js/blob/a74deb63e310df473583ab6f7c1783bc609ca236/packages/next/src/client/app-index.tsx#L15
+  const origConsoleError = globalThis.console.error;
+  globalThis.console.error = (...args: unknown[]) => {
+    const error = args[0];
+    if (isNextRouterError(error) || isAsyncClientComponentError(error)) {
+      return;
+    }
+    origConsoleError.apply(globalThis.console, args);
+  };
+
+  globalThis.addEventListener('error', (ev: WindowEventMap['error']): void => {
+    if (isNextRouterError(ev.error) || isAsyncClientComponentError(ev.error)) {
+      ev.preventDefault();
+      return;
+    }
+  });
+}
+
+export const parameters = {
+  docs: {
+    source: {
+      excludeDecorators: true,
+    },
+  },
+  react: {
+    rootOptions: {
+      onCaughtError(error: unknown) {
+        if (isNextRouterError(error)) {
+          return;
+        }
+        console.error(error);
+      },
+    },
+  },
+};

--- a/code/frameworks/nextjs/src/preview.tsx
+++ b/code/frameworks/nextjs/src/preview.tsx
@@ -12,47 +12,13 @@ import { createNavigation } from '@storybook/nextjs/navigation.mock';
 // @ts-ignore we must ignore types here as during compilation they are not generated yet
 import { createRouter } from '@storybook/nextjs/router.mock';
 
-import { isNextRouterError } from 'next/dist/client/components/is-next-router-error.js';
-
 import { HeadManagerDecorator } from './head-manager/decorator.tsx';
 import { ImageDecorator } from './images/decorator.tsx';
+import { setupNextErrorPatching, parameters } from './preview-shared.ts';
 import { RouterDecorator } from './routing/decorator.tsx';
 import { StyledJsxDecorator } from './styledJsx/decorator.tsx';
 
-function addNextHeadCount() {
-  const meta = document.createElement('meta');
-  meta.name = 'next-head-count';
-  meta.content = '0';
-  document.head.appendChild(meta);
-}
-
-function isAsyncClientComponentError(error: unknown) {
-  return (
-    typeof error === 'string' &&
-    (error.includes('Only Server Components can be async at the moment.') ||
-      error.includes('A component was suspended by an uncached promise.') ||
-      error.includes('async/await is not yet supported in Client Components'))
-  );
-}
-addNextHeadCount();
-
-// Copying Next patch of console.error:
-// https://github.com/vercel/next.js/blob/a74deb63e310df473583ab6f7c1783bc609ca236/packages/next/src/client/app-index.tsx#L15
-const origConsoleError = globalThis.console.error;
-globalThis.console.error = (...args: unknown[]) => {
-  const error = args[0];
-  if (isNextRouterError(error) || isAsyncClientComponentError(error)) {
-    return;
-  }
-  origConsoleError.apply(globalThis.console, args);
-};
-
-globalThis.addEventListener('error', (ev: WindowEventMap['error']): void => {
-  if (isNextRouterError(ev.error) || isAsyncClientComponentError(ev.error)) {
-    ev.preventDefault();
-    return;
-  }
-});
+setupNextErrorPatching();
 
 export const decorators: Addon_DecoratorFunction<any>[] = [
   StyledJsxDecorator,
@@ -73,20 +39,4 @@ export const loaders: Addon_LoaderFunction = async ({ globals, parameters }) => 
   }
 };
 
-export const parameters = {
-  docs: {
-    source: {
-      excludeDecorators: true,
-    },
-  },
-  react: {
-    rootOptions: {
-      onCaughtError(error: unknown) {
-        if (isNextRouterError(error)) {
-          return;
-        }
-        console.error(error);
-      },
-    },
-  },
-};
+export { parameters };


### PR DESCRIPTION
Closes #34465

## What I did

`code/frameworks/nextjs/src/preview.tsx` and `code/frameworks/nextjs-vite/src/preview.tsx` contained ~55 lines of near-identical code: `addNextHeadCount()`, `isAsyncClientComponentError()`, the global `console.error` patch, the `error` event listener override, and the entire `parameters` export.

Created `code/frameworks/nextjs/src/preview-shared.ts` with:
- `addNextHeadCount()`
- `isAsyncClientComponentError()`
- `setupNextErrorPatching()` — wraps the console.error patch + error event listener
- `parameters` export

Both `preview.tsx` files now import these from the shared module and call `setupNextErrorPatching()` at module load time, preserving the original execution order.

**Files changed:**
- New `code/frameworks/nextjs/src/preview-shared.ts` — shared utilities
- `code/frameworks/nextjs/src/preview.tsx` — imports from shared module
- `code/frameworks/nextjs-vite/src/preview.tsx` — imports from `@storybook/nextjs/preview-shared`
- Added `./preview-shared` export entry to `@storybook/nextjs` package.json
- Added `@storybook/nextjs: workspace:*` to `@storybook/nextjs-vite` dependencies

The decorators and loaders sections remain intentionally different between the two files (different type signatures for vite vs webpack).

Note: This PR adds `@storybook/nextjs` as a dependency of `@storybook/nextjs-vite` — the same dependency already added in #34474 for the `portable-stories` dedup. If that PR merges first, the `package.json` change here will be a no-op.

## Checklist for Contributors

### Testing

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Pure refactor — no behavior changes. Both files call `setupNextErrorPatching()` once at module load time, same as the inline code before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Next.js error handling utilities into a shared module for improved consistency across framework integrations and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->