### PR TITLE
fix: clear stale vue reactive globals

### DIFF
--- a/code/renderers/vue3/src/render.test.ts
+++ b/code/renderers/vue3/src/render.test.ts
@@ -109,4 +109,20 @@ describe('Render Story', () => {
     expect(observedTheme).toBe('dark');
     expect(reactiveGlobals).toEqual({ theme: 'dark', locale: 'en' });
   });
+
+  it('clears reactive Args when nextArgs is empty', () => {
+    const reactiveArgs = reactive({ argFoo: 'foo', argBar: 'bar' });
+
+    updateArgs(reactiveArgs, {});
+
+    expect(reactiveArgs).toEqual({});
+  });
+
+  it('clears reactive Globals when nextGlobals is empty', () => {
+    const reactiveGlobals = reactive<Globals>({ theme: 'light', locale: 'en' });
+
+    updateArgs<Globals>(reactiveGlobals, {});
+
+    expect(reactiveGlobals).toEqual({});
+  });
 });

--- a/code/renderers/vue3/src/render.ts
+++ b/code/renderers/vue3/src/render.ts
@@ -153,9 +153,6 @@ export function updateArgs<
     [name: string]: unknown;
   },
 >(reactiveArgs: T, nextArgs: T) {
-  if (Object.keys(nextArgs).length === 0) {
-    return;
-  }
   const currentArgs = isReactive(reactiveArgs) ? reactiveArgs : reactive(reactiveArgs);
   // delete all args in currentArgs that are not in nextArgs
   Object.keys(currentArgs).forEach((key) => {


### PR DESCRIPTION
## What I changed

This removes the early return in `updateArgs()` for the Vue 3 renderer so the deletion pass still runs when `nextArgs` or `globals` are cleared to `{}`.

I also added regression tests covering both cases:

- clearing reactive args to an empty object
- clearing reactive globals to an empty object

Fixes #34319

## How to test

### Automated tests

- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

```sh
corepack yarn test code/renderers/vue3/src/render.test.ts --config code/renderers/vue3/vitest.config.ts
```

### Manual testing

No manual testing required for this change. It is covered by focused Vue renderer regression tests.

## Notes

I initially tried the root `yarn test` entrypoint, but in this checkout it fails during unrelated workspace Vitest project setup for `@storybook/addon-vitest`. The targeted Vue renderer Vitest config above passes and exercises the changed code directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reactive state was not properly cleared when updating with empty arguments or globals in the Vue3 renderer. The renderer now correctly resets reactive state when provided with empty input objects.

* **Tests**
  * Added test cases verifying that reactive state is properly cleared when updating with empty arguments and globals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->