### PR TITLE
Add `@storybook/react-vite` as an optional peer dependency

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -379,10 +379,14 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
+    "@storybook/react-vite": "^10",
     "prettier": "^2 || ^3",
     "vite-plus": "^0.1.15"
   },
   "peerDependenciesMeta": {
+    "@storybook/react-vite": {
+      "optional": true
+    },
     "prettier": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -29384,9 +29384,12 @@ __metadata:
     ws: "npm:^8.18.0"
     zod: "npm:^3.25.76"
   peerDependencies:
+    "@storybook/react-vite": ^10
     prettier: ^2 || ^3
     vite-plus: ^0.1.15
   peerDependenciesMeta:
+    "@storybook/react-vite":
+      optional: true
     prettier:
       optional: true
     vite-plus:


### PR DESCRIPTION
When running pnpm in stricter modes, I see this error:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@storybook/react-vite'
imported from
/Users/[user]/Library/pnpm/store/v10/links/@/storybook/10.3.5/[hash]/node_modules/storybook/dist/_node-chunks/chunk-YBRG5EIF.js
```

This because pnpm doesn't link this package, as it isn't declared as a peer dependency.

As a workaround, users can add this to `pnpm-workspace.yaml`:
```yaml
packageExtensions:
  storybook:
    optionalDependencies:
      "@storybook/react-vite": "^10"
```

## What I did

Added `@storybook/react-vite` as an optional peer dependency to the `storybook` package.

## Checklist for Contributors

### Testing

See manual testing.

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Use these settings in `pnpm-workspace.yaml`:
```yaml
# Symlinks all packages.
enableGlobalVirtualStore: true
```


### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional Storybook React Vite support as a peer dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->