### PR TITLE
fix(angular): restore literal union type inference for controls (#33779)

### DIFF
--- a/code/frameworks/angular/src/client/compodoc.ts
+++ b/code/frameworks/angular/src/client/compodoc.ts
@@ -131,7 +131,15 @@ const extractEnumValues = (compodocType: any) => {
   }
 
   try {
-    return compodocType.split('|').map((value) => JSON.parse(value));
+    return compodocType.split('|').map((value) => {
+      const trimmed = value.trim();
+      // Handle quoted string literals like 'S' or "S"
+      if ((trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+          (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+        return trimmed.slice(1, -1);
+      }
+      return JSON.parse(trimmed);
+    });
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## Problem

Storybook 10 no longer infers controls from TypeScript literal union types in Angular components.

Given a component input typed as:
```typescript
size = input<'S' | 'M' | 'L'>()
```

In Storybook < 10, this automatically generated a select control with options `S`, `M`, `L`.
In Storybook 10, literal union types are not read and controls must be manually defined.

## Root Cause

The `extractEnumValues()` function in `code/frameworks/angular/src/client/compodoc.ts` processes compodoc type strings. When compodoc returns an inline literal union like `'S' | 'M' | 'L'`:

1. `compodocType.split('|')` produces `["'S' ", " 'M' ", " 'L'"]`
2. `JSON.parse("'S' ")` fails because of trailing whitespace
3. The function returns `null`
4. `extractType()` falls back to `{ name: 'other', value: 'empty-enum' }`

## Fix

Trim whitespace before parsing, and handle single-quoted string literals directly by slicing quotes instead of relying on `JSON.parse` (which doesn't support single quotes).

```diff
-    return compodocType.split('|').map((value) => JSON.parse(value));
+    return compodocType.split('|').map((value) => {
+      const trimmed = value.trim();
+      // Handle quoted string literals like 'S' or "S"
+      if ((trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+          (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+        return trimmed.slice(1, -1);
+      }
+      return JSON.parse(trimmed);
+    });
```

## Testing

- Before fix: `'S' | 'M' | 'L'` → `{ name: 'other', value: 'empty-enum' }` (no select control)
- After fix: `'S' | 'M' | 'L'` → `{ name: 'enum', value: ['S', 'M', 'L'] }` (select control with options)

---

*Automated fix submitted by Atlas Bounty Hunter*
Fixes #33779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced enum value processing to correctly handle quoted string literals and improve parsing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->