### PR TITLE
Build: Simplify lint-staged formatting with '*' glob

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 if [ -z "$SKIP_STORYBOOK_GIT_HOOKS" ]; then
-  yarn lint-staged
+  yarn lint-staged --concurrent=false
 fi

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -5,8 +5,13 @@ const fmtCmd = autofix ? 'oxfmt' : 'oxfmt --check';
 const lintSuffix = autofix ? ' --fix' : '';
 
 export default {
+  // Repo root: included in yarn fmt:check but not under code/scripts/docs_snippets globs below
+  '{.lintstagedrc.mjs,.oxfmtrc.json,nx.json,vitest.config.ts}': [fmtCmd],
   'code/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd, `yarn --cwd code lint:js:cmd${lintSuffix}`],
-  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [fmtCmd, `yarn --cwd scripts lint:js:cmd${lintSuffix}`],
+  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [
+    fmtCmd,
+    `yarn --cwd scripts lint:js:cmd${lintSuffix}`,
+  ],
   'docs/_snippets/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd],
   '**/*.ejs': ['yarn --cwd scripts exec ejslint'],
   '**/package.json': ['yarn --cwd scripts lint:package'],

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -5,14 +5,11 @@ const fmtCmd = autofix ? 'oxfmt' : 'oxfmt --check';
 const lintSuffix = autofix ? ' --fix' : '';
 
 export default {
-  // Repo root: included in yarn fmt:check but not under code/scripts/docs_snippets globs below
-  '{.lintstagedrc.mjs,.oxfmtrc.json,nx.json,vitest.config.ts}': [fmtCmd],
-  'code/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd, `yarn --cwd code lint:js:cmd${lintSuffix}`],
-  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [
-    fmtCmd,
-    `yarn --cwd scripts lint:js:cmd${lintSuffix}`,
-  ],
-  'docs/_snippets/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd],
+  // oxfmt skips unknown extensions and respects .oxfmtrc.json ignorePatterns,
+  // so matching every staged file keeps pre-commit aligned with CI (yarn fmt:check)
+  '*': [fmtCmd],
+  'code/**/*.{js,jsx,mjs,ts,tsx,html,json}': [`yarn --cwd code lint:js:cmd${lintSuffix}`],
+  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [`yarn --cwd scripts lint:js:cmd${lintSuffix}`],
   '**/*.ejs': ['yarn --cwd scripts exec ejslint'],
   '**/package.json': ['yarn --cwd scripts lint:package'],
 };

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -6,7 +6,7 @@ const lintSuffix = autofix ? ' --fix' : '';
 
 export default {
   'code/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd, `yarn --cwd code lint:js:cmd${lintSuffix}`],
-  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [`yarn --cwd scripts lint:js:cmd${lintSuffix}`],
+  'scripts/**/*.{html,js,json,jsx,mjs,ts,tsx}': [fmtCmd, `yarn --cwd scripts lint:js:cmd${lintSuffix}`],
   'docs/_snippets/**/*.{js,jsx,mjs,ts,tsx,html,json}': [fmtCmd],
   '**/*.ejs': ['yarn --cwd scripts exec ejslint'],
   '**/package.json': ['yarn --cwd scripts lint:package'],


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

CI enforces `yarn fmt:check` (root `oxfmt --check .`) on the whole repo, but pre-commit only ran `oxfmt` for `code/**` and `docs/_snippets/**`. Files like `.lintstagedrc.mjs`, `nx.json`, or anything under `scripts/**` could drift until CI failed.

Instead of enumerating every covered path, take advantage of oxfmt already:

- respecting `.oxfmtrc.json` `ignorePatterns` when given explicit file paths, and
- silently skipping unknown extensions.

That makes a single `'*'` glob safe and keeps pre-commit aligned with CI automatically, even for new files at the repo root or in new directories.

Also switch `yarn lint-staged` to `--concurrent=false` so overlapping globs (e.g. `oxfmt` from `'*'` and `eslint --fix` from `code/**`) don't race on the same file.

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

Verified locally:

- `yarn fmt:check` passes on the whole repo.
- Committing an intentionally unformatted `.lintstagedrc.mjs` triggers `oxfmt` via the `*` group and fixes it (with `FIX_ON_COMMIT=1`) / fails the commit (without), matching CI.
- Staged files outside every named glob (e.g. `.husky/pre-commit`) are still picked up by the `*` group and either skipped (unknown extension) or formatted as appropriate.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened pre-commit formatting to run the formatter on all staged files (previously targeted specific docs snippets), while keeping existing lint checks scoped to code files.
  * Pre-commit now runs the staged-lint step with concurrency disabled; formatting still runs in "check" mode when autofix is off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->