### PR TITLE
CLI: Review onboarding trigger logic on first dev run

### DIFF
--- a/code/core/src/core-server/build-dev.onboarding.test.ts
+++ b/code/core/src/core-server/build-dev.onboarding.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Use vi.hoisted so these are available when vi.mock factory runs
-const { mockCacheGet, mockCacheRemove } = vi.hoisted(() => ({
+const { mockCacheGet, mockCacheRemove, mockDetectAgent } = vi.hoisted(() => ({
   mockCacheGet: vi.fn(),
   mockCacheRemove: vi.fn(),
+  mockDetectAgent: vi.fn(),
 }));
 
 vi.mock('storybook/internal/common', async (importOriginal) => {
@@ -18,50 +19,45 @@ vi.mock('storybook/internal/common', async (importOriginal) => {
   };
 });
 
-import { resolveOnboardingInitialPath } from './build-dev.ts';
+vi.mock('storybook/internal/telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('storybook/internal/telemetry')>();
+  return { ...actual, detectAgent: mockDetectAgent };
+});
 
-const ADDONS_WITH_ONBOARDING = ['@storybook/addon-onboarding'];
-const ADDONS_WITHOUT_ONBOARDING = ['@storybook/addon-essentials'];
+import { resolveOnboardingInitialPath } from './build-dev.ts';
 
 describe('resolveOnboardingInitialPath', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDetectAgent.mockReturnValue(undefined); // default: not an agent
   });
 
-  it('returns /onboarding and removes cache entry when onboarding-pending is set, no CLI initialPath, and addon is present', async () => {
+  it('returns /onboarding and removes cache entry when onboarding-pending is set and no CLI initialPath', async () => {
     mockCacheGet.mockResolvedValue(true);
-    const result = await resolveOnboardingInitialPath(undefined, ADDONS_WITH_ONBOARDING);
+    const result = await resolveOnboardingInitialPath(undefined);
     expect(result).toBe('/onboarding');
     expect(mockCacheRemove).toHaveBeenCalledWith('onboarding-pending');
   });
 
   it('returns undefined and does not remove cache when onboarding-pending is absent', async () => {
     mockCacheGet.mockResolvedValue(undefined);
-    const result = await resolveOnboardingInitialPath(undefined, ADDONS_WITH_ONBOARDING);
+    const result = await resolveOnboardingInitialPath(undefined);
     expect(result).toBeUndefined();
     expect(mockCacheRemove).not.toHaveBeenCalled();
   });
 
   it('returns CLI initialPath and does NOT remove cache when CLI initialPath is already set', async () => {
     mockCacheGet.mockResolvedValue(true);
-    const result = await resolveOnboardingInitialPath('/my-story', ADDONS_WITH_ONBOARDING);
+    const result = await resolveOnboardingInitialPath('/my-story');
     expect(result).toBe('/my-story');
     expect(mockCacheRemove).not.toHaveBeenCalled();
   });
 
-  it('returns undefined and does NOT remove cache when addon-onboarding is not installed', async () => {
+  it('returns undefined and does NOT remove cache when running in an agent context', async () => {
+    mockDetectAgent.mockReturnValue({ name: 'claude' });
     mockCacheGet.mockResolvedValue(true);
-    const result = await resolveOnboardingInitialPath(undefined, ADDONS_WITHOUT_ONBOARDING);
+    const result = await resolveOnboardingInitialPath(undefined);
     expect(result).toBeUndefined();
     expect(mockCacheRemove).not.toHaveBeenCalled();
-  });
-
-  it('works with object-form addon entries', async () => {
-    mockCacheGet.mockResolvedValue(true);
-    const result = await resolveOnboardingInitialPath(undefined, [
-      { name: '@storybook/addon-onboarding' },
-    ]);
-    expect(result).toBe('/onboarding');
-    expect(mockCacheRemove).toHaveBeenCalledWith('onboarding-pending');
   });
 });

--- a/code/core/src/core-server/build-dev.onboarding.test.ts
+++ b/code/core/src/core-server/build-dev.onboarding.test.ts
@@ -20,29 +20,48 @@ vi.mock('storybook/internal/common', async (importOriginal) => {
 
 import { resolveOnboardingInitialPath } from './build-dev.ts';
 
+const ADDONS_WITH_ONBOARDING = ['@storybook/addon-onboarding'];
+const ADDONS_WITHOUT_ONBOARDING = ['@storybook/addon-essentials'];
+
 describe('resolveOnboardingInitialPath', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns /onboarding and removes cache entry when onboarding-pending is set and no CLI initialPath', async () => {
+  it('returns /onboarding and removes cache entry when onboarding-pending is set, no CLI initialPath, and addon is present', async () => {
     mockCacheGet.mockResolvedValue(true);
-    const result = await resolveOnboardingInitialPath(undefined);
+    const result = await resolveOnboardingInitialPath(undefined, ADDONS_WITH_ONBOARDING);
     expect(result).toBe('/onboarding');
     expect(mockCacheRemove).toHaveBeenCalledWith('onboarding-pending');
   });
 
   it('returns undefined and does not remove cache when onboarding-pending is absent', async () => {
     mockCacheGet.mockResolvedValue(undefined);
-    const result = await resolveOnboardingInitialPath(undefined);
+    const result = await resolveOnboardingInitialPath(undefined, ADDONS_WITH_ONBOARDING);
     expect(result).toBeUndefined();
     expect(mockCacheRemove).not.toHaveBeenCalled();
   });
 
   it('returns CLI initialPath and does NOT remove cache when CLI initialPath is already set', async () => {
     mockCacheGet.mockResolvedValue(true);
-    const result = await resolveOnboardingInitialPath('/my-story');
+    const result = await resolveOnboardingInitialPath('/my-story', ADDONS_WITH_ONBOARDING);
     expect(result).toBe('/my-story');
     expect(mockCacheRemove).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined and does NOT remove cache when addon-onboarding is not installed', async () => {
+    mockCacheGet.mockResolvedValue(true);
+    const result = await resolveOnboardingInitialPath(undefined, ADDONS_WITHOUT_ONBOARDING);
+    expect(result).toBeUndefined();
+    expect(mockCacheRemove).not.toHaveBeenCalled();
+  });
+
+  it('works with object-form addon entries', async () => {
+    mockCacheGet.mockResolvedValue(true);
+    const result = await resolveOnboardingInitialPath(undefined, [
+      { name: '@storybook/addon-onboarding' },
+    ]);
+    expect(result).toBe('/onboarding');
+    expect(mockCacheRemove).toHaveBeenCalledWith('onboarding-pending');
   });
 });

--- a/code/core/src/core-server/build-dev.onboarding.test.ts
+++ b/code/core/src/core-server/build-dev.onboarding.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Use vi.hoisted so these are available when vi.mock factory runs
+const { mockCacheGet, mockCacheRemove } = vi.hoisted(() => ({
+  mockCacheGet: vi.fn(),
+  mockCacheRemove: vi.fn(),
+}));
+
+vi.mock('storybook/internal/common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('storybook/internal/common')>();
+  return {
+    ...actual,
+    cache: {
+      get: mockCacheGet,
+      set: vi.fn(),
+      remove: mockCacheRemove,
+    },
+  };
+});
+
+import { resolveOnboardingInitialPath } from './build-dev.ts';
+
+describe('resolveOnboardingInitialPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns /onboarding and removes cache entry when onboarding-pending is set and no CLI initialPath', async () => {
+    mockCacheGet.mockResolvedValue(true);
+    const result = await resolveOnboardingInitialPath(undefined);
+    expect(result).toBe('/onboarding');
+    expect(mockCacheRemove).toHaveBeenCalledWith('onboarding-pending');
+  });
+
+  it('returns undefined and does not remove cache when onboarding-pending is absent', async () => {
+    mockCacheGet.mockResolvedValue(undefined);
+    const result = await resolveOnboardingInitialPath(undefined);
+    expect(result).toBeUndefined();
+    expect(mockCacheRemove).not.toHaveBeenCalled();
+  });
+
+  it('returns CLI initialPath and does NOT remove cache when CLI initialPath is already set', async () => {
+    mockCacheGet.mockResolvedValue(true);
+    const result = await resolveOnboardingInitialPath('/my-story');
+    expect(result).toBe('/my-story');
+    expect(mockCacheRemove).not.toHaveBeenCalled();
+  });
+});

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -63,9 +63,9 @@ export async function resolveOnboardingInitialPath(
     // Agent environments skip onboarding (no browser to open).
     return cliInitialPath;
   }
-  const onboardingPending = await cache.get('onboarding-pending');
+  const onboardingPending = await cache.get('onboarding-pending').catch(() => {});
   if (onboardingPending) {
-    await cache.remove('onboarding-pending');
+    await cache.remove('onboarding-pending').catch(() => {});
     return '/onboarding';
   }
   return undefined;

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -16,7 +16,12 @@ import {
 } from 'storybook/internal/common';
 import { CLI_COLORS, deprecate, logger, prompt } from 'storybook/internal/node-logger';
 import { MissingBuilderError, NoStatsForViteDevError } from 'storybook/internal/server-errors';
-import { oneWayHash, setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import {
+  detectAgent,
+  oneWayHash,
+  setTelemetryEnabled,
+  telemetry,
+} from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
@@ -45,13 +50,14 @@ import { warnWhenUsingArgTypesRegex } from './utils/warnWhenUsingArgTypesRegex.t
 /**
  * Resolves the initialPath for the browser open URL.
  * CLI-provided initialPath always wins. If not set, checks the project cache for
- * an `onboarding-pending` entry written by `storybook init`. If found, returns
- * '/onboarding' and removes the cache entry so it only triggers once.
+ * an `onboarding-pending` entry written by `storybook init`. If found, and if the
+ * user is human rather than an agent, returns '/onboarding' and removes the cache
+ * entry so it only triggers once.
  */
 export async function resolveOnboardingInitialPath(
   cliInitialPath: string | undefined
 ): Promise<string | undefined> {
-  if (cliInitialPath) {
+  if (cliInitialPath || detectAgent()) {
     // Explicit CLI flag wins; leave cache intact for next run
     return cliInitialPath;
   }

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 
 import {
   JsPackageManagerFactory,
+  cache,
   getConfigInfo,
   getInterpretedFile,
   getProjectRoot,
@@ -40,6 +41,27 @@ import { stripCommentsAndStrings } from './utils/strip-comments-and-strings.ts';
 import { updateCheck } from './utils/update-check.ts';
 import { warnOnIncompatibleAddons } from './utils/warnOnIncompatibleAddons.ts';
 import { warnWhenUsingArgTypesRegex } from './utils/warnWhenUsingArgTypesRegex.ts';
+
+/**
+ * Resolves the initialPath for the browser open URL.
+ * CLI-provided initialPath always wins. If not set, checks the project cache for
+ * an `onboarding-pending` entry written by `storybook init`. If found, returns
+ * '/onboarding' and removes the cache entry so it only triggers once.
+ */
+export async function resolveOnboardingInitialPath(
+  cliInitialPath: string | undefined
+): Promise<string | undefined> {
+  if (cliInitialPath) {
+    // Explicit CLI flag wins; leave cache intact for next run
+    return cliInitialPath;
+  }
+  const onboardingPending = await cache.get('onboarding-pending');
+  if (onboardingPending) {
+    await cache.remove('onboarding-pending');
+    return '/onboarding';
+  }
+  return undefined;
+}
 
 export async function buildDevStandalone(
   options: CLIOptions &
@@ -86,6 +108,9 @@ export async function buildDevStandalone(
   }
 
   const cacheKey = oneWayHash(relative(getProjectRoot(), configDir));
+
+  // Resolve initialPath: CLI flag takes precedence; fall back to onboarding-pending cache entry
+  options.initialPath = await resolveOnboardingInitialPath(options.initialPath);
 
   const cacheOutputDir = resolvePathInStorybookCache('public', cacheKey);
   let outputDir = resolve(options.outputDir || cacheOutputDir);

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -16,7 +16,12 @@ import {
 } from 'storybook/internal/common';
 import { CLI_COLORS, deprecate, logger, prompt } from 'storybook/internal/node-logger';
 import { MissingBuilderError, NoStatsForViteDevError } from 'storybook/internal/server-errors';
-import { oneWayHash, setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import {
+  detectAgent,
+  oneWayHash,
+  setTelemetryEnabled,
+  telemetry,
+} from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
@@ -44,30 +49,24 @@ import { warnWhenUsingArgTypesRegex } from './utils/warnWhenUsingArgTypesRegex.t
 
 /**
  * Resolves the initialPath for the browser open URL.
- * CLI-provided initialPath always wins. If not set, checks the project cache for
- * an `onboarding-pending` entry written by `storybook init`. If found AND
- * `@storybook/addon-onboarding` is present in the project's addon list, returns
- * '/onboarding' and removes the cache entry so it only triggers once.
- * If the addon is not present, the cache entry is left intact for a future run
- * once the addon is installed.
+ * CLI-provided initialPath always wins. If not set and not running in an agent context,
+ * checks the project cache for an `onboarding-pending` entry written by `storybook init`.
+ * If found, returns '/onboarding' and removes the cache entry so it only triggers once.
+ * The cache entry is only written by init when onboarding is known to be supported,
+ * so no further addon check is needed here.
  */
 export async function resolveOnboardingInitialPath(
-  cliInitialPath: string | undefined,
-  addons: Array<string | { name: string }> = []
+  cliInitialPath: string | undefined
 ): Promise<string | undefined> {
-  if (cliInitialPath) {
-    // Explicit CLI flag wins; leave cache intact for next run
+  if (cliInitialPath || detectAgent()) {
+    // Explicit CLI flag wins; leave cache intact for next run.
+    // Agent environments skip onboarding (no browser to open).
     return cliInitialPath;
   }
   const onboardingPending = await cache.get('onboarding-pending');
   if (onboardingPending) {
-    const hasOnboardingAddon = addons.some((addon) =>
-      (typeof addon === 'string' ? addon : addon.name).includes('@storybook/addon-onboarding')
-    );
-    if (hasOnboardingAddon) {
-      await cache.remove('onboarding-pending');
-      return '/onboarding';
-    }
+    await cache.remove('onboarding-pending');
+    return '/onboarding';
   }
   return undefined;
 }
@@ -118,6 +117,17 @@ export async function buildDevStandalone(
 
   const cacheKey = oneWayHash(relative(getProjectRoot(), configDir));
 
+  // Resolve initialPath: CLI flag takes precedence; fall back to onboarding-pending cache entry.
+  invariant(port, 'expected options to have a port');
+  options.initialPath = await resolveOnboardingInitialPath(options.initialPath);
+
+  const { address: localAddress, networkAddress } = getServerAddresses(
+    port,
+    options.host,
+    options.https ? 'https' : 'http',
+    options.initialPath
+  );
+
   const cacheOutputDir = resolvePathInStorybookCache('public', cacheKey);
   let outputDir = resolve(options.outputDir || cacheOutputDir);
   if (options.smokeTest) {
@@ -130,6 +140,9 @@ export async function buildDevStandalone(
   options.configDir = configDir;
   options.cacheKey = cacheKey;
   options.outputDir = outputDir;
+  options.serverChannelUrl = getServerChannelUrl(port, options);
+  options.localAddress = localAddress;
+  options.networkAddress = networkAddress;
 
   // TODO: Remove in SB11
   options.pnp = await detectPnp();
@@ -144,23 +157,6 @@ export async function buildDevStandalone(
 
   const config = await loadMainConfig(options);
   const { core, framework } = config;
-
-  // Resolve initialPath after config is loaded so we can check for addon-onboarding.
-  // CLI flag takes precedence; falls back to onboarding-pending cache entry.
-  invariant(port, 'expected options to have a port');
-  options.initialPath = await resolveOnboardingInitialPath(
-    options.initialPath,
-    config.addons ?? []
-  );
-  const { address: localAddress, networkAddress } = getServerAddresses(
-    port,
-    options.host,
-    options.https ? 'https' : 'http',
-    options.initialPath
-  );
-  options.serverChannelUrl = getServerChannelUrl(port, options);
-  options.localAddress = localAddress;
-  options.networkAddress = networkAddress;
 
   const corePresets = [];
 

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -16,12 +16,7 @@ import {
 } from 'storybook/internal/common';
 import { CLI_COLORS, deprecate, logger, prompt } from 'storybook/internal/node-logger';
 import { MissingBuilderError, NoStatsForViteDevError } from 'storybook/internal/server-errors';
-import {
-  detectAgent,
-  oneWayHash,
-  setTelemetryEnabled,
-  telemetry,
-} from 'storybook/internal/telemetry';
+import { oneWayHash, setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
@@ -50,21 +45,29 @@ import { warnWhenUsingArgTypesRegex } from './utils/warnWhenUsingArgTypesRegex.t
 /**
  * Resolves the initialPath for the browser open URL.
  * CLI-provided initialPath always wins. If not set, checks the project cache for
- * an `onboarding-pending` entry written by `storybook init`. If found, and if the
- * user is human rather than an agent, returns '/onboarding' and removes the cache
- * entry so it only triggers once.
+ * an `onboarding-pending` entry written by `storybook init`. If found AND
+ * `@storybook/addon-onboarding` is present in the project's addon list, returns
+ * '/onboarding' and removes the cache entry so it only triggers once.
+ * If the addon is not present, the cache entry is left intact for a future run
+ * once the addon is installed.
  */
 export async function resolveOnboardingInitialPath(
-  cliInitialPath: string | undefined
+  cliInitialPath: string | undefined,
+  addons: Array<string | { name: string }> = []
 ): Promise<string | undefined> {
-  if (cliInitialPath || detectAgent()) {
+  if (cliInitialPath) {
     // Explicit CLI flag wins; leave cache intact for next run
     return cliInitialPath;
   }
   const onboardingPending = await cache.get('onboarding-pending');
   if (onboardingPending) {
-    await cache.remove('onboarding-pending');
-    return '/onboarding';
+    const hasOnboardingAddon = addons.some((addon) =>
+      (typeof addon === 'string' ? addon : addon.name).includes('@storybook/addon-onboarding')
+    );
+    if (hasOnboardingAddon) {
+      await cache.remove('onboarding-pending');
+      return '/onboarding';
+    }
   }
   return undefined;
 }
@@ -115,22 +118,11 @@ export async function buildDevStandalone(
 
   const cacheKey = oneWayHash(relative(getProjectRoot(), configDir));
 
-  // Resolve initialPath: CLI flag takes precedence; fall back to onboarding-pending cache entry
-  options.initialPath = await resolveOnboardingInitialPath(options.initialPath);
-
   const cacheOutputDir = resolvePathInStorybookCache('public', cacheKey);
   let outputDir = resolve(options.outputDir || cacheOutputDir);
   if (options.smokeTest) {
     outputDir = cacheOutputDir;
   }
-
-  invariant(port, 'expected options to have a port');
-  const { address: localAddress, networkAddress } = getServerAddresses(
-    port,
-    options.host,
-    options.https ? 'https' : 'http',
-    options.initialPath
-  );
 
   options.port = port;
   options.versionCheck = versionCheck;
@@ -138,9 +130,6 @@ export async function buildDevStandalone(
   options.configDir = configDir;
   options.cacheKey = cacheKey;
   options.outputDir = outputDir;
-  options.serverChannelUrl = getServerChannelUrl(port, options);
-  options.localAddress = localAddress;
-  options.networkAddress = networkAddress;
 
   // TODO: Remove in SB11
   options.pnp = await detectPnp();
@@ -155,6 +144,24 @@ export async function buildDevStandalone(
 
   const config = await loadMainConfig(options);
   const { core, framework } = config;
+
+  // Resolve initialPath after config is loaded so we can check for addon-onboarding.
+  // CLI flag takes precedence; falls back to onboarding-pending cache entry.
+  invariant(port, 'expected options to have a port');
+  options.initialPath = await resolveOnboardingInitialPath(
+    options.initialPath,
+    config.addons ?? []
+  );
+  const { address: localAddress, networkAddress } = getServerAddresses(
+    port,
+    options.host,
+    options.https ? 'https' : 'http',
+    options.initialPath
+  );
+  options.serverChannelUrl = getServerChannelUrl(port, options);
+  options.localAddress = localAddress;
+  options.networkAddress = networkAddress;
+
   const corePresets = [];
 
   let frameworkName = typeof framework === 'string' ? framework : framework?.name;

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -162,7 +162,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   // Signal dev to redirect to onboarding on first run
   const shouldOnboard = newUser;
   if (shouldOnboard && FeatureCompatibilityService.supportsOnboarding(projectType)) {
-    await cache.set('onboarding-pending', true);
+    await cache.set('onboarding-pending', true).catch(() => {});
   }
 
   return {

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -220,17 +220,14 @@ async function runStorybookDev(result: {
   projectType: ProjectType;
   packageManager: JsPackageManager;
   storybookCommand?: string | null;
-  shouldOnboard: boolean;
 }): Promise<void> {
-  const { projectType, packageManager, storybookCommand, shouldOnboard } = result;
+  const { projectType, packageManager, storybookCommand } = result;
 
   if (!storybookCommand) {
     return;
   }
 
   try {
-    const supportsOnboarding = FeatureCompatibilityService.supportsOnboarding(projectType);
-
     const parts = storybookCommand.split(' ');
 
     // Angular CLI throws "Unknown argument: silent"
@@ -257,10 +254,6 @@ async function runStorybookDev(result: {
 
       if (useAlternativePort) {
         parts.push(`-p`, `${availablePort}`);
-      }
-
-      if (supportsOnboarding && shouldOnboard) {
-        parts.push('--initial-path=/onboarding');
       }
 
       parts.push('--quiet');

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -2,6 +2,7 @@ import { ProjectType } from 'storybook/internal/cli';
 import {
   type JsPackageManager,
   PackageManagerName,
+  cache,
   executeCommand,
 } from 'storybook/internal/common';
 import { getServerPort, withTelemetry } from 'storybook/internal/core-server';
@@ -157,6 +158,12 @@ export async function doInitiate(options: CommandOptions): Promise<
 
   // Step 9: Track telemetry
   await telemetryService.trackInitWithContext(projectType, selectedFeatures, newUser);
+
+  // Signal dev to redirect to onboarding on first run
+  const shouldOnboard = newUser;
+  if (shouldOnboard && FeatureCompatibilityService.supportsOnboarding(projectType)) {
+    await cache.set('onboarding-pending', true);
+  }
 
   return {
     shouldRunDev:


### PR DESCRIPTION
## What I did

Replaced the old `init` -> `dev --initial-path=/onboarding` workflow with one where `init` registers when onboarding must happen in the local project cache, and any subsequent `dev` call consumes this registered flag if no `--initial-path` is set, allowing the user to be onboarded.

## Checklist for Contributors

### Testing


#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

* Remove "skipOnbarding" from your global SB settings in your home
* Create a new project
* Run `dev`

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34552-sha-a34e9165`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34552-sha-a34e9165 sandbox` or in an existing project with `npx storybook@0.0.0-pr-34552-sha-a34e9165 upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34552-sha-a34e9165`](https://npmjs.com/package/storybook/v/0.0.0-pr-34552-sha-a34e9165) |
| **Triggered by** | @Sidnioulz |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`sidnioulz/fix-onboarding-ux-trigger`](https://github.com/storybookjs/storybook/tree/sidnioulz/fix-onboarding-ux-trigger) |
| **Commit** | [`a34e9165`](https://github.com/storybookjs/storybook/commit/a34e9165610ead76b80fd113da40c7245587a8bf) |
| **Datetime** | Wed Apr 15 14:27:55 UTC 2026 (`1776263275`) |
| **Workflow run** | [24460240811](https://github.com/storybookjs/storybook/actions/runs/24460240811) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34552`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering onboarding initial-path resolution for cached onboarding, CLI-provided paths, and agent contexts.

* **Refactor**
  * Onboarding signaling now uses a persistent flag instead of injecting a CLI path.
  * Dev startup respects an explicit CLI path and agent context over the onboarding flag; explicit initial-path injection removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->