### PR TITLE
Telemetry: Fix delayed init events

### DIFF
--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -16,11 +16,7 @@ import {
 } from 'storybook/internal/common';
 import { CLI_COLORS, deprecate, logger, prompt } from 'storybook/internal/node-logger';
 import { MissingBuilderError, NoStatsForViteDevError } from 'storybook/internal/server-errors';
-import {
-  detectAgent,
-  oneWayHash,
-  telemetry,
-} from 'storybook/internal/telemetry';
+import { detectAgent, oneWayHash, telemetry } from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';

--- a/code/core/src/core-server/build-dev.ts
+++ b/code/core/src/core-server/build-dev.ts
@@ -19,7 +19,6 @@ import { MissingBuilderError, NoStatsForViteDevError } from 'storybook/internal/
 import {
   detectAgent,
   oneWayHash,
-  setTelemetryEnabled,
   telemetry,
 } from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
@@ -215,9 +214,7 @@ export async function buildDevStandalone(
     }),
   });
 
-  const { allowedHosts, renderer, builder, disableTelemetry } = await presets.apply('core', {});
-
-  await setTelemetryEnabled(!disableTelemetry);
+  const { allowedHosts, renderer, builder } = await presets.apply('core', {});
 
   // '0.0.0.0' binds to all interfaces, which is useful for Docker and other containerized environments.
   // By default we allow requests from all hosts in this case, but the user should be made aware of the risk.

--- a/code/core/src/core-server/build-static.ts
+++ b/code/core/src/core-server/build-static.ts
@@ -9,7 +9,7 @@ import {
   resolveAddonName,
 } from 'storybook/internal/common';
 import { logger } from 'storybook/internal/node-logger';
-import { getPrecedingUpgrade, setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import { getPrecedingUpgrade, telemetry } from 'storybook/internal/telemetry';
 import type { BuilderOptions, CLIOptions, LoadOptions, Options } from 'storybook/internal/types';
 
 import { global } from '@storybook/global';
@@ -110,8 +110,6 @@ export async function buildStaticStandalone(options: BuildStaticStandaloneOption
     presets.apply('core'),
     presets.apply('staticDirs'),
   ]);
-
-  await setTelemetryEnabled(!core?.disableTelemetry);
 
   const invokedBy = process.env.STORYBOOK_INVOKED_BY;
   if (invokedBy) {

--- a/code/core/src/core-server/presets/common-preset.ts
+++ b/code/core/src/core-server/presets/common-preset.ts
@@ -15,7 +15,7 @@ import {
 import { StoryIndexGenerator } from 'storybook/internal/core-server';
 import { loadCsf } from 'storybook/internal/csf-tools';
 import { logger } from 'storybook/internal/node-logger';
-import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import { telemetry } from 'storybook/internal/telemetry';
 import type {
   CoreConfig,
   Indexer,
@@ -272,10 +272,6 @@ export const experimental_serverChannel = async (
   channel: Channel,
   options: OptionsWithRequiredCache
 ) => {
-  const coreOptions = await options.presets.apply('core');
-
-  await setTelemetryEnabled(!coreOptions?.disableTelemetry);
-
   initAIAnalyticsChannel(channel, options, () => storyIndexGeneratorPromise);
   initializeChecklist(channel);
   initializeWhatsNew(channel, options);

--- a/code/core/src/core-server/withTelemetry.test.ts
+++ b/code/core/src/core-server/withTelemetry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { cache, isCI, loadAllPresets } from 'storybook/internal/common';
+import { cache, isCI, loadAllPresets, loadMainConfig } from 'storybook/internal/common';
 import { prompt } from 'storybook/internal/node-logger';
 import {
   ErrorCollector,
@@ -10,6 +10,7 @@ import {
   setTelemetryEnabled,
   telemetry,
 } from 'storybook/internal/telemetry';
+import type { StorybookConfigRaw } from 'storybook/internal/types';
 
 import { getErrorLevel, sendTelemetryError, withTelemetry } from './withTelemetry.ts';
 
@@ -34,10 +35,71 @@ afterEach(() => {
 describe('withTelemetry', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(isTelemetryStateResolved).mockReturnValue(false);
+    vi.mocked(loadMainConfig).mockRejectedValue(new Error('main config not available'));
     vi.mocked(ErrorCollector.getErrors).mockReturnValue([]);
     vi.mocked(telemetry).mockResolvedValue(undefined);
     vi.mocked(collectAiSetupEvidence).mockResolvedValue(undefined);
   });
+
+  it('does not resolve telemetry state again when it is already initialized', async () => {
+    vi.mocked(isTelemetryStateResolved).mockReturnValue(true);
+    const run = vi.fn();
+
+    await withTelemetry('dev', { cliOptions }, run);
+
+    expect(loadMainConfig).not.toHaveBeenCalled();
+    expect(setTelemetryEnabled).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves telemetry state from an explicit cli opt-in before run()', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(setTelemetryEnabled).mockImplementation(async () => {
+      callOrder.push('setTelemetryEnabled');
+    });
+    const run = vi.fn(async () => {
+      callOrder.push('run');
+    });
+
+    await withTelemetry('dev', { cliOptions: { disableTelemetry: false } }, run);
+
+    expect(loadMainConfig).not.toHaveBeenCalled();
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(true);
+    expect(callOrder).toEqual(['setTelemetryEnabled', 'run']);
+  });
+
+  it('resolves telemetry state from main config before run()', async () => {
+    const callOrder: string[] = [];
+    const mainConfig = { stories: [], core: {} } satisfies StorybookConfigRaw;
+    vi.mocked(loadMainConfig).mockResolvedValue(mainConfig);
+    vi.mocked(setTelemetryEnabled).mockImplementation(async () => {
+      callOrder.push('setTelemetryEnabled');
+    });
+    const run = vi.fn(async () => {
+      callOrder.push('run');
+    });
+
+    await withTelemetry('dev', { cliOptions }, run);
+
+    expect(loadMainConfig).toHaveBeenCalledWith({ configDir: '.storybook' });
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(true);
+    expect(callOrder).toEqual(['setTelemetryEnabled', 'run']);
+  });
+
+  it('resolves telemetry state to disabled when main config opts out', async () => {
+    const mainConfig = {
+      stories: [],
+      core: { disableTelemetry: true },
+    } satisfies StorybookConfigRaw;
+    vi.mocked(loadMainConfig).mockResolvedValue(mainConfig);
+    const run = vi.fn();
+
+    await withTelemetry('dev', { cliOptions }, run);
+
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(false);
+  });
+
   it('works in happy path', async () => {
     const run = vi.fn();
 
@@ -48,7 +110,7 @@ describe('withTelemetry', () => {
     expect(telemetry).toHaveBeenCalledWith('boot', { eventType: 'dev' }, { stripMetadata: true });
   });
 
-  it('does not send boot when cli option is passed', async () => {
+  it('resolves telemetry state when cli option is passed', async () => {
     const run = vi.fn();
 
     await withTelemetry('dev', { cliOptions: { disableTelemetry: true } }, run);
@@ -72,7 +134,7 @@ describe('withTelemetry', () => {
       expect(collectAiSetupEvidence).toHaveBeenCalledTimes(1);
     });
 
-    it('does not send boot when cli option is passed', async () => {
+    it('resolves telemetry state when cli option is passed', async () => {
       await expect(async () =>
         withTelemetry('dev', { cliOptions: { disableTelemetry: true }, printError: vi.fn() }, run)
       ).rejects.toThrow(error);
@@ -370,9 +432,7 @@ describe('withTelemetry', () => {
     });
   });
 
-  it('resolves telemetry state to disabled when run() throws and state is still uninitialized', async () => {
-    vi.mocked(isTelemetryStateResolved).mockReturnValue(false);
-
+  it('falls back to disabled when the main config cannot be loaded', async () => {
     const run = vi.fn(async () => {
       throw new Error('preset loading failed');
     });
@@ -381,6 +441,7 @@ describe('withTelemetry', () => {
       withTelemetry('dev', { cliOptions: {}, printError: vi.fn() }, run)
     ).rejects.toThrow('preset loading failed');
 
+    expect(loadMainConfig).toHaveBeenCalledWith({ configDir: '.storybook' });
     expect(setTelemetryEnabled).toHaveBeenCalledWith(false);
   });
 });

--- a/code/core/src/core-server/withTelemetry.ts
+++ b/code/core/src/core-server/withTelemetry.ts
@@ -1,7 +1,7 @@
 import {
   HandledError,
   cache,
-  getStorybookInfo,
+  loadMainConfig,
   isCI,
   loadAllPresets,
 } from 'storybook/internal/common';
@@ -10,7 +10,6 @@ import {
   collectAiSetupEvidence,
   ErrorCollector,
   getPrecedingUpgrade,
-  isTelemetryModuleEnabled,
   isTelemetryStateResolved,
   oneWayHash,
   onPayloadError,
@@ -18,10 +17,9 @@ import {
   telemetry,
 } from 'storybook/internal/telemetry';
 import type { EventType } from 'storybook/internal/telemetry';
-import type { CLIOptions } from 'storybook/internal/types';
+import type { CLIOptions, StorybookConfigRaw } from 'storybook/internal/types';
 
 import { StorybookError } from '../storybook-error.ts';
-import { dirname } from 'path';
 
 type TelemetryOptions = {
   cliOptions: CLIOptions;
@@ -29,6 +27,7 @@ type TelemetryOptions = {
   printError?: (err: any) => void;
   skipPrompt?: boolean;
   eventType?: EventType;
+  fallbackTelemetryState?: boolean;
 };
 
 const promptCrashReports = async () => {
@@ -167,35 +166,28 @@ export async function sendTelemetryError(
   }
 }
 
-export function isTelemetryEnabled(options: TelemetryOptions) {
-  return !options.cliOptions.disableTelemetry;
-}
-
-/**
- * Resolve telemetry state by loading presets from configDir to check core.disableTelemetry.
- * Used when run() completes without resolving telemetry state (e.g. CLI commands like
- * add/remove/doctor/upgrade/migrate that don't load presets themselves).
- */
-async function tryResolveTelemetryStateFromConfig(options: TelemetryOptions) {
-  const configDir = options.cliOptions.configDir || options.presetOptions?.configDir;
-
-  try {
-    const { mainConfig } = await getStorybookInfo(
-      configDir,
-      configDir ? dirname(configDir) : undefined
-    );
-
-    if (!mainConfig) {
-      // No config dir available — default to enabled
-      await setTelemetryEnabled(true);
-      return;
-    }
-
-    await setTelemetryEnabled(!mainConfig.core?.disableTelemetry);
-  } catch {
-    // If presets fail to load, conservatively disable
-    await setTelemetryEnabled(false);
+async function resolveTelemetryState(options: TelemetryOptions) {
+  // 1. If telemetry is explicitly set via CLI options or env var, set and skip loading main config
+  if (options.cliOptions.disableTelemetry !== undefined) {
+    return await setTelemetryEnabled(!options.cliOptions.disableTelemetry);
   }
+
+  let mainConfig;
+  const configDir =
+    options.cliOptions.configDir ?? options.presetOptions?.configDir ?? '.storybook';
+  try {
+    mainConfig = (await loadMainConfig({ configDir })) as StorybookConfigRaw;
+  } catch {}
+
+  // 2. If main config succesfully loaded, set based on that
+  // (unset = enabled, true/false = disabled/enabled)
+  if (mainConfig) {
+    return await setTelemetryEnabled(!mainConfig?.core?.disableTelemetry);
+  }
+
+  // 3. If main config could not be loaded, set to fallback,
+  // which is usually disabled but can be enabled for certain commands (e.g. init)
+  await setTelemetryEnabled(options.fallbackTelemetryState ?? false);
 }
 
 export async function withTelemetry<T>(
@@ -203,8 +195,8 @@ export async function withTelemetry<T>(
   options: TelemetryOptions,
   run: () => Promise<T>
 ): Promise<T | undefined> {
-  if (!isTelemetryEnabled(options)) {
-    await setTelemetryEnabled(false);
+  if (!isTelemetryStateResolved()) {
+    await resolveTelemetryState(options);
   }
 
   let canceled = false;
@@ -235,19 +227,8 @@ export async function withTelemetry<T>(
 
   try {
     const result = await run();
-
-    // If run() completed but telemetry state was never resolved (e.g. CLI commands like
-    // add/remove/doctor that don't load presets themselves), load the config to resolve it.
-    if (!isTelemetryStateResolved()) {
-      await tryResolveTelemetryStateFromConfig(options);
-    }
-
     return result;
   } catch (error: any) {
-    if (!isTelemetryStateResolved()) {
-      await tryResolveTelemetryStateFromConfig(options);
-    }
-
     if (canceled) {
       return undefined;
     }

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -7,7 +7,7 @@ import {
 } from 'storybook/internal/common';
 import { getServerPort, withTelemetry } from 'storybook/internal/core-server';
 import { logTracker, logger } from 'storybook/internal/node-logger';
-import { telemetry } from 'storybook/internal/telemetry';
+import { telemetry, setTelemetryEnabled } from 'storybook/internal/telemetry';
 import { Feature } from 'storybook/internal/types';
 import type {
   SupportedBuilder,
@@ -206,6 +206,9 @@ export async function initiate(options: CommandOptions): Promise<void> {
       printError: (err) => !err.handled && logger.error(err),
     },
     async () => {
+      // we need to explicitly set this before init to not delay the events until the end of the flow
+      setTelemetryEnabled(!options.disableTelemetry);
+
       const result = await doInitiate(options);
 
       logger.outro('');

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -207,7 +207,7 @@ export async function initiate(options: CommandOptions): Promise<void> {
     },
     async () => {
       // we need to explicitly set this before init to not delay the events until the end of the flow
-      setTelemetryEnabled(!options.disableTelemetry);
+      await setTelemetryEnabled(!options.disableTelemetry);
 
       const result = await doInitiate(options);
 

--- a/code/lib/create-storybook/src/initiate.ts
+++ b/code/lib/create-storybook/src/initiate.ts
@@ -204,6 +204,8 @@ export async function initiate(options: CommandOptions): Promise<void> {
     {
       cliOptions: options,
       printError: (err) => !err.handled && logger.error(err),
+      // enable telemetry if nothing else specified in env var or CLI options
+      fallbackTelemetryState: true,
     },
     async () => {
       // we need to explicitly set this before init to not delay the events until the end of the flow

--- a/code/vitest-setup.ts
+++ b/code/vitest-setup.ts
@@ -13,7 +13,7 @@ const ignoreList = [
     error.message.match(
       `Support for defaultProps will be removed from function components in a future major release`
     ),
-  (error: any) => error.message.match(/Browserslist: .* is outdated. Please run:/),
+  (error: any) => error.message.match(/Browserslist: .*Please run:/),
   (error: any) => error.message.includes('Consider adding an error boundary'),
   (error: any) =>
     error.message.includes('react-async-component-lifecycle-hooks') &&


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

We found that during init, telemetry events would not be sent until the very end of the flow, where everything would be sent at once. If the flow was canclled mid-way, no events would be sent.

This change ensures that events are sent when they happen.

This was originally a regression from https://github.com/storybookjs/storybook/pull/34485 which was released in 10.4.0-alpha.10, so it's only a small window of bad telemetry.

Now, we immediately resolve telemetry state, instead of relying on the different commands do to it eventually from their loaded presets.
There's a small change here, where previously we would use preset loading mechanism to look up `core.disableTelemetry` but now we just load the main config, because it's faster. So theoretically someone could have an external preset where they set telemetry setting and that wouldn't be supported anymore, now we only support it when it's directly set in main.ts (although it can be imported from elsewhere, etc.)

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:

- [ ] stories
- [ ] unit tests
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

> [!CAUTION]
> This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!

<!-- Please include the steps to test your changes here. For example:

1. Run a sandbox for template, e.g. `yarn task --task sandbox --start-from auto --template react-vite/default-ts`
2. Open Storybook in your browser
3. Access X story

-->

-

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes
- [ ] If you are deprecating/removing a feature, make sure to update
      [MIGRATION.MD](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md)

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli-storybook/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `bug`: Internal changes that fixes incorrect behavior.
  - `maintenance`: User-facing maintenance tasks.
  - `dependencies`: Upgrading (sometimes downgrading) dependencies.
  - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
  - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
  - `documentation`: Documentation **only** changes. Will not show up in release changelog.
  - `feature request`: Introducing a new feature.
  - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
  - `other`: Changes that don't fit in the above categories.

   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/publish.yml) or locally with `gh workflow run --repo storybookjs/storybook publish.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->

<!-- BENCHMARK_SECTION -->
<!-- BENCHMARK_SECTION -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Telemetry preference is resolved earlier during startup and now uses a defined fallback behavior for unresolved cases, making initialization telemetry more consistent.
* **Tests**
  * Expanded telemetry initialization tests to cover CLI opt‑in, config‑derived settings, fallback behavior, and related edge cases.
* **Chores**
  * Test setup updated to ignore a specific Browserslist warning pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->