### PR TITLE
CLI: Do not show onboarding when AI is selected

### DIFF
--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
@@ -261,10 +261,11 @@ describe('UserPreferencesCommand', () => {
         value: true,
         configurable: true,
       });
-      process.env.IN_STORYBOOK_SANDBOX = 'true';
-
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
+
+      const oldInSandbox = process.env.IN_STORYBOOK_SANDBOX;
+      process.env.IN_STORYBOOK_SANDBOX = 'true';
 
       try {
         const result = await command.execute({
@@ -275,7 +276,11 @@ describe('UserPreferencesCommand', () => {
         expect(result.selectedFeatures.has(Feature.AI)).toBe(true);
         expect(result.selectedFeatures.has(Feature.ONBOARDING)).toBe(true);
       } finally {
-        delete process.env.IN_STORYBOOK_SANDBOX;
+        if (oldInSandbox !== undefined) {
+          process.env.IN_STORYBOOK_SANDBOX = oldInSandbox;
+        } else {
+          delete process.env.IN_STORYBOOK_SANDBOX;
+        }
       }
     });
 

--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
@@ -266,15 +266,17 @@ describe('UserPreferencesCommand', () => {
       vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
       vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
 
-      const result = await command.execute({
-        ...defaultExecuteOptions,
-        isAiSetupAvailable: true,
-      });
+      try {
+        const result = await command.execute({
+          ...defaultExecuteOptions,
+          isAiSetupAvailable: true,
+        });
 
-      delete process.env.IN_STORYBOOK_SANDBOX;
-
-      expect(result.selectedFeatures.has(Feature.AI)).toBe(true);
-      expect(result.selectedFeatures.has(Feature.ONBOARDING)).toBe(true);
+        expect(result.selectedFeatures.has(Feature.AI)).toBe(true);
+        expect(result.selectedFeatures.has(Feature.ONBOARDING)).toBe(true);
+      } finally {
+        delete process.env.IN_STORYBOOK_SANDBOX;
+      }
     });
 
     it('should not include AI feature when user declines AI setup', async () => {

--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.test.ts
@@ -238,6 +238,45 @@ describe('UserPreferencesCommand', () => {
       expect(result.selectedFeatures.has(Feature.AI)).toBe(true);
     });
 
+    it('should not include ONBOARDING feature when user accepts AI setup', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+
+      vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
+      vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
+
+      const result = await command.execute({
+        ...defaultExecuteOptions,
+        isAiSetupAvailable: true,
+      });
+
+      expect(result.selectedFeatures.has(Feature.AI)).toBe(true);
+      expect(result.selectedFeatures.has(Feature.ONBOARDING)).toBe(false);
+    });
+
+    it('should include ONBOARDING when AI is selected inside a sandbox (IN_STORYBOOK_SANDBOX)', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.IN_STORYBOOK_SANDBOX = 'true';
+
+      vi.mocked(prompt.select).mockResolvedValueOnce(true); // new user
+      vi.mocked(prompt.confirm).mockResolvedValueOnce(true); // AI setup: yes
+
+      const result = await command.execute({
+        ...defaultExecuteOptions,
+        isAiSetupAvailable: true,
+      });
+
+      delete process.env.IN_STORYBOOK_SANDBOX;
+
+      expect(result.selectedFeatures.has(Feature.AI)).toBe(true);
+      expect(result.selectedFeatures.has(Feature.ONBOARDING)).toBe(true);
+    });
+
     it('should not include AI feature when user declines AI setup', async () => {
       Object.defineProperty(process.stdout, 'isTTY', {
         value: true,

--- a/code/lib/create-storybook/src/commands/UserPreferencesCommand.ts
+++ b/code/lib/create-storybook/src/commands/UserPreferencesCommand.ts
@@ -211,6 +211,11 @@ export class UserPreferencesCommand {
       if (isTestFeatureAvailable) {
         features.add(Feature.TEST);
       }
+
+      // We leave onboarding for sandboxes as we test onboarding in CI
+      if (!process.env.IN_STORYBOOK_SANDBOX) {
+        features.delete(Feature.ONBOARDING);
+      }
     }
 
     return features;

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -168,8 +168,7 @@ export async function doInitiate(options: CommandOptions): Promise<
   await telemetryService.trackInitWithContext(projectType, selectedFeatures, newUser);
 
   // Signal dev to redirect to onboarding on first run
-  const shouldOnboard = newUser;
-  if (shouldOnboard && FeatureCompatibilityService.supportsOnboarding(projectType)) {
+  if (selectedFeatures.has(Feature.ONBOARDING)) {
     await cache.set('onboarding-pending', true).catch(() => {});
   }
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

**Onboarding IS added (Feature.ONBOARDING ends up in the set):**

- New user with non-AI-supporting framework (e.g. Webpack, Svelte, Vue)
- New user with AI-supporting framework (React+Vite) but user declines the AI prompt
- New user with AI-supporting framework but it's a sandbox run - still added as it's needed for CI sandbox E2E tests

**Onboarding is NOT added (Feature.ONBOARDING absent from the set):**

- Returning user (newUser === false)
- InstallType might also be 'light' (didn't select recommended)
- New user with AI-supporting framework, and user accepts AI prompt
- New user with AI-supporting framework, non-interactive/CI, no sandbox env var — AI auto-accepted (skipPrompt=true)

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [x] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

-

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->
This pull request has been released as version `0.0.0-pr-34650-sha-4ef905aa`. Try it out in a new sandbox by running `npx storybook@0.0.0-pr-34650-sha-4ef905aa sandbox` or in an existing project with `npx storybook@0.0.0-pr-34650-sha-4ef905aa upgrade`.
<details>
<summary>More information</summary>

| | |
| --- | --- |
| **Published version** | [`0.0.0-pr-34650-sha-4ef905aa`](https://npmjs.com/package/storybook/v/0.0.0-pr-34650-sha-4ef905aa) |
| **Triggered by** | @yannbf |
| **Repository** | [storybookjs/storybook](https://github.com/storybookjs/storybook) |
| **Branch** | [`yann/skip-onboarding-with-ai`](https://github.com/storybookjs/storybook/tree/yann/skip-onboarding-with-ai) |
| **Commit** | [`4ef905aa`](https://github.com/storybookjs/storybook/commit/4ef905aa527a9031a0a134adc140fea9151d58d6) |
| **Datetime** | Wed Apr 29 09:41:49 UTC 2026 (`1777455709`) |
| **Workflow run** | [25101771834](https://github.com/storybookjs/storybook/actions/runs/25101771834) |

To request a new release of this pull request, mention the `@storybookjs/core` team.

_core team members can create a new canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=34650`_
</details>
<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI-assisted setup no longer enables onboarding by default except when running in sandbox mode.
  * Onboarding redirect signaling is now driven by selected features rather than first-run or project-type checks.

* **Tests**
  * Added interactive tests for AI setup verifying feature selection with and without sandbox mode and that environment state is restored after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->