### PR TITLE
CI: Avoid shallow checkout for Chromatic job

### DIFF
--- a/scripts/ci/common-jobs.ts
+++ b/scripts/ci/common-jobs.ts
@@ -128,7 +128,7 @@ export const storybookChromatic = defineJob(
       class: 'medium+',
     },
     steps: [
-      ...workflow.restoreLinux(),
+      ...workflow.restoreLinux({ shallow: false }),
       {
         run: {
           name: 'Build internal storybook',

--- a/scripts/ci/utils/helpers.ts
+++ b/scripts/ci/utils/helpers.ts
@@ -168,14 +168,13 @@ export const verdaccio = {
 };
 
 export const workflow = {
-  restoreLinux: () => [
-    //
-    git.checkout(),
+  restoreLinux: (checkoutOpts: { forceHttps?: boolean; shallow?: boolean } = {}) => [
+    git.checkout(checkoutOpts),
     workspace.attach(),
     cache.attach(CACHE_KEYS()),
   ],
-  restoreWindows: (at = WINDOWS_ROOT_DIR) => [
-    git.checkout({ forceHttps: true }),
+  restoreWindows: (at = WINDOWS_ROOT_DIR, checkoutOpts: { shallow?: boolean } = {}) => [
+    git.checkout({ ...checkoutOpts, forceHttps: true }),
     node.installOnWindows(),
     workspace.attach(at),
     /**


### PR DESCRIPTION
## What I did

This should fix an ongoing issue we've had with Chromatic history getting heavily polluted when rebasing branches. There was a regression in the switch to dynamically generated CI, where we stopped checking out the git history of the repo for the Chromatic job, and switched to a default shallow clone.

The PR reintroduces a deeper clone by letting us pass checkout options to the `restore*` helpers. It then passes `shallow: false` specifically for Chromatic.


## Checklist for Contributors

### Testing

> [!CAUTION]
> THIS IS NOT COVERED BY TESTS 🚨

#### Manual testing

> [!CAUTION]
> I HAVE NOT TESTED THIS 🚨

I don't know how to test this other than merge and observe it.

### Documentation

ø

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [x] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow helpers to support configurable Git checkout behavior, enabling flexible shallow clone options during build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->