### PR TITLE
Core: Improve startup performance by deferring change detection initialization

### DIFF
--- a/code/builders/builder-vite/src/index.test.ts
+++ b/code/builders/builder-vite/src/index.test.ts
@@ -302,12 +302,24 @@ describe('onModuleGraphChange', () => {
     expect(fakeViteServer.waitForRequestsIdle).not.toHaveBeenCalled();
   });
 
-  it('rejects listeners registered after start', async () => {
-    await start(createStartArgs());
+  it('allows listeners registered after start and runs change detection', async () => {
+    await start(createStartArgs(['/src/Button.tsx']));
+    await vi.advanceTimersByTimeAsync(1000);
 
-    expect(() => onModuleGraphChange(vi.fn())).toThrow(
-      'Vite module graph listeners must be registered before the builder starts.'
-    );
+    fakeViteServer.moduleGraph.fileToModulesMap = createFileToModulesMap([
+      '/src/Button.tsx',
+      new Set([createViteModuleNode('/src/Button.tsx')]),
+    ]);
+
+    const cb = vi.fn();
+    onModuleGraphChange(cb);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    cb.mockClear();
+    fakeViteServer.watcher.emit('change', '/src/Button.tsx');
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 
   it('does not reattach the watcher if bail runs while waiting for idle requests', async () => {

--- a/code/builders/builder-vite/src/index.ts
+++ b/code/builders/builder-vite/src/index.ts
@@ -3,10 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 import { logger } from 'storybook/internal/node-logger';
-import {
-  NoStatsForViteDevError,
-  ViteModuleGraphSubscriptionError,
-} from 'storybook/internal/server-errors';
+import { NoStatsForViteDevError } from 'storybook/internal/server-errors';
 import type { StoryIndexGenerator } from 'storybook/internal/core-server';
 import type {
   Builder,
@@ -45,11 +42,12 @@ function iframeHandler(options: Options, server: ViteDevServer): Middleware {
 }
 
 let server: ViteDevServer;
+let lastBuilderOptions: Options | undefined;
 const listeners = new Set<(event: ModuleGraphChangeEvent) => void>();
 let debounce: ReturnType<typeof setTimeout> | undefined;
 let watcherChangeHandler: (() => void) | undefined;
 let waitForModuleGraph: ReturnType<typeof setInterval> | undefined;
-let moduleGraphRegistrationClosed = false;
+let moduleGraphTrackingStarted = false;
 
 function clearModuleGraphPolling(): void {
   if (waitForModuleGraph) {
@@ -85,16 +83,41 @@ export async function bail(): Promise<void> {
     debounce = undefined;
   }
 
-  moduleGraphRegistrationClosed = false;
+  moduleGraphTrackingStarted = false;
+  lastBuilderOptions = undefined;
   listeners.clear();
   return server?.close();
 }
 
-export const onModuleGraphChange: NonNullable<Builder<Options>['onModuleGraphChange']> = (cb) => {
-  if (moduleGraphRegistrationClosed) {
-    throw new ViteModuleGraphSubscriptionError();
+function startModuleGraphTracking(): void {
+  if (moduleGraphTrackingStarted || listeners.size === 0 || !server || !lastBuilderOptions) {
+    return;
   }
+
+  moduleGraphTrackingStarted = true;
+
+  // Debounce handler to prevent multiple callback invocations when multiple files are edited
+  watcherChangeHandler = () => {
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      notifyListeners(buildModuleGraph(server.moduleGraph.fileToModulesMap));
+    }, 100);
+  };
+
+  startChangeDetection(lastBuilderOptions).catch((error) => {
+    clearModuleGraphPolling();
+    logger.error('Failed to initialize Vite change detection');
+    logger.error(error instanceof Error ? error : String(error));
+    notifyListenersOfStartupFailure({
+      type: 'error',
+      error: error instanceof Error ? error : new Error(String(error)),
+    });
+  });
+}
+
+export const onModuleGraphChange: NonNullable<Builder<Options>['onModuleGraphChange']> = (cb) => {
   listeners.add(cb);
+  startModuleGraphTracking();
 
   return () => {
     listeners.delete(cb);
@@ -163,31 +186,13 @@ export const start: ViteBuilder['start'] = async ({
   router,
   server: devServer,
 }) => {
-  moduleGraphRegistrationClosed = true;
+  lastBuilderOptions = options as Options;
   server = await createViteServer(options as Options, devServer);
 
   router.get('/iframe.html', iframeHandler(options as Options, server));
   router.use(server.middlewares);
 
-  if (listeners.size > 0) {
-    // Debounce handler to prevent multiple callback invocations when multiple files are edited
-    watcherChangeHandler = () => {
-      clearTimeout(debounce);
-      debounce = setTimeout(() => {
-        notifyListeners(buildModuleGraph(server.moduleGraph.fileToModulesMap));
-      }, 100);
-    };
-    // We intentionally don't await this. Cleanup happens in bail().
-    void startChangeDetection(options).catch((error) => {
-      clearModuleGraphPolling();
-      logger.error('Failed to initialize Vite change detection');
-      logger.error(error instanceof Error ? error : String(error));
-      notifyListenersOfStartupFailure({
-        type: 'error',
-        error: error instanceof Error ? error : new Error(String(error)),
-      });
-    });
-  }
+  startModuleGraphTracking();
 
   return {
     bail,

--- a/code/core/src/core-server/dev-server.ts
+++ b/code/core/src/core-server/dev-server.ts
@@ -1,4 +1,5 @@
 import { logConfig, normalizeStories } from 'storybook/internal/common';
+import { DOCS_PREPARED, STORY_RENDERED } from 'storybook/internal/core-events';
 import { logger } from 'storybook/internal/node-logger';
 import { MissingBuilderError } from 'storybook/internal/server-errors';
 import { CHANGE_DETECTION_STATUS_TYPE_ID } from 'storybook/internal/types';
@@ -9,6 +10,7 @@ import polka from 'polka';
 
 import { telemetry } from '../telemetry/index.ts';
 import { ChangeDetectionService } from './change-detection/index.ts';
+import { setChangeDetectionReadiness } from './change-detection/readiness.ts';
 import { getStatusStoreByTypeId } from './stores/status.ts';
 import type { StoryIndexGenerator } from './utils/StoryIndexGenerator.ts';
 import { doTelemetry } from './utils/doTelemetry.ts';
@@ -120,7 +122,10 @@ export async function storybookDevServer(
       statusStore: getStatusStoreByTypeId(CHANGE_DETECTION_STATUS_TYPE_ID),
       workingDir,
     });
-    changeDetectionService.start(previewBuilder.onModuleGraphChange, features?.changeDetection);
+
+    if (features?.changeDetection === false) {
+      changeDetectionService.start(previewBuilder.onModuleGraphChange, false);
+    }
 
     logger.debug('Starting preview..');
     previewResult = await previewBuilder
@@ -146,6 +151,29 @@ export async function storybookDevServer(
         // re-throw the error
         throw e;
       });
+
+    if (features?.changeDetection !== false) {
+      let changeDetectionStarted = false;
+      const startChangeDetection = () => {
+        if (changeDetectionStarted) {
+          return;
+        }
+        try {
+          changeDetectionStarted = true;
+          changeDetectionService.start(previewBuilder.onModuleGraphChange, true);
+        } catch (error) {
+          logger.error('Failed to start change detection');
+          logger.error(error instanceof Error ? error : String(error));
+          setChangeDetectionReadiness({
+            status: 'error',
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+        }
+      };
+
+      options.channel.once(STORY_RENDERED, startChangeDetection);
+      options.channel.once(DOCS_PREPARED, startChangeDetection);
+    }
   }
 
   const listening = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## What I did

Deferred initialization of the ChangeDetectionService and - more importantly - Vite module graph pre-warming, until whenever the preview has rendered the first story or docs page.

Change detection requires the module graph to include all story files, which we ensure by firing a warmup request for each story file. However, this had significant impact on Storybook's startup speed, due to resource contention (warmup is async, but Node is still single-threaded).

### Benchmarks

In Storybook's monorepo, `changeDetection` was adding significant overhead:

With `changeDetection=false`, average startup time (till story rendered) was 8.0s. With `changeDetection=true`, this increased to 14.5s on average, a 6.5s (~81%) slowdown.

With deferred initialization, the average startup time with `changeDetection=true` was 8.1s, only very slightly (and acceptably) slower than without change detection.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Module graph listeners can now be registered after builder initialization.
  * Change detection can be configured to start lazily, improving startup performance based on feature flags.

* **Bug Fixes**
  * Enhanced error handling for change detection startup failures with improved status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->