### PR TITLE
Build: Add FIX_ON_COMMIT env var to force autofix in pre-commit hook

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,10 +1,12 @@
 import { detectAgent } from 'std-env';
 
-const fmtCmd = detectAgent().name ? 'oxfmt' : 'oxfmt --check';
+const autofix = process.env.FIX_ON_COMMIT || detectAgent().name;
+const fmtCmd = autofix ? 'oxfmt' : 'oxfmt --check';
+const lintSuffix = autofix ? ' --fix' : '';
 
 export default {
-  'code/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd, 'yarn --cwd code lint:js:cmd'],
-  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': ['yarn --cwd scripts lint:js:cmd'],
+  'code/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd, `yarn --cwd code lint:js:cmd${lintSuffix}`],
+  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [`yarn --cwd scripts lint:js:cmd${lintSuffix}`],
   'docs/_snippets/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd],
   '**/*.ejs': ['yarn --cwd scripts exec ejslint'],
   '**/package.json': ['yarn --cwd scripts lint:package'],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ Avoid `console.log`, `console.warn`, and `console.error` unless the file is isol
 | `STORYBOOK_DISABLE_TELEMETRY` | Disable telemetry           |
 | `STORYBOOK_TELEMETRY_DEBUG`   | Log telemetry events        |
 | `DEBUG`                       | Enable debug logging        |
+| `FIX_ON_COMMIT`               | Force autofix for fmt & lint in pre-commit hook |
 
 ## Commands To Avoid
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Added a `FIX_ON_COMMIT` environment variable that, when set, forces the pre-commit hook to run formatting (`oxfmt`) and linting (`eslint --fix`) in autofix mode — regardless of whether the committer is an AI agent or a human.

Previously, autofix was only enabled when `std-env` detected a package manager agent. Now you can set `FIX_ON_COMMIT=1` to get the same behavior manually.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

Test by running:
1. `FIX_ON_COMMIT=1 git commit` — formatting and lint should autofix staged files
2. `git commit` (without the env var, outside an agent context) — should run in check-only mode as before

### Documentation

- [x] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Formatting and linting can now be automatically fixed during pre-commit hooks when enabled via environment variable.

* **Documentation**
  * Added documentation for the new environment variable controlling autofix behavior on commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->