### PR TITLE
CLI: Add storybook skills file and commands to install them

### DIFF
--- a/code/core/src/telemetry/types.ts
+++ b/code/core/src/telemetry/types.ts
@@ -45,7 +45,8 @@ export type EventType =
   | 'doctor'
   | 'share'
   | 'ghost-stories'
-  | 'ai-prepare';
+  | 'ai-prepare'
+  | 'ai-install-skills';
 export interface Dependency {
   version: string | undefined;
   versionSpecifier?: string;

--- a/code/lib/cli-storybook/src/bin/run.ts
+++ b/code/lib/cli-storybook/src/bin/run.ts
@@ -24,6 +24,7 @@ import { doctor } from '../doctor/index.ts';
 import { link } from '../link.ts';
 import { migrate } from '../migrate.ts';
 import { sandbox } from '../sandbox.ts';
+import { installAgentSkills } from '../../../create-storybook/src/install-agent-skills.ts';
 import { aiPrepare } from '../ai/index.ts';
 import { type UpgradeOptions, upgrade } from '../upgrade.ts';
 
@@ -326,6 +327,18 @@ aiCommand
     await withTelemetry('ai-prepare', { cliOptions: mergedOptions }, async () => {
       await aiPrepare(mergedOptions);
     }).catch(handleCommandFailure(mergedOptions.logfile));
+  });
+
+aiCommand
+  .command('install-skills')
+  .description(
+    'Install Storybook agent skills for AI coding agents (Claude, Cursor, Copilot, etc.)'
+  )
+  .action(async (_options, cmd) => {
+    const parentOptions = cmd.parent?.opts() ?? {};
+    await withTelemetry('ai-install-skills', { cliOptions: parentOptions }, async () => {
+      await installAgentSkills();
+    }).catch(handleCommandFailure(parentOptions.logfile));
   });
 
 // Show available subcommands when `storybook ai` is run without arguments

--- a/code/lib/create-storybook/package.json
+++ b/code/lib/create-storybook/package.json
@@ -33,6 +33,7 @@
     "bin/**/*",
     "dist/**/*",
     "rendererAssets/**/*",
+    "skills/**/*",
     "templates/**/*",
     "README.md",
     "!src/**/*"

--- a/code/lib/create-storybook/skills/setup-storybook/SKILL.md
+++ b/code/lib/create-storybook/skills/setup-storybook/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: setup-storybook
+description: >
+  Use when setting up Storybook in a project: writing the initial preview
+  configuration, decorators, and example stories for existing components.
+  Trigger this skill after `storybook init` has installed Storybook, or
+  whenever the user asks to "set up Storybook", "configure Storybook",
+  or "write stories for my components".
+---
+
+# Storybook Setup
+
+> **Managed by Storybook.** This file is installed and updated by `@storybook/cli`. It is symlinked from `node_modules/@storybook/cli/skills/setup-storybook/SKILL.md`, so it refreshes automatically when you upgrade Storybook. Edit the symlink target only if you know what you're doing — your changes will be overwritten on the next install.
+
+This skill helps you finish setting up Storybook in a project that already has it installed. It does **not** install Storybook from scratch — for that, run `npx storybook init` first.
+
+## How to use this skill
+
+Run the following command and follow its output exactly:
+
+```bash
+npx storybook ai prepare
+```
+
+This command inspects the project's Storybook configuration and prints a tailored markdown prompt with:
+
+- A project info table (version, renderer, framework, builder, addons, CSF format)
+- Renderer-specific documentation links
+- Step-by-step instructions for analyzing the codebase, configuring `preview.ts` or `preview.tsx` with the right decorators, writing example stories, and verifying them with Vitest
+
+**Treat the output of `storybook ai prepare` as your authoritative instructions.** Do not improvise setup steps from memory — the command's output is generated from the project's actual configuration and stays in sync with the installed Storybook version.
+
+## When NOT to use this skill
+
+- The user wants to add Storybook to a fresh project → run `npx storybook init` instead
+- The user is asking general questions about Storybook → fetch https://storybook.js.org/llms.txt or append `.md` to any docs URL
+- The user wants to upgrade Storybook → run `npx storybook upgrade`

--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.ts
@@ -193,7 +193,7 @@ export class UserPreferencesCommand {
 
     return prompt.confirm({
       message: dedent`Would you like to improve your Storybook setup with AI?
-      We will provide you with a prompt that you can use with your LLM to fully set up Storybook with best practices, tailored to your project.`,
+      We will install Storybook skills for your AI coding agent (Claude, Cursor, Copilot, etc.) and provide you with a prompt to fully set up Storybook with best practices, tailored to your project.`,
     });
   }
 

--- a/code/lib/create-storybook/src/index.ts
+++ b/code/lib/create-storybook/src/index.ts
@@ -1,1 +1,2 @@
 export { doInitiate as initiate } from './initiate.ts';
+export { installAgentSkills } from './install-agent-skills.ts';

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -108,29 +108,21 @@ export async function doInitiate(options: CommandOptions): Promise<
     options,
   });
 
+  if (selectedFeatures.has(Feature.AI)) {
+    const { installAgentSkills } = await import('./install-agent-skills.ts');
+    await installAgentSkills();
+
+    logger.step(
+      CLI_COLORS.storybook(dedent`To finalize setting up with AI, either use the /setup-storybook skill we just added to your project or paste this prompt to your AI agent:
+      Run \`npx storybook ai prepare\` and follow its instructions precisely.`)
+    );
+  }
+
   // Step 8: Print final summary
   await executeFinalization({
     logfile: options.logfile,
     storybookCommand,
   });
-
-  // Install agent skills when an agent is detected or the user opted into AI
-  if (options.agent || selectedFeatures.has(Feature.AI)) {
-    const { installAgentSkills } = await import('./install-agent-skills.ts');
-    await installAgentSkills();
-  }
-
-  if (selectedFeatures.has(Feature.AI)) {
-    if (options.agent) {
-      const { aiPrepare } = await import('../../cli-storybook/src/ai/index.ts');
-      await aiPrepare({ configDir: configDir ?? '.storybook' });
-    } else {
-      logger.step(
-        CLI_COLORS.storybook(dedent`To finalize setting up with AI, paste this prompt to your AI agent:
-        Run \`npx storybook ai prepare\` and follow its instructions precisely.`)
-      );
-    }
-  }
 
   // Step 9: Track telemetry
   await telemetryService.trackInitWithContext(projectType, selectedFeatures, newUser);

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -109,11 +109,12 @@ export async function doInitiate(options: CommandOptions): Promise<
   });
 
   if (selectedFeatures.has(Feature.AI)) {
+    logger.step('Setting up Storybook AI skills file');
     const { installAgentSkills } = await import('./install-agent-skills.ts');
     await installAgentSkills();
 
-    logger.step(
-      CLI_COLORS.storybook(dedent`To finalize setting up with AI, either use the /setup-storybook skill we just added to your project or paste this prompt to your AI agent:
+    logger.log(
+      CLI_COLORS.storybook(dedent`Done. To finalize setting up with AI, either use the /setup-storybook skill or paste the following prompt to your AI agent:
       Run \`npx storybook ai prepare\` and follow its instructions precisely.`)
     );
   }

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -114,6 +114,12 @@ export async function doInitiate(options: CommandOptions): Promise<
     storybookCommand,
   });
 
+  // Install agent skills when an agent is detected or the user opted into AI
+  if (options.agent || selectedFeatures.has(Feature.AI)) {
+    const { installAgentSkills } = await import('./install-agent-skills.ts');
+    await installAgentSkills();
+  }
+
   if (selectedFeatures.has(Feature.AI)) {
     if (options.agent) {
       const { aiPrepare } = await import('../../cli-storybook/src/ai/index.ts');

--- a/code/lib/create-storybook/src/install-agent-skills.ts
+++ b/code/lib/create-storybook/src/install-agent-skills.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+import { executeCommand } from 'storybook/internal/common';
+import { logger } from 'storybook/internal/node-logger';
+
+/**
+ * Installs all Storybook agent skills using the Vercel skills CLI.
+ *
+ * Points `npx skills add` at the bundled `skills/` directory, which auto-discovers
+ * every `SKILL.md` underneath. Adding a new skill is as simple as creating a new
+ * `skills/<skill-name>/SKILL.md` file — no changes to this command needed.
+ *
+ * Uses symlink mode (default) so that updating Storybook automatically refreshes
+ * the skill content via the symlink target in node_modules. The skills CLI handles
+ * agent detection and file placement.
+ *
+ * The `skills/` directory ships with the `create-storybook` package. We resolve
+ * its location via `require.resolve` so the path is correct regardless of which
+ * package bundled this code — this file is inlined into both `create-storybook`
+ * and `@storybook/cli` builds by the bundler.
+ */
+export async function installAgentSkills(): Promise<void> {
+  const require = createRequire(import.meta.url);
+  const createStorybookPkg = require.resolve('create-storybook/package.json');
+  const skillsDir = join(dirname(createStorybookPkg), 'skills');
+
+  try {
+    await executeCommand({
+      command: 'npx',
+      args: ['skills', 'add', skillsDir, '--skill', '*', '--yes'],
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    // Non-critical — don't fail the init if skill export fails
+    logger.warn(
+      `Could not install agent skills: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/code/lib/create-storybook/src/install-agent-skills.ts
+++ b/code/lib/create-storybook/src/install-agent-skills.ts
@@ -26,15 +26,23 @@ export async function installAgentSkills(): Promise<void> {
   const skillsDir = join(dirname(createStorybookPkg), 'skills');
 
   try {
+    // Silently pipe output on success; surface it only when the command fails.
     await executeCommand({
       command: 'npx',
       args: ['skills', 'add', skillsDir, '--skill', '*', '--yes'],
-      stdio: 'inherit',
+      stdio: 'pipe',
     });
   } catch (error) {
-    // Non-critical — don't fail the init if skill export fails
-    logger.warn(
-      `Could not install agent skills: ${error instanceof Error ? error.message : String(error)}`
-    );
+    // Non-critical — don't fail the init if skill installation fails.
+    const message = error instanceof Error ? error.message : String(error);
+    // execa attaches the subprocess's stderr/stdout to the error; include them so
+    // users can see why the skills CLI failed.
+    const stderr =
+      error && typeof error === 'object' && 'stderr' in error ? String(error.stderr ?? '') : '';
+    const stdout =
+      error && typeof error === 'object' && 'stdout' in error ? String(error.stdout ?? '') : '';
+    const details = [stderr, stdout].filter(Boolean).join('\n');
+
+    logger.warn(`Could not install agent skills: ${message}${details ? `\n${details}` : ''}`);
   }
 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR introduces a new subcommand, `storybook ai install-skills` which adds a Storybook skill for setting up projects.
It also automatically does that during `init` in case the user says yes to AI or in an agentic session.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34520-sha-f27a9583`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34520-sha-f27a9583 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34520-sha-f27a9583 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34520-sha-f27a9583`](https://npmjs.com/package/storybook/v/0.0.0-pr-34520-sha-f27a9583) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/storybook-skill`](https://github.com/storybookjs/storybook/tree/yann/storybook-skill) |
| **Commit** | [`f27a9583`](https://github.com/storybookjs/storybook/commit/f27a9583f98af6946ea733700a9702d98d55cc28) |
| **Datetime** | Mon Apr 13 14:33:11 UTC 2026 (`1776090791`) |
| **Workflow run** | [24349124731](https://github.com/storybookjs/storybook/actions/runs/24349124731) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34520`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `storybook ai install-skills` CLI command to install Storybook skills for AI coding agents.
  * AI skills can now be installed automatically during Storybook setup; setup now suggests running `npx storybook ai prepare`.
  * Introduced a "setup-storybook" skill that guides configuration, decorators, and example story creation.
  * Updated the AI setup confirmation prompt to describe installing Storybook skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->