### PR TITLE
Core: Update change detection terminology from "affected" to "related"

### DIFF
--- a/code/core/src/manager-api/tests/statuses.test.ts
+++ b/code/core/src/manager-api/tests/statuses.test.ts
@@ -64,7 +64,7 @@ describe('parseStatusesParam', () => {
 
   it('parses all known status values', () => {
     expect(
-      parseStatusesParam('new;modified;affected;error;warning;success;pending;unknown')
+      parseStatusesParam('new;modified;related;error;warning;success;pending;unknown')
     ).toEqual({
       included: [
         'status-value:new',
@@ -76,6 +76,13 @@ describe('parseStatusesParam', () => {
         'status-value:pending',
         'status-value:unknown',
       ],
+      excluded: [],
+    });
+  });
+
+  it('keeps backward compatibility for affected in URL params', () => {
+    expect(parseStatusesParam('affected')).toEqual({
+      included: ['status-value:affected'],
       excluded: [],
     });
   });
@@ -100,6 +107,11 @@ describe('serializeStatusesParam', () => {
 
   it('serializes mixed included and excluded', () => {
     expect(serializeStatusesParam(['status-value:new'], ['status-value:error'])).toBe('new;!error');
+  });
+
+  it('serializes affected as related for URL params', () => {
+    expect(serializeStatusesParam(['status-value:affected'], [])).toBe('related');
+    expect(serializeStatusesParam([], ['status-value:affected'])).toBe('!related');
   });
 
   it('round-trips with parseStatusesParam', () => {

--- a/code/core/src/manager-api/tests/stories.test.ts
+++ b/code/core/src/manager-api/tests/stories.test.ts
@@ -1689,7 +1689,7 @@ describe('stories API', () => {
     });
 
     it('parses included status short names', () => {
-      const result = parseStatusesParam('new;modified;affected');
+      const result = parseStatusesParam('new;modified;related');
       expect(result.included).toEqual([
         'status-value:new',
         'status-value:modified',
@@ -1718,7 +1718,7 @@ describe('stories API', () => {
 
     it('parses all known status values', () => {
       const result = parseStatusesParam(
-        'new;modified;affected;error;warning;success;pending;unknown'
+        'new;modified;related;error;warning;success;pending;unknown'
       );
       expect(result.included).toEqual([
         'status-value:new',
@@ -1730,6 +1730,12 @@ describe('stories API', () => {
         'status-value:pending',
         'status-value:unknown',
       ]);
+    });
+
+    it('keeps backward compatibility for affected in URL params', () => {
+      const result = parseStatusesParam('affected');
+      expect(result.included).toEqual(['status-value:affected']);
+      expect(result.excluded).toEqual([]);
     });
   });
 
@@ -1754,6 +1760,11 @@ describe('stories API', () => {
       expect(serializeStatusesParam(['status-value:new'], ['status-value:error'])).toBe(
         'new;!error'
       );
+    });
+
+    it('serializes affected as related for URL params', () => {
+      expect(serializeStatusesParam(['status-value:affected'], [])).toBe('related');
+      expect(serializeStatusesParam([], ['status-value:affected'])).toBe('!related');
     });
 
     it('round-trips with parseStatusesParam', () => {

--- a/code/core/src/manager/components/sidebar/Filter.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Filter.stories.tsx
@@ -237,7 +237,7 @@ export const Clear = {
         storyId: 'c1-doc',
         typeId: 'change-detection',
         value: 'status-value:affected',
-        title: 'Affected',
+        title: 'Related',
         description: '',
       },
     ]);
@@ -316,7 +316,7 @@ export const NoUserTags = {
         storyId: 'c1-doc',
         typeId: 'change-detection',
         value: 'status-value:affected',
-        title: 'Affected',
+        title: 'Related',
         description: '',
       },
     ]);

--- a/code/core/src/manager/components/sidebar/FilterPanel.stories.tsx
+++ b/code/core/src/manager/components/sidebar/FilterPanel.stories.tsx
@@ -155,7 +155,7 @@ export const BuiltInOnly: Story = {
         storyId: 'c2-story1',
         typeId: 'change-detection',
         statusValue: 'status-value:affected',
-        title: 'Affected',
+        title: 'Related',
       }
     ),
   },
@@ -247,7 +247,7 @@ export const WithStatuses: Story = {
         storyId: 'c2-story1',
         typeId: 'change-detection',
         statusValue: 'status-value:affected',
-        title: 'Affected',
+        title: 'Related',
       }
     ),
   },
@@ -289,13 +289,13 @@ export const OnlyModifiedStatus: Story = {
   },
 };
 
-export const OnlyAffectedStatus: Story = {
+export const OnlyRelatedStatus: Story = {
   args: {
     allStatuses: makeStatuses({
       storyId: 'c2-story1',
       typeId: 'change-detection',
       statusValue: 'status-value:affected',
-      title: 'Affected',
+      title: 'Related',
     }),
   },
 };

--- a/code/core/src/manager/components/sidebar/FilterPanel.tsx
+++ b/code/core/src/manager/components/sidebar/FilterPanel.tsx
@@ -84,14 +84,16 @@ export const FilterPanel = ({
 
   const toStatusFilterItem = useCallback(
     (entry: StatusFilterEntry): FilterItem => {
+      const shortName = entry.shortName === 'affected' ? 'related' : entry.shortName;
       const isIncluded = includedStatusFilters.includes(entry.statusValue);
       const isExcluded = excludedStatusFilters.includes(entry.statusValue);
       const isChecked = isIncluded || isExcluded;
       const { icon: statusIconEl, iconColor } = getStatus(theme, entry.statusValue);
+
       return {
-        id: entry.shortName,
+        id: shortName,
         type: 'status',
-        title: entry.shortName.charAt(0).toUpperCase() + entry.shortName.slice(1),
+        title: shortName.charAt(0).toUpperCase() + shortName.slice(1),
         count: entry.count,
         icon: statusIconEl ? <StatusIcon $iconColor={iconColor}>{statusIconEl}</StatusIcon> : null,
         isIncluded,

--- a/code/core/src/manager/components/sidebar/IconSymbols.tsx
+++ b/code/core/src/manager/components/sidebar/IconSymbols.tsx
@@ -138,7 +138,7 @@ export const IconSymbols: FC = () => {
         <circle cx="7" cy="7" r="3" fill="currentColor" />
       </symbol>
       <symbol id={AFFECTED_ID}>
-        <circle cx="7" cy="7" r="2" fill="currentColor" />
+        <circle cx="7" cy="7" r="3" fill="currentColor" />
       </symbol>
     </Svg>
   );

--- a/code/core/src/manager/components/sidebar/IconSymbols.tsx
+++ b/code/core/src/manager/components/sidebar/IconSymbols.tsx
@@ -139,20 +139,6 @@ export const IconSymbols: FC = () => {
       </symbol>
       <symbol id={AFFECTED_ID}>
         <circle cx="7" cy="7" r="2" fill="currentColor" />
-        <path
-          d="M7 3.5A3.5 3.5 0 0 0 7 10.5"
-          stroke="currentColor"
-          strokeWidth="1"
-          strokeLinecap="round"
-          fill="none"
-        />
-        <path
-          d="M7 3.5A3.5 3.5 0 0 1 7 10.5"
-          stroke="currentColor"
-          strokeWidth="1"
-          strokeLinecap="round"
-          fill="none"
-        />
       </symbol>
     </Svg>
   );

--- a/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Sidebar.stories.tsx
@@ -578,7 +578,7 @@ export const StatusesModified: Story = {
   play: waitForChecklistWidget,
 };
 
-export const StatusesAffected: Story = {
+export const StatusesRelated: Story = {
   args: {
     allStatuses: Object.entries(index).reduce((acc, [id, item]) => {
       if (item.type !== 'story') return acc;
@@ -590,7 +590,7 @@ export const StatusesAffected: Story = {
             storyId: id,
             value: 'status-value:affected' as StatusValue,
             title: 'Change Detection',
-            description: 'This story is affected by a change',
+            description: 'This story is related to a change',
           },
         },
       } satisfies StatusesByStoryIdAndTypeId;
@@ -633,7 +633,7 @@ export const StatusesChangeDetectionPriority: Story = {
     allStatuses: Object.entries(index).reduce((acc, [id, item]) => {
       if (item.type !== 'story') return acc;
       // Cycles through all change-detection variants + warning/error to verify
-      // priority ordering (most critical wins): error > warning > affected > modified > new
+      // priority ordering (most critical wins): error > warning > related > modified > new
       const priorityValues: StatusValue[] = [
         'status-value:new',
         'status-value:modified',

--- a/code/core/src/manager/components/sidebar/Tree.stories.tsx
+++ b/code/core/src/manager/components/sidebar/Tree.stories.tsx
@@ -412,14 +412,14 @@ export const WithTestStatusOnly: Story = makeDualSlotStory({
   },
 });
 
-export const WithAffectedStatus: Story = makeDualSlotStory({
+export const WithRelatedStatus: Story = makeDualSlotStory({
   [dualSlotStoryId]: {
     'storybook/change-detection': {
       storyId: dualSlotStoryId,
       typeId: 'storybook/change-detection',
       value: 'status-value:affected',
       title: 'Change Detection',
-      description: 'Story is affected',
+      description: 'Story is related',
       sidebarContextMenu: false,
     },
   },

--- a/code/core/src/shared/status-store/index.ts
+++ b/code/core/src/shared/status-store/index.ts
@@ -31,12 +31,14 @@ export const STATUS_VALUES: StatusValue[] = [
 
 /** Converts a short name like "error" to `"status-value:error"`. Returns undefined if invalid. */
 export const toStatusValue = (shortName: string): StatusValue | undefined => {
+  if (shortName === 'related') return 'status-value:affected';
   const candidate = `${STATUS_VALUE_PREFIX}${shortName}` as StatusValue;
   return STATUS_VALUES.includes(candidate) ? candidate : undefined;
 };
 
 /** Extracts the short name from a StatusValue, e.g. `"status-value:error"` → `"error"`. */
 export const statusValueShortName = (value: StatusValue): string => {
+  if (value === 'status-value:affected') return 'related';
   return value.slice(STATUS_VALUE_PREFIX.length);
 };
 

--- a/docs/api/main-config/main-config-features.mdx
+++ b/docs/api/main-config/main-config-features.mdx
@@ -141,7 +141,7 @@ Type: `boolean`
 
 Default: `true`
 
-Enable [change detection](../../configure/user-interface/change-detection.mdx). When enabled, Storybook monitors your git working tree and the builder's module graph to show which stories are new, modified, or affected by uncommitted changes. Changed stories are displayed with status icons in the sidebar.
+Enable [change detection](../../configure/user-interface/change-detection.mdx). When enabled, Storybook monitors your git working tree and the builder's module graph to show which stories are new, modified, or related to code changes. Changed stories are displayed with status icons in the sidebar.
 
 {/* prettier-ignore-start */}
 

--- a/docs/configure/user-interface/change-detection.mdx
+++ b/docs/configure/user-interface/change-detection.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-During development, Storybook monitors your git working tree and the builder's module graph to identify which stories are affected by your uncommitted changes. Status icons appear next to stories and components in the sidebar so you can focus your review and testing on what has actually changed.
+During development, Storybook monitors your git working tree and the builder's module graph to identify which stories are related to your changes. Status icons appear next to stories and components in the sidebar so you can focus your review and testing on what has actually changed.
 
 ![Sidebar showing change detection status icons](../../_assets/configure/change-detection-full.png)
 
@@ -16,27 +16,27 @@ Change detection is a **development-only** feature. It is active when running `s
 The following are required for change detection to work:
 
 - **Git repository**: Storybook uses `git diff` to detect changed files.
-- **Vite builder**: Storybook traces changed files through the builder's module import graph to identify all affected stories.
+- **Vite builder**: Storybook traces changed files through the builder's module import graph to identify all related stories.
 
 If change detection status indicators never appear in your sidebar, check that both requirements above are met and that the feature has not been [disabled](#configuration).
 
 ## Status indicators
 
-When a change is detected, Storybook shows one of the following status icons next to the affected story in the sidebar:
+When a change is detected, Storybook shows one of the following status icons next to the relevant stories in the sidebar:
 
 | Icon                  | Status       | Definition                                                                            |
 | --------------------- | ------------ | ------------------------------------------------------------------------------------- |
 | ✦ Sparkle             | **new**      | The story file is untracked or newly added in git.                                    |
 | ● Filled circle       | **modified** | The story's own file, or a file it directly imports, was changed.                     |
-| ◉ Circle with outline | **affected** | A file further up the story's dependency chain was changed (a transitive dependency). |
+| ◉ Circle with outline | **related**  | A file further up the story's dependency chain was changed (a transitive dependency). |
 
-When multiple statuses apply to the same story, the highest priority wins: **new** > **modified** > **affected**.
+When multiple statuses apply to the same story, the highest priority wins: **new** > **modified** > **related**.
 
 <Callout variant="info" icon="💡">
 
-**Modified vs. affected**
+**Modified vs. related**
 
-This distinction helps you prioritize your review. **Modified** stories are closest to the change, so you should typically review them first. **Affected** stories depend on the changed code indirectly, so review them after you've verified the directly modified stories look correct. This can be especially helpful in larger codebases where a single change may impact many stories.
+This distinction helps you prioritize your review. **Modified** stories are closest to the change, so you should typically review them first. **Related** stories depend on the changed code indirectly, so review them after you've verified the directly modified stories look correct. This can be especially helpful in larger codebases where a single change may impact many stories.
 
 </Callout>
 
@@ -58,4 +58,4 @@ Change detection is enabled by default. To disable it, set [`features.changeDete
 
 ## How it works
 
-When you run `storybook dev`, Storybook subscribes to the builder's module graph via an `onModuleGraphChange` hook. A git diff provider watches your working tree for changes and runs `git diff` to identify modified or new files. Storybook then traces each changed file through the module import graph (by following `import` statements) to find all story files that depend on it — directly or transitively. Stories with the shortest import distance are marked **modified**; those at greater distance are marked **affected**. New untracked files are marked **new**.
+When you run `storybook dev`, Storybook subscribes to the builder's module graph via an `onModuleGraphChange` hook. A git diff provider watches your working tree for changes and runs `git diff` to identify modified or new files. Storybook then traces each changed file through the module import graph (by following `import` statements) to find all story files that depend on it — directly or transitively. Stories with the shortest import distance are marked **modified**; those at greater distance are marked **related**. New untracked files are marked **new**.

--- a/docs/configure/user-interface/features-and-behavior.mdx
+++ b/docs/configure/user-interface/features-and-behavior.mdx
@@ -139,4 +139,4 @@ You can use URL parameters to configure some of the available features:
 | **selectedPanel**   | `addonPanel` | Any panel ID                                                                                  |
 | **showTabs**        | `tabs`       | `true`                                                                                        |
 | ---                 | `instrument` | `false`, `true`                                                                               |
-| ---                 | `statuses`   | Semicolon-separated status values: `new`, `modified`, `affected` (prefix with `!` to exclude) |
+| ---                 | `statuses`   | Semicolon-separated status values: `new`, `modified`, `related` (prefix with `!` to exclude) |

--- a/docs/configure/user-interface/features-and-behavior.mdx
+++ b/docs/configure/user-interface/features-and-behavior.mdx
@@ -130,13 +130,13 @@ Storybook can show status icons in the sidebar to highlight new and modified sto
 
 You can use URL parameters to configure some of the available features:
 
-| Config option       | Query param  | Supported values                                                                              |
-| ------------------- | ------------ | --------------------------------------------------------------------------------------------- |
-| **enableShortcuts** | `shortcuts`  | `false`                                                                                       |
-| --- (fullscreen)    | `full`       | `true`, `false`                                                                               |
-| --- (show sidebar)  | `nav`        | `true`, `false`                                                                               |
-| --- (show panel)    | `panel`      | `false`, `'right'`, `'bottom'`                                                                |
-| **selectedPanel**   | `addonPanel` | Any panel ID                                                                                  |
-| **showTabs**        | `tabs`       | `true`                                                                                        |
-| ---                 | `instrument` | `false`, `true`                                                                               |
+| Config option       | Query param  | Supported values                                                                             |
+| ------------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| **enableShortcuts** | `shortcuts`  | `false`                                                                                      |
+| --- (fullscreen)    | `full`       | `true`, `false`                                                                              |
+| --- (show sidebar)  | `nav`        | `true`, `false`                                                                              |
+| --- (show panel)    | `panel`      | `false`, `'right'`, `'bottom'`                                                               |
+| **selectedPanel**   | `addonPanel` | Any panel ID                                                                                 |
+| **showTabs**        | `tabs`       | `true`                                                                                       |
+| ---                 | `instrument` | `false`, `true`                                                                              |
 | ---                 | `statuses`   | Semicolon-separated status values: `new`, `modified`, `related` (prefix with `!` to exclude) |


### PR DESCRIPTION
## What I did

Rewording of user-facing terminology to avoid inaccurate assumptions which may be inferred from the word "affected".
Updated the icon for "related" stories to match the one for "modified", for simplicity and to avoid confusion.

<img width="423" height="759" alt="Screenshot 2026-04-30 at 22 55 14" src="https://github.com/user-attachments/assets/4059a160-f9ff-40ce-8f25-d38085195a53" />


## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [x] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated change-detection docs and the statuses URL-parameter table to use "Related" instead of "Affected".

* **Features**
  * Sidebar filters, labels, and stories now show "Related" in place of "Affected".
  * URL parameters treat "related" as canonical while still accepting the legacy "affected" for backward compatibility.
  * Simplified the non-direct status icon visuals.

* **Tests**
  * Test coverage updated for canonical naming, serialization, parsing, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->