### PR TITLE
fix: correct typos in posix util parameter and store tests

### DIFF
--- a/code/core/src/common/utils/posix.ts
+++ b/code/core/src/common/utils/posix.ts
@@ -1,5 +1,5 @@
 import { posix as posixPath, sep } from 'node:path';
 
 /** Replaces the path separator with forward slashes */
-export const posix = (localPath: string, seperator: string = sep) =>
-  localPath.split(seperator).filter(Boolean).join(posixPath.sep);
+export const posix = (localPath: string, separator: string = sep) =>
+  localPath.split(separator).filter(Boolean).join(posixPath.sep);

--- a/code/core/src/preview-api/modules/store/args.test.ts
+++ b/code/core/src/preview-api/modules/store/args.test.ts
@@ -305,7 +305,7 @@ describe('groupArgsByTarget', () => {
     });
   });
 
-  it('groups non-targetted args into a group with no name', () => {
+  it('groups non-targeted args into a group with no name', () => {
     const groups = groupArgsByTarget({
       args: { a: 1, b: 2, c: 3 },
       argTypes: { a: { name: 'a' }, b: { name: 'b', target: 'group2' }, c: { name: 'c' } },

--- a/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
+++ b/code/core/src/preview-api/modules/store/csf/prepareStory.test.ts
@@ -686,7 +686,7 @@ describe('prepareStory', () => {
       );
     });
 
-    it('always sets args, even when all are targetted', () => {
+    it('always sets args, even when all are targeted', () => {
       const renderMock = vi.fn();
       const firstStory = prepareStory(
         {


### PR DESCRIPTION

**Repo:** storybookjs/storybook (⭐ 84000)
**Type:** bugfix
**Files changed:** 3
**Lines:** +4/-4

## What
Renames the `seperator` parameter to `separator` in `code/core/src/common/utils/posix.ts` and corrects the test descriptions `targetted` → `targeted` in `args.test.ts` and `prepareStory.test.ts`. The `posix` helper's parameter is internal-only (no other callers pass it by name in the repo), so the rename does not break consumers.

## Why
"Seperator" and "targetted" are misspellings. Cleaning them up improves code clarity and prevents the typo from spreading via copy/paste. The parameter is documented but misspelled, which is a small papercut for any contributor who searches for "separator".

## Testing
- `git grep seperator code/` → no remaining hits.
- `git grep targetted code/` → no remaining hits.
- The only callers of `posix()` (`get-story-id.ts`, `posix.test.ts`) pass the second argument positionally, so the parameter rename is safe.

## Risk
Low — single-character spelling fix on an internal parameter name plus two test description strings; no behavior change.
