### PR TITLE
fix(manager-api): add generic type parameter to useArgs hook

### DIFF
--- a/code/core/src/manager-api/root.tsx
+++ b/code/core/src/manager-api/root.tsx
@@ -459,7 +459,27 @@ export function useAddonState<S>(addonId: string, defaultState?: S) {
   return useSharedState<S>(addonId, defaultState);
 }
 
-export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[]) => void, Args] {
+/**
+ * Returns the current args for the active story, and functions to update/reset them.
+ * Supports a generic type parameter for full type inference.
+ *
+ * @example
+ * ```ts
+ * const [args, updateArgs, resetArgs, initialArgs] = useArgs<{ name: string; age: number }>();
+ * console.log(`Current args: ${JSON.stringify(args)}`);
+ * updateArgs({ name: 'John' });
+ * resetArgs(['name']);
+ * ```
+ *
+ * @template TArgs The type of the story's args. Defaults to `Args`.
+ * @returns A tuple of [currentArgs, updateFn, resetFn, initialArgs].
+ */
+export function useArgs<TArgs extends Args = Args>(): [
+  TArgs,
+  (newArgs: Partial<TArgs>) => void,
+  (argNames?: (keyof TArgs)[]) => void,
+  TArgs,
+] {
   const { getCurrentStoryData, updateStoryArgs, resetStoryArgs } = useStorybookApi();
 
   const data = getCurrentStoryData();
@@ -467,15 +487,15 @@ export function useArgs(): [Args, (newArgs: Args) => void, (argNames?: string[])
   const initialArgs = data?.type === 'story' ? data.initialArgs : {};
 
   const updateArgs = useCallback(
-    (newArgs: Args) => updateStoryArgs(data as API_StoryEntry, newArgs),
+    (newArgs: Partial<TArgs>) => updateStoryArgs(data as API_StoryEntry, newArgs),
     [data, updateStoryArgs]
   );
   const resetArgs = useCallback(
-    (argNames?: string[]) => resetStoryArgs(data as API_StoryEntry, argNames),
+    (argNames?: (keyof TArgs)[]) => resetStoryArgs(data as API_StoryEntry, argNames),
     [data, resetStoryArgs]
   );
 
-  return [args!, updateArgs, resetArgs, initialArgs!];
+  return [args as TArgs, updateArgs, resetArgs, initialArgs as TArgs];
 }
 
 export function useGlobals(): [

--- a/code/core/src/manager-api/tests/useArgs-types.test-d.ts
+++ b/code/core/src/manager-api/tests/useArgs-types.test-d.ts
@@ -1,0 +1,68 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { Args } from 'storybook/internal/types';
+
+// We import from the manager API (the one we fixed)
+// In the preview API context, useArgs would come from preview-api/modules/addons/hooks
+// but in the manager/panel context it comes from manager-api/root
+import { useArgs } from './root.tsx';
+
+/**
+ * Type tests for `useArgs` generic parameter support.
+ *
+ * Regression test for: https://github.com/storybookjs/storybook/issues/25070
+ *
+ * The `useArgs` hook should accept a generic type parameter that properly
+ * constrains the returned args tuple. Without this fix, the manager API's
+ * `useArgs` was not generic (unlike the preview API version), causing
+ * type conflicts and losing type information.
+ */
+describe('useArgs generic types', () => {
+  it('infers arg types from the generic parameter', () => {
+    const [args, updateArgs, resetArgs, initialArgs] = useArgs<{
+      name: string;
+      age: number;
+    }>();
+
+    // args should be typed as the provided generic type
+    expectTypeOf(args).toEqualTypeOf<{ name: string; age: number }>();
+
+    // updateArgs should accept Partial<TArgs>
+    expectTypeOf(updateArgs).toBeFunction();
+    expectTypeOf(updateArgs).parameter(0).toMatchTypeOf<Partial<{ name: string; age: number }>>();
+
+    // resetArgs should accept an optional array of keys of TArgs
+    expectTypeOf(resetArgs).toBeFunction();
+
+    // initialArgs should match TArgs
+    expectTypeOf(initialArgs).toEqualTypeOf<{ name: string; age: number }>();
+  });
+
+  it('defaults to Args when no generic is provided', () => {
+    const [args] = useArgs();
+
+    // Should default to the base Args type
+    expectTypeOf(args).toMatchTypeOf<Args>();
+  });
+
+  it('allows narrowing via the generic parameter', () => {
+    interface CustomArgs {
+      enabled: boolean;
+      count: number;
+      label?: string;
+    }
+
+    const [args, updateArgs, resetArgs] = useArgs<CustomArgs>();
+
+    // args should be exactly CustomArgs
+    expectTypeOf(args).toMatchTypeOf<CustomArgs>();
+
+    // updateArgs should accept Partial<CustomArgs> — all fields optional
+    updateArgs({ count: 42 });
+    // @ts-expect-error - unknown field should error
+    updateArgs({ unknown: 'value' });
+
+    // resetArgs should accept key names as strings (from keyof)
+    resetArgs(['count', 'label']);
+  });
+});


### PR DESCRIPTION
## Problem

**Issue: #25070**

`useArgs<generic>` lost its generic type parameter when upgrading from 7.4.6 → 7.6.2. The preview API version of `useArgs` (in `preview-api/modules/addons/hooks.ts`) correctly supports generics, but the **manager API** version (in `manager-api/root.tsx`) does not, causing a type conflict.

### Before fix (broken)

\`\`\`typescript
// In manager/panel context:
const [args, updateArgs, resetArgs] = useArgs<{ name: string }>();
// args is typed as `Args` (loose) — NOT `{ name: string }`
// updateArgs expects `Args` — NOT `Partial<{ name: string }>`
// resetArgs expects `string[]` — NOT `(keyof TArgs)[]`
\`\`\`

### After fix

\`\`\`typescript
// Generic type flows through correctly:
const [args, updateArgs, resetArgs, initialArgs] = useArgs<{ name: string; age: number }>();
// args: { name: string; age: number } ✅
// updateArgs: (Partial<{ name: string; age: number }>) => void ✅
// resetArgs: ((keyof { name: string; age: number })[]) => void ✅
// initialArgs: { name: string; age: number } ✅
\`\`\`

## Root Cause

There are **two exports** of \`useArgs\`:

| Location | Generic? | Used in |
|---|---|---|
| \`preview-api/modules/addons/hooks.ts\` | ✅ Yes `<TArgs extends Args = Args>` | Preview iframe (stories) |
| \`manager-api/root.tsx\` | ❌ No (was bare \`Args\`) | Manager UI (panels, controls) |

The manager API version was never updated when PR #20610 added generic support to the preview API version. When TypeScript resolves the import in manager contexts, it finds the non-generic version and loses all type information.

## Fix Details

Modified \`code/core/src/manager-api/root.tsx\`:

1. Added generic parameter: `<TArgs extends Args = Args>`
2. Typed return tuple with \`TArgs\` instead of bare \`Args\`
3. \`updateArgs\` callback now accepts \`Partial<TArgs>\` instead of \`Args\`
4. \`resetArgs\` argNames now typed as \`(keyof TArgs)[]\` instead of \`string[]\`
5. Added JSDoc with example matching the preview API documentation
6. Cast internal values to \`TArgs\` for proper type narrowing

## Test Coverage

Added type test file \`manager-api/tests/useArgs-types.test-d.ts\`:

- **Generic inference**: Verifies that `useArgs<{ name: string; age: number }>()` returns properly typed args
- **Default type**: Verifies that `useArgs()` without generic defaults to `Args`
- **Type narrowing**: Verifies that `updateArgs` accepts partial updates and rejects unknown fields

## Verification

\`\`\`bash
# Run the type tests:
cd code/core && pnpm vitest run src/manager-api/tests/useArgs-types.test-d.ts

# Manual type check:
pnpm tsc --noEmit --project tsconfig.manager.json
\`\`\`

## Edge Cases Handled

- **No generic provided**: Defaults to base \`Args\` type (backwards compatible)
- **Optional fields in args**: \`Partial<TArgs>\` correctly makes all fields optional in \`updateArgs\`
- **resetArgs key names**: Keys are properly constrained to \`keyof TArgs\`, not arbitrary strings
- **Fourth element (initialArgs)**: Also typed as \`TArgs\` for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated useArgs hook with generic type support for more precise type inference and narrower return types.

* **Tests**
  * Added TypeScript type tests for useArgs hook to validate generic behavior and type constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->