### PR TITLE
CLI: Sync storybook setup prompt with eval pattern-copy-play improvements

### DIFF
--- a/code/lib/cli-storybook/src/ai/prompt.ts
+++ b/code/lib/cli-storybook/src/ai/prompt.ts
@@ -366,7 +366,21 @@ function getSetupInstructions(projectInfo: ProjectInfo): string {
     - a toast, alert, or badge has the expected accessible text and visual state
     - a CSS class or computed style confirms the real state that matters
 
-    ### Step 7: Cover the patterns you found
+    ### Step 7: Prove CSS is loaded in exactly one story
+
+    In exactly one story, assert a component-specific computed style. \`toBeVisible\` passes on an unstyled component; a concrete style value proves the shared preview loaded the app's CSS.
+
+    Read a styling value from the component's source and assert it with \`getComputedStyle\`:
+
+    \`\`\`tsx
+    play: async ({ canvas }) => {
+      const button = canvas.getByRole("button", { name: /submit/i });
+      // PrimaryButton uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+      await expect(getComputedStyle(button).backgroundColor).toBe("rgb(37, 99, 235)");
+    },
+    \`\`\`
+
+    ### Step 8: Cover the patterns you found
 
     Write stories for the real patterns in the codebase, for example:
 
@@ -382,7 +396,7 @@ function getSetupInstructions(projectInfo: ProjectInfo): string {
 
     ${getPageStoryExample(projectInfo)}
 
-    ### Step 8: Verify both rendering and types
+    ### Step 9: Verify both rendering and types
 
     As you work, verify the stories with Vitest:
 

--- a/code/lib/cli-storybook/src/ai/prompt.ts
+++ b/code/lib/cli-storybook/src/ai/prompt.ts
@@ -49,6 +49,8 @@ function getSetupInstructions(projectInfo: ProjectInfo): string {
     Your goal is to make Storybook fully functional in this project by analyzing the codebase,
     configuring the preview with the right decorators, and writing stories for some components.
 
+    The end state should be a Storybook where any component — from a small button to a full page — can be added without story-specific workarounds. All necessary providers, CSS, browser state, and network mocks should live in the shared preview so that new stories only need the component import and a render call.
+
     After each created story, run Vitest to verify it renders.
     If the test fails, read the error, fix the issue, and re-run until it passes before moving on.
 
@@ -286,6 +288,16 @@ function getSetupInstructions(projectInfo: ProjectInfo): string {
     or the rendering is incomplete), add the \`needs-work\` tag alongside \`ai-generated\`:
 
     ${getNeedsWorkTagExample(projectInfo)}
+
+    #### Args vs render
+
+    For simple components where props drive the state, prefer \`args\` stories — no \`render\` function needed:
+
+    ${getArgsStoryExample(projectInfo)}
+
+    Use \`render\` when the story needs composition — wrapping the component in layout, combining multiple components, or passing children as JSX:
+
+    ${getRenderCompositionExample(projectInfo)}
 
     Keep app mocking and runtime setup in preview, not in the stories.
     Do not build large story-specific harnesses.
@@ -661,6 +673,144 @@ function getNeedsWorkTagExample(projectInfo: ProjectInfo): string {
       component: SomeComponent,
       tags: ['ai-generated', 'needs-work'],
     } satisfies Meta<typeof SomeComponent>;
+    \`\`\`
+  `;
+}
+
+function getArgsStoryExample(projectInfo: ProjectInfo): string {
+  if (projectInfo.hasCsfFactoryPreview) {
+    return dedent`
+      \`\`\`tsx
+      import preview from '#.storybook/preview';
+      import { expect } from 'storybook/test';
+      import { Button } from './Button';
+
+      const meta = preview.meta({
+        component: Button,
+        tags: ['ai-generated'],
+      });
+
+      export const Primary = meta.story({
+        args: {
+          variant: 'primary',
+          children: 'Save',
+        },
+        play: async ({ canvas }) => {
+          await expect(canvas.getByRole('button', { name: /save/i })).toBeVisible();
+        },
+      });
+
+      export const Disabled = meta.story({
+        args: {
+          variant: 'primary',
+          disabled: true,
+          children: 'Save',
+        },
+        play: async ({ canvas }) => {
+          await expect(canvas.getByRole('button')).toBeDisabled();
+        },
+      });
+      \`\`\`
+    `;
+  }
+
+  const typeImport = getTypeImportSource(projectInfo);
+
+  return dedent`
+    \`\`\`tsx
+    import type { Meta, StoryObj } from '${typeImport}';
+    import { expect } from 'storybook/test';
+    import { Button } from './Button';
+
+    const meta = {
+      component: Button,
+      tags: ['ai-generated'],
+    } satisfies Meta<typeof Button>;
+
+    export default meta;
+    type Story = StoryObj<typeof meta>;
+
+    export const Primary: Story = {
+      args: {
+        variant: 'primary',
+        children: 'Save',
+      },
+      play: async ({ canvas }) => {
+        await expect(canvas.getByRole('button', { name: /save/i })).toBeVisible();
+      },
+    };
+
+    export const Disabled: Story = {
+      args: {
+        variant: 'primary',
+        disabled: true,
+        children: 'Save',
+      },
+      play: async ({ canvas }) => {
+        await expect(canvas.getByRole('button')).toBeDisabled();
+      },
+    };
+    \`\`\`
+  `;
+}
+
+function getRenderCompositionExample(projectInfo: ProjectInfo): string {
+  if (projectInfo.hasCsfFactoryPreview) {
+    return dedent`
+      \`\`\`tsx
+      import preview from '#.storybook/preview';
+      import { expect } from 'storybook/test';
+      import { Button } from './Button';
+      import { Card } from './Card';
+
+      const meta = preview.meta({
+        component: Button,
+        tags: ['ai-generated'],
+      });
+
+      export const InsideCard = meta.story({
+        render: () => (
+          <Card>
+            <Button disabled={false}>Save</Button>
+          </Card>
+        ),
+        play: async ({ canvas, userEvent }) => {
+          await expect(canvas.getByRole('button', { name: /save/i })).toBeVisible();
+          await userEvent.click(canvas.getByRole('button', { name: /save/i }));
+        },
+      });
+      \`\`\`
+    `;
+  }
+
+  const typeImport = getTypeImportSource(projectInfo);
+
+  return dedent`
+    \`\`\`tsx
+    import type { Meta, StoryObj } from '${typeImport}';
+    import { expect } from 'storybook/test';
+    import { Button } from './Button';
+    import { Card } from './Card';
+
+    const meta = {
+      component: Button,
+      tags: ['ai-generated'],
+    } satisfies Meta<typeof Button>;
+
+    export default meta;
+    type Story = StoryObj<typeof meta>;
+
+    export const InsideCard: Story = {
+      render: () => (
+        <Card>
+          <Button disabled={false}>Save</Button>
+        </Card>
+      ),
+      play: async ({ canvas, userEvent }) => {
+        await expect(canvas.getByRole('button', { name: /save/i })).toBeVisible();
+        await userEvent.click(canvas.getByRole('button', { name: /save/i }));
+      },
+    };
     \`\`\`
   `;
 }

--- a/code/lib/cli-storybook/src/ai/prompt.ts
+++ b/code/lib/cli-storybook/src/ai/prompt.ts
@@ -378,18 +378,21 @@ function getSetupInstructions(projectInfo: ProjectInfo): string {
     - a toast, alert, or badge has the expected accessible text and visual state
     - a CSS class or computed style confirms the real state that matters
 
-    ### Step 7: Prove CSS is loaded in exactly one story
+    ### Step 7: Prove CSS is loaded in exactly one story named \`CssCheck\`
 
-    In exactly one story, assert a component-specific computed style. \`toBeVisible\` passes on an unstyled component; a concrete style value proves the shared preview loaded the app's CSS.
+    In exactly one story, named \`CssCheck\`, assert a component-specific computed style. \`toBeVisible\` passes on an unstyled component; a concrete style value proves the shared preview loaded the app's CSS.
 
-    Read a styling value from the component's source and assert it with \`getComputedStyle\`:
+    Pick a visually distinctive component, read a styling value from its source, and assert it with \`getComputedStyle\`:
 
     \`\`\`tsx
-    play: async ({ canvas }) => {
-      const button = canvas.getByRole("button", { name: /submit/i });
-      // PrimaryButton uses bg-blue-600 — fails if Tailwind / global CSS did not load.
-      await expect(getComputedStyle(button).backgroundColor).toBe("rgb(37, 99, 235)");
-    },
+    export const CssCheck: Story = {
+      args: { children: "Submit" },
+      play: async ({ canvas }) => {
+        const button = canvas.getByRole("button", { name: /submit/i });
+        // PrimaryButton uses bg-blue-600 — fails if Tailwind / global CSS did not load.
+        await expect(getComputedStyle(button).backgroundColor).toBe("rgb(37, 99, 235)");
+      },
+    };
     \`\`\`
 
     ### Step 8: Cover the patterns you found

--- a/code/lib/cli-storybook/src/ai/prompt.ts
+++ b/code/lib/cli-storybook/src/ai/prompt.ts
@@ -49,7 +49,7 @@ function getSetupInstructions(projectInfo: ProjectInfo): string {
     Your goal is to make Storybook fully functional in this project by analyzing the codebase,
     configuring the preview with the right decorators, and writing stories for some components.
 
-    The end state should be a Storybook where any component — from a small button to a full page — can be added without story-specific workarounds. All necessary providers, CSS, browser state, and network mocks should live in the shared preview so that new stories only need the component import and a render call.
+    The end state should be a Storybook where any component — from a small button to a full page — can be added without story-specific workarounds. All necessary providers, CSS, browser state, and network mocks should live in the shared preview so that just rendering the component in the story is enough.
 
     After each created story, run Vitest to verify it renders.
     If the test fails, read the error, fix the issue, and re-run until it passes before moving on.


### PR DESCRIPTION
## What I did

Brings the CLI's shipped `storybook setup` AI prompt (`code/lib/cli-storybook/src/ai/prompt.ts`) up to parity with recent improvements made to the eval harness's `pattern-copy-play` prompt. The two were near-identical until recently, but eval-side edits have drifted forward. This PR ports the drift that applies to end-users without touching anything eval-only.

**Three synced pieces:**

1. **New Step 7: "Prove CSS is loaded in exactly one story"** — asks the agent to include, in exactly one story, a `play` function that asserts a component-specific computed style via `getComputedStyle`. Catches the "component renders but CSS never loaded" failure (missing global CSS import, Tailwind not configured, theme provider not wired up) that otherwise passes `toBeVisible` checks. Step 8/9 renumbered accordingly.

2. **End-state paragraph in the intro** — clarifies the goal: the shared preview should own all providers/CSS/browser state/network mocks so that just rendering the component in the story is enough. (Original eval text said "the component import and a render call", which biased toward `render: () => ...`; softened in a later commit here to avoid that bias.)

3. **New `#### Args vs render` subsection under Step 5** — teaches when to prefer `args` vs when to reach for `render`, with two full examples (`Button` with `args`, `Button inside Card` with `render`). Follows the existing `hasCsfFactoryPreview` / CSF3 branch pattern via two new helpers: `getArgsStoryExample` and `getRenderCompositionExample`.

None of this changes behavior — it's prompt content shipped to the user as markdown by `storybook setup`. The only code additions are the two new helper functions that follow the style of the existing `getStoryExample` / `getNeedsWorkTagExample` / `getPageStoryExample` helpers.

## Checklist for Contributors

### Testing

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

Pure prompt content change in a function that returns a dedented markdown string. No existing tests target `getSetupInstructions` output; I did not add snapshot tests — the prompt evolves too often for snapshots to be useful, and the behavior we care about is "does the agent follow the prompt", which is measured by the eval harness (companion PR #34595 adds a diff-level assertion for the CSS step specifically).

#### Manual testing

1. Run `storybook setup` (or `storybook init` flow that invokes it) against a small React app.
2. Inspect the generated prompt markdown (or the transcript it was sent to the agent).
3. Verify:
   - The intro contains "The end state should be a Storybook where any component..."
   - Step 5 has a `#### Args vs render` subsection with two code examples.
   - Step 7 is "Prove CSS is loaded in exactly one story" with a `getComputedStyle` example.
   - Steps 8 and 9 renumbered from the previous 7 and 8.
4. For CSF Factory projects, verify both new examples use `preview.meta(...)` / `meta.story(...)` syntax; for CSF3 projects, they use `Meta<typeof ...>` / `StoryObj<typeof meta>`.

### Documentation

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

No user-facing documentation changes — the prompt itself is the doc, delivered at `storybook setup` time.

## Checklist for Maintainers

- [x] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes.
- [x] Make sure this PR contains **one** of the labels below.

Labels applied: `build`, `ci:normal`.

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Stricter Storybook setup instructions requiring shared preview for providers, CSS, browser state, and network mocks
  * New "Args vs render" guidance with two story templates showing args-driven and render-based composition
  * Step sequence updated so verification steps are renumbered and validation requirements clarified

* **New Features**
  * Added a dedicated CSS-check story pattern to assert computed component styles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->