### PR TITLE
Ci: Allow branch selection for sandbox generation

### DIFF
--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -102,8 +102,9 @@ jobs:
 
       - name: Publish
         # publish sandboxes even if the generation fails, as some sandboxes might have been generated successfully
+        # when triggered manually, always publish to the `next` branch on the sandboxes repo
         if: ${{ !cancelled() }}
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=${{ matrix.branch }}
+        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=${{ github.event_name == 'workflow_dispatch' && 'next' || matrix.branch }}
 
       - name: Report failure to Discord
         if: failure()

--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -29,12 +29,16 @@ jobs:
     steps:
       - id: set
         working-directory: ${{ github.workspace }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo 'branches=["${{ github.ref_name }}"]' >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            branches=$(jq -nc --arg ref "$REF_NAME" '[$ref]')
           else
-            echo 'branches=["next","main"]' >> "$GITHUB_OUTPUT"
+            branches='["next","main"]'
           fi
+          echo "branches=$branches" >> "$GITHUB_OUTPUT"
 
   generate:
     name: Generate to ${{ matrix.branch }}

--- a/.github/workflows/generate-sandboxes.yml
+++ b/.github/workflows/generate-sandboxes.yml
@@ -3,15 +3,11 @@ name: Generate and publish sandboxes
 on:
   schedule:
     - cron: '2 2 */1 * *'
+  # When triggered manually, GitHub's workflow_dispatch UI provides a native
+  # branch selector ("Use workflow from") that lists every branch on the
+  # remote. The selected branch is exposed as `github.ref_name` and is used
+  # below to decide which branch to generate sandboxes for.
   workflow_dispatch:
-  # To test fixes on push rather than wait for the scheduling, do the following:
-  # 1. Uncomment the lines below and add your branch.
-  # push:
-  #   branches:
-  #     - <your-branch-name>
-  # 2. Change the "ref" value to <your-branch-name> in the actions/checkout step below.
-  # 3. Comment out the whole "generate-main" job starting at line 77
-  # 4. 👉 DON'T FORGET TO UNDO THE STEPS BEFORE YOU MERGE YOUR CHANGES!
 
 env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
@@ -22,11 +18,33 @@ defaults:
   run:
     working-directory: ./code
 
+
 jobs:
-  generate-next:
-    name: Generate to next
+  set-branches:
+    name: Resolve target branches
     if: github.repository_owner == 'storybookjs'
     runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set.outputs.branches }}
+    steps:
+      - id: set
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo 'branches=["${{ github.ref_name }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'branches=["next","main"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  generate:
+    name: Generate to ${{ matrix.branch }}
+    needs: set-branches
+    if: github.repository_owner == 'storybookjs'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.set-branches.outputs.branches) }}
     steps:
       - name: Remove unnecessary files to release disk space
         working-directory: ${{ github.workspace }}
@@ -47,7 +65,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: next
+          ref: ${{ matrix.branch }}
 
       - uses: actions/setup-node@v4
         with:
@@ -81,7 +99,7 @@ jobs:
       - name: Publish
         # publish sandboxes even if the generation fails, as some sandboxes might have been generated successfully
         if: ${{ !cancelled() }}
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=next
+        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=${{ matrix.branch }}
 
       - name: Report failure to Discord
         if: failure()
@@ -90,74 +108,5 @@ jobs:
         uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554
         with:
           args: |
-            The generation of some or all sandboxes on the **next** branch has failed.
-            [See the job summary for details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-  generate-main:
-    name: Generate to main
-    if: github.repository_owner == 'storybookjs'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove unnecessary files to release disk space
-        working-directory: ${{ github.workspace }}
-        run: |
-          sudo rm -rf \
-            /opt/ghc \
-            /opt/google/chrome \
-            /opt/microsoft/msedge \
-            /opt/microsoft/powershell \
-            /usr/lib/mono \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/local/share/powershell \
-            /usr/share/dotnet \
-            /usr/share/swift
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Setup git user
-        run: |
-          git config --global user.name "storybook-bot"
-          git config --global user.email "32066757+storybook-bot@users.noreply.github.com"
-
-      - name: Install dependencies
-        working-directory: ./scripts
-        run: node --experimental-modules ./check-dependencies.js
-
-      - name: Compile Storybook libraries
-        run: yarn task --task compile --start-from=auto --no-link
-
-      - name: Publish to local registry
-        run: yarn local-registry --publish
-
-      - name: Run local registry
-        run: yarn local-registry --open &
-
-      - name: Wait for registry
-        run: yarn wait-on tcp:127.0.0.1:6001
-
-      - name: Generate
-        id: generate
-        run: yarn generate-sandboxes --local-registry
-
-      - name: Publish
-        # publish sandboxes even if the generation fails, as some sandboxes might have been generated successfully
-        if: ${{ !cancelled() }}
-        run: yarn publish-sandboxes --remote=https://storybook-bot:${{ secrets.PAT_STORYBOOK_BOT }}@github.com/storybookjs/sandboxes.git --push --branch=main
-
-      - name: Report failure to Discord
-        if: failure()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_MONITORING_URL }}
-        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554
-        with:
-          args: |
-            The generation of some or all sandboxes on the **main** branch has failed.
+            The generation of some or all sandboxes on the **${{ matrix.branch }}** branch has failed.
             [See the job summary for details](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR changes the generate sandbox CI to allow selection of the source branch from which is generation is run from

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

verify sandbox generation action can be selected with any other branch 

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated sandbox generation into a single matrix-driven workflow that handles both manual and scheduled runs.
  * Added branch-selection so manual runs target the invoked branch and scheduled runs target both main and next.
  * Updated failure reporting to reference the active branch and removed duplicate branch-specific jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->