### PR TITLE
docs: prefer userEvent in unit test examples

### DIFF
--- a/docs/_snippets/component-test-with-testing-library.md
+++ b/docs/_snippets/component-test-with-testing-library.md
@@ -1,16 +1,19 @@
 ```ts filename="form.component.spec.ts" renderer="angular" language="ts"
-import { render, screen, fireEvent } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 
 import { FormComponent } from './login-form.component';
 
 import { InvalidForm } from './Form.stories'; //👈 Our stories imported here.
 
 test('Checks if the form is valid ', async () => {
+  const user = userEvent.setup();
+
   await render(FormComponent, {
     componentProperties: InvalidForm.args,
   });
 
-  fireEvent.click(screen.getByText('Submit'));
+  await user.click(screen.getByText('Submit'));
 
   const isFormValid = screen.getByTestId('invalid-form');
   expect(isFormValid).toBeInTheDocument();
@@ -22,14 +25,17 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { h } from 'preact';
 
-import { render, fireEvent } from '@testing-library/preact';
+import { render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
 
 import { InvalidForm } from './LoginForm.stories'; //👈 Our stories imported here.
 
 it('Checks if the form is valid', async () => {
+  const user = userEvent.setup();
+
   const { getByTestId, getByText } = render(<InvalidForm {...InvalidForm.args} />);
 
-  fireEvent.click(getByText('Submit'));
+  await user.click(getByText('Submit'));
 
   const isFormValid = getByTestId('invalid-form');
   expect(isFormValid).toBeInTheDocument();
@@ -37,7 +43,8 @@ it('Checks if the form is valid', async () => {
 ```
 
 ```js filename="Form.test.js|jsx" renderer="react" language="js"
-import { fireEvent, render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
 import { composeStories } from '@storybook/your-framework';
@@ -47,6 +54,8 @@ import * as stories from './LoginForm.stories'; // 👈 Our stories imported her
 const { InvalidForm } = composeStories(stories);
 
 test('Checks if the form is valid', async () => {
+  const user = userEvent.setup();
+
   // Renders the composed story
   await InvalidForm.run();
 
@@ -54,7 +63,7 @@ test('Checks if the form is valid', async () => {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
@@ -62,7 +71,8 @@ test('Checks if the form is valid', async () => {
 ```
 
 ```ts filename="Form.test.ts|tsx" renderer="react" language="ts"
-import { fireEvent, render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
 import { composeStories } from '@storybook/your-framework';
@@ -72,6 +82,8 @@ import * as stories from './LoginForm.stories'; // 👈 Our stories imported her
 const { InvalidForm } = composeStories(stories);
 
 test('Checks if the form is valid', async () => {
+  const user = userEvent.setup();
+
   // Renders the composed story
   await InvalidForm.run();
 
@@ -79,7 +91,7 @@ test('Checks if the form is valid', async () => {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
@@ -87,7 +99,8 @@ test('Checks if the form is valid', async () => {
 ```
 
 ```js filename="Form.test.js" renderer="svelte" language="js"
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. sveltekit or svelte-vite
 import { composeStories } from '@storybook/your-framework';
@@ -97,10 +110,12 @@ import * as stories from './LoginForm.stories'; // 👈 Our stories imported her
 const { InvalidForm } = composeStories(stories);
 
 it('Checks if the form is valid', async () => {
+  const user = userEvent.setup();
+
   // Renders the composed story
   await InvalidForm.run();
 
-  await fireEvent.click(screen.getByText('Submit'));
+  await user.click(screen.getByText('Submit'));
 
   const isFormValid = screen.getByTestId('invalid-form');
   expect(isFormValid).toBeInTheDocument();
@@ -108,7 +123,8 @@ it('Checks if the form is valid', async () => {
 ```
 
 ```js filename="tests/Form.test.js" renderer="vue" language="js"
-import { fireEvent, render, screen } from '@testing-library/vue';
+import { screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { composeStories } from '@storybook/vue3-vite';
 
@@ -117,6 +133,8 @@ import * as stories from './LoginForm.stories'; // 👈 Our stories imported her
 const { InvalidForm } = composeStories(stories);
 
 test('Checks if the form is valid', async () => {
+  const user = userEvent.setup();
+
   // Renders the composed story
   await InvalidForm.run();
 
@@ -124,7 +142,7 @@ test('Checks if the form is valid', async () => {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
@@ -132,7 +150,8 @@ test('Checks if the form is valid', async () => {
 ```
 
 ```ts filename="tests/Form.test.ts" renderer="vue" language="ts"
-import { fireEvent, render, screen } from '@testing-library/vue';
+import { screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { composeStories } from '@storybook/vue3-vite';
 
@@ -141,6 +160,8 @@ import * as stories from './LoginForm.stories'; // 👈 Our stories imported her
 const { InvalidForm } = composeStories(stories);
 
 test('Checks if the form is valid', async () => {
+  const user = userEvent.setup();
+
   // Renders the composed story
   await InvalidForm.run();
 
@@ -148,7 +169,7 @@ test('Checks if the form is valid', async () => {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();

--- a/docs/_snippets/multiple-stories-test.md
+++ b/docs/_snippets/multiple-stories-test.md
@@ -1,5 +1,6 @@
 ```js filename="Form.test.js|jsx" renderer="react" language="js"
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
 import { composeStories } from '@storybook/your-framework';
@@ -9,26 +10,30 @@ import * as FormStories from './LoginForm.stories';
 const { InvalidForm, ValidForm } = composeStories(FormStories);
 
 test('Tests invalid form state', async () => {
+  const user = userEvent.setup();
+
   await InvalidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
 });
 
 test('Tests filled form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();
@@ -36,7 +41,8 @@ test('Tests filled form', async () => {
 ```
 
 ```ts filename="Form.test.ts|tsx" renderer="react" language="ts"
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
 import { composeStories } from '@storybook/your-framework';
@@ -46,26 +52,30 @@ import * as FormStories from './LoginForm.stories';
 const { InvalidForm, ValidForm } = composeStories(FormStories);
 
 test('Tests invalid form state', async () => {
+  const user = userEvent.setup();
+
   await InvalidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
 });
 
 test('Tests filled form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();
@@ -73,7 +83,8 @@ test('Tests filled form', async () => {
 ```
 
 ```js filename="tests/Form.test.js" renderer="vue" language="js"
-import { fireEvent, screen } from '@testing-library/vue';
+import { screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { composeStories } from '@storybook/vue3-vite';
 
@@ -82,26 +93,30 @@ import * as FormStories from './LoginForm.stories';
 const { InvalidForm, ValidForm } = composeStories(FormStories);
 
 test('Tests invalid form state', async () => {
+  const user = userEvent.setup();
+
   await InvalidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
 });
 
 test('Tests filled form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();
@@ -109,7 +124,8 @@ test('Tests filled form', async () => {
 ```
 
 ```ts filename="tests/Form.test.ts" renderer="vue" language="ts"
-import { fireEvent, screen } from '@testing-library/vue';
+import { screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { composeStories } from '@storybook/vue3-vite';
 
@@ -118,26 +134,30 @@ import * as FormStories from './LoginForm.stories';
 const { InvalidForm, ValidForm } = composeStories(FormStories);
 
 test('Tests invalid form state', async () => {
+  const user = userEvent.setup();
+
   await InvalidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).toBeInTheDocument();
 });
 
 test('Tests filled form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();

--- a/docs/_snippets/single-story-test.md
+++ b/docs/_snippets/single-story-test.md
@@ -1,5 +1,6 @@
 ```js filename="Form.test.js|jsx" renderer="react" language="js"
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
 import { composeStory } from '@storybook/your-framework';
@@ -9,13 +10,15 @@ import Meta, { ValidForm as ValidFormStory } from './LoginForm.stories';
 const ValidForm = composeStory(ValidFormStory, Meta);
 
 test('Validates form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();
@@ -23,7 +26,8 @@ test('Validates form', async () => {
 ```
 
 ```ts filename="Form.test.ts|tsx" renderer="react" language="ts"
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Replace your-framework with the framework you are using, e.g. react-vite, nextjs, nextjs-vite, etc.
 import { composeStory } from '@storybook/your-framework';
@@ -33,13 +37,15 @@ import Meta, { ValidForm as ValidFormStory } from './LoginForm.stories';
 const ValidForm = composeStory(ValidFormStory, Meta);
 
 test('Validates form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();
@@ -47,7 +53,8 @@ test('Validates form', async () => {
 ```
 
 ```js filename="tests/Form.test.js" renderer="vue" language="js"
-import { fireEvent, screen } from '@testing-library/vue';
+import { screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { composeStory } from '@storybook/vue3-vite';
 
@@ -56,13 +63,15 @@ import Meta, { ValidForm as ValidFormStory } from './LoginForm.stories';
 const ValidForm = composeStory(ValidFormStory, Meta);
 
 test('Validates form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();
@@ -70,7 +79,8 @@ test('Validates form', async () => {
 ```
 
 ```ts filename="tests/Form.test.ts" renderer="vue" language="ts"
-import { fireEvent, screen } from '@testing-library/vue';
+import { screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 
 import { composeStory } from '@storybook/vue3-vite';
 
@@ -79,13 +89,15 @@ import Meta, { ValidForm as ValidFormStory } from './LoginForm.stories';
 const ValidForm = composeStory(ValidFormStory, Meta);
 
 test('Validates form', async () => {
+  const user = userEvent.setup();
+
   await ValidForm.run();
 
   const buttonElement = screen.getByRole('button', {
     name: 'Submit',
   });
 
-  fireEvent.click(buttonElement);
+  await user.click(buttonElement);
 
   const isFormValid = screen.getByLabelText('invalid-form');
   expect(isFormValid).not.toBeInTheDocument();

--- a/docs/writing-tests/integrations/stories-in-unit-tests.mdx
+++ b/docs/writing-tests/integrations/stories-in-unit-tests.mdx
@@ -19,6 +19,8 @@ Storybook provides a [`composeStories`](../../api/portable-stories/portable-stor
 
 <CodeSnippets path="component-test-with-testing-library.md" />
 
+These examples use Testing Library's `screen` queries because the composed stories run inside your unit test renderer. In a story's `play` function, prefer the provided `canvas` queries so interactions stay scoped to the rendered story.
+
 <Callout variant="warning">
 
 You **must** [configure your test environment to use portable stories](../../api/portable-stories/portable-stories-vitest.mdx#1-apply-project-level-annotations) to ensure your stories are composed with all aspects of your Storybook configuration, such as [decorators](../../writing-stories/decorators.mdx).


### PR DESCRIPTION
## What

Update the stories-in-unit-tests examples to prefer `userEvent.setup()` and `await user.click(...)` over `fireEvent.click(...)`.

## Why

Testing Library recommends `userEvent` for interactions that model user behavior. This also makes the unit-test examples more consistent with Storybook interaction testing, where `userEvent` is provided to play functions.

## How

- Replaced `fireEvent` imports/usages in the unit-test snippets with `@testing-library/user-event`
- Kept `screen` queries in the unit-test examples because composed stories run inside the external test renderer
- Added a short note explaining when to use `screen` vs the `canvas` queries provided to play functions

## Issue

Fixes #31868

## Validation

- `corepack yarn docs:check`
- `corepack yarn fmt:check docs/_snippets/component-test-with-testing-library.md docs/_snippets/single-story-test.md docs/_snippets/multiple-stories-test.md docs/writing-tests/integrations/stories-in-unit-tests.mdx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation snippets to replace `fireEvent.click()` with `@testing-library/user-event` for improved interaction testing.
  * Added clarification on which Testing Library query APIs to use when testing stories in unit tests, with guidance on using `screen` for provided examples and `canvas` queries within story `play` functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->