### PR TITLE
fix: clear vue reactive args when nextArgs is empty

### DIFF
--- a/code/renderers/vue3/src/render.test.ts
+++ b/code/renderers/vue3/src/render.test.ts
@@ -91,6 +91,18 @@ describe('Render Story', () => {
     expect(reactiveArgs).toEqual({ objectArg: { argFoo: 'bar' } });
   });
 
+  it('clears reactive args when nextArgs is empty', () => {
+    const reactiveArgs = reactive({ argFoo: 'foo', argBar: 'bar' });
+    updateArgs(reactiveArgs, {} as Args);
+    expect(reactiveArgs).toEqual({});
+  });
+
+  it('clears reactive globals when nextArgs is empty', () => {
+    const reactiveGlobals = reactive<Globals>({ theme: 'light', locale: 'en' });
+    updateArgs<Globals>(reactiveGlobals, {} as Globals);
+    expect(reactiveGlobals).toEqual({});
+  });
+
   it('update reactive Globals', async () => {
     const reactiveGlobals = reactive<Globals>({ theme: 'light', locale: 'en' });
 

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -153,9 +153,6 @@ export function updateArgs<
     [name: string]: unknown;
   },
 >(reactiveArgs: T, nextArgs: T) {
-  if (Object.keys(nextArgs).length === 0) {
-    return;
-  }
   const currentArgs = isReactive(reactiveArgs) ? reactiveArgs : reactive(reactiveArgs);
   // delete all args in currentArgs that are not in nextArgs
   Object.keys(currentArgs).forEach((key) => {


### PR DESCRIPTION
## Summary

Fix Vue renderer stale reactive args/globals when `nextArgs` is empty.

## Changes

- remove the early return in `updateArgs`
- add tests to verify empty updates clear reactive args and globals

Closes #34319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed reactive state management when updating with empty argument values. Previously, operations to clear reactive arguments and globals were incorrectly skipped, preventing proper cleanup of existing keys. The renderer now correctly reconciles and removes all reactive properties to maintain proper state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->